### PR TITLE
fix: Remove duplicate words in requirements text

### DIFF
--- a/script.js
+++ b/script.js
@@ -1407,7 +1407,11 @@ function displayRandomTask() {
     currentTask = availableTasks[randomIndex];
 
     taskTitleEl.textContent = currentTask.task;
-    taskInfoEl.innerHTML = `<strong>Location:</strong> ${currentTask.locality}<br><strong>Points:</strong> ${currentTask.pts}<br><strong>Info:</strong> ${currentTask.information}<br><strong>Requires:</strong> ${currentTask.requirements}`;
+
+    // Clean up duplicate words in requirements
+    const requirementsText = currentTask.requirements.replace(/\b(\w+)\s+\1\b/g, '$1');
+
+    taskInfoEl.innerHTML = `<strong>Location:</strong> ${currentTask.locality}<br><strong>Points:</strong> ${currentTask.pts}<br><strong>Info:</strong> ${currentTask.information}<br><strong>Requires:</strong> ${requirementsText}`;
     completeBtn.style.display = 'inline-block';
 }
 


### PR DESCRIPTION
This commit fixes a display issue where duplicated words would appear in the requirements text for some tasks (e.g., "Magic Magic").

The `displayRandomTask` function has been updated to process the requirements string with a regular expression before rendering it to the DOM. This cleanup removes any consecutive, identical words, ensuring the requirements are displayed cleanly and correctly.