### PR TITLE
feat: Add filter for skill type

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
             <div class="filters card">
                 <select id="location-filter"></select>
                 <select id="points-filter"></select>
+                <select id="skill-filter"></select>
                 <input type="text" id="keyword-filter" placeholder="Keyword search...">
             </div>
 


### PR DESCRIPTION
This commit introduces a new feature allowing users to filter tasks by skill.

Key changes:
- A predefined list of skills has been added to `script.js`.
- The task parsing logic now analyzes each task's requirements to determine which skills are associated with it, adding a `skills` array to each task object.
- A new dropdown menu for skill filtering has been added to `index.html`.
- The filtering and display logic in `script.js` has been updated to incorporate the new skill filter, allowing users to see only tasks relevant to a selected skill.