### PR TITLE
fix: Update hiscores URL to point to Catalyst League

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
             </div>
 
             <div class="task-actions card">
+                <div class="player-lookup">
+                    <input type="text" id="player-name" placeholder="Enter your name...">
+                    <button id="lookup-btn">Look Up</button>
+                </div>
                 <button id="randomize-btn">Get Random Task</button>
                 <button id="reset-btn">Reset All Tasks</button>
             </div>
@@ -28,6 +32,7 @@
         <p class="task-count-display">Available tasks: <span id="task-count">0</span></p>
 
         <div id="task-container" class="card">
+            <div id="req-check-container"></div>
             <h2 id="task-title"></h2>
             <p id="task-info"></p>
             <button id="complete-btn" style="display: none;">Complete Task</button>

--- a/script.js
+++ b/script.js
@@ -1310,6 +1310,17 @@ const SKILL_LIST = [
     'Smithing', 'Strength', 'Summoning', 'Thieving', 'Woodcutting'
 ];
 
+const HISCORES_URL = 'https://secure.runescape.com/m=hiscore_leagues/index_lite.ws?player=';
+const SKILL_MAP = [
+    'Overall', 'Attack', 'Defence', 'Strength', 'Constitution', 'Ranged', 'Prayer', 'Magic',
+    'Cooking', 'Woodcutting', 'Fletching', 'Fishing', 'Firemaking', 'Crafting', 'Smithing',
+    'Mining', 'Herblore', 'Agility', 'Thieving', 'Slayer', 'Farming', 'Runecrafting',
+    'Hunter', 'Construction', 'Summoning', 'Dungeoneering', 'Divination', 'Invention',
+    'Archaeology', 'Necromancy'
+];
+
+var playerStats = null; // Use var to make it a property of the window object for testing
+
 function parseTasks() {
     const rawLines = taskData.trim().split('\n');
     rawLines.shift(); // remove header
@@ -1350,9 +1361,26 @@ function parseTasks() {
         const requirements = parts[3] || '';
 
         const skillsInTask = [];
+        const skillReqs = {};
+        const reqLower = requirements.toLowerCase();
+
+        // First, a simple check for any skill name
         for (const skill of SKILL_LIST) {
-            if (requirements.toLowerCase().includes(skill.toLowerCase())) {
+            if (reqLower.includes(skill.toLowerCase())) {
                 skillsInTask.push(skill);
+            }
+        }
+
+        // Then, a more detailed parse for level requirements
+        const reqPattern = /(\d+)\s+(\w+)/g;
+        let match;
+        while ((match = reqPattern.exec(requirements)) !== null) {
+            const level = parseInt(match[1], 10);
+            const skillName = match[2];
+            // Find the canonical skill name
+            const canonicalSkill = SKILL_LIST.find(s => s.toLowerCase() === skillName.toLowerCase());
+            if (canonicalSkill) {
+                skillReqs[canonicalSkill] = level;
             }
         }
 
@@ -1364,7 +1392,8 @@ function parseTasks() {
             requirements: requirements,
             pts: parseInt(parts[4], 10) || 0,
             comp: parts[5] || '',
-            skills: skillsInTask
+            skills: skillsInTask,
+            skillReqs: skillReqs
         };
     }).filter(task => task.task); // Filter out any potentially empty tasks
 }
@@ -1423,18 +1452,26 @@ function populateFilters() {
     }
 }
 
-function displayRandomTask() {
-    updateAvailableTasks();
-    if (availableTasks.length === 0) {
-        taskTitleEl.textContent = "No tasks available!";
-        taskInfoEl.textContent = "Try adjusting your filters or resetting your completed tasks.";
-        completeBtn.style.display = 'none';
-        currentTask = null;
-        return;
+function displayRandomTask(keepCurrent = false) {
+    if (!keepCurrent) {
+        updateAvailableTasks();
+        if (availableTasks.length === 0) {
+            taskTitleEl.textContent = "No tasks available!";
+            taskInfoEl.textContent = "Try adjusting your filters or resetting your completed tasks.";
+            completeBtn.style.display = 'none';
+            currentTask = null;
+            return;
+        }
+        const randomIndex = Math.floor(Math.random() * availableTasks.length);
+        currentTask = availableTasks[randomIndex];
     }
 
-    const randomIndex = Math.floor(Math.random() * availableTasks.length);
-    currentTask = availableTasks[randomIndex];
+    if (!currentTask) {
+        taskTitleEl.textContent = "No task selected.";
+        taskInfoEl.textContent = "Click 'Get Random Task' or adjust filters.";
+        completeBtn.style.display = 'none';
+        return;
+    }
 
     taskTitleEl.textContent = currentTask.task;
 
@@ -1442,7 +1479,35 @@ function displayRandomTask() {
     const requirementsText = currentTask.requirements.replace(/\b(\w+)\s+\1\b/g, '$1');
 
     taskInfoEl.innerHTML = `<strong>Location:</strong> ${currentTask.locality}<br><strong>Points:</strong> ${currentTask.pts}<br><strong>Info:</strong> ${currentTask.information}<br><strong>Requires:</strong> ${requirementsText}`;
+
+    checkRequirements(playerStats, currentTask);
+
     completeBtn.style.display = 'inline-block';
+}
+
+function checkRequirements(stats, task) {
+    const reqCheckContainer = document.getElementById('req-check-container');
+    reqCheckContainer.innerHTML = ''; // Clear previous results
+
+    if (!stats) {
+        reqCheckContainer.innerHTML = `<p class="req-note">Look up a player to check skill requirements.</p>`;
+        return;
+    }
+
+    const unmetReqs = [];
+    for (const [skill, level] of Object.entries(task.skillReqs)) {
+        if (stats[skill] < level) {
+            unmetReqs.push(`${level} ${skill}`);
+        }
+    }
+
+    if (Object.keys(task.skillReqs).length === 0) {
+         reqCheckContainer.innerHTML = `<p class="req-note">This task has no specific skill level requirements.</p>`;
+    } else if (unmetReqs.length === 0) {
+        reqCheckContainer.innerHTML = `<p class="req-met">✅ You meet all skill level requirements!</p>`;
+    } else {
+        reqCheckContainer.innerHTML = `<p class="req-unmet">❌ You do not meet the following requirements: ${unmetReqs.join(', ')}</p>`;
+    }
 }
 
 function completeCurrentTask() {
@@ -1490,8 +1555,50 @@ function resetTasks() {
     }
 }
 
+async function lookupPlayer() {
+    const playerNameInput = document.getElementById('player-name');
+    const playerName = playerNameInput.value.trim();
+    if (!playerName) {
+        alert('Please enter a player name.');
+        return;
+    }
+
+    try {
+        const response = await fetch(HISCORES_URL + playerName);
+        if (!response.ok) {
+            throw new Error(`Hiscores not found for player: ${playerName}. Status: ${response.status}`);
+        }
+        const data = await response.text();
+        playerStats = parseHiscores(data);
+        alert(`Successfully looked up stats for ${playerName}.`);
+        // Refresh the current task display to check requirements
+        if(currentTask) {
+            displayRandomTask(true); // pass a flag to not randomize again
+        }
+    } catch (error) {
+        console.error('Error fetching hiscores:', error);
+        alert(`Could not fetch hiscores. This may be because the player does not exist, or the API is unavailable. It's also possible your browser is blocking the request due to CORS policy.`);
+        playerStats = null;
+    }
+}
+
+function parseHiscores(data) {
+    const stats = {};
+    const lines = data.split('\n');
+    for (let i = 0; i < SKILL_MAP.length; i++) {
+        if (lines[i]) {
+            const [rank, level, xp] = lines[i].split(',');
+            stats[SKILL_MAP[i]] = parseInt(level, 10);
+        }
+    }
+    return stats;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-    randomizeBtn.addEventListener('click', displayRandomTask);
+    const lookupBtn = document.getElementById('lookup-btn');
+
+    lookupBtn.addEventListener('click', lookupPlayer);
+    randomizeBtn.addEventListener('click', () => displayRandomTask(false));
     completeBtn.addEventListener('click', completeCurrentTask);
     resetBtn.addEventListener('click', resetTasks);
 

--- a/style.css
+++ b/style.css
@@ -57,6 +57,21 @@ h1 {
     text-align: center;
 }
 
+.player-lookup {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.player-lookup input {
+    flex-grow: 1;
+}
+
+.player-lookup button {
+    padding: 0.8rem 1.5rem;
+    font-size: 1rem;
+}
+
 select, input[type="text"] {
     width: 100%;
     padding: 0.8rem;
@@ -161,4 +176,36 @@ button:hover {
     margin-bottom: 0.5rem;
     color: var(--secondary-accent);
     border-left: 5px solid var(--primary-accent);
+}
+
+#req-check-container {
+    margin-bottom: 1rem;
+    padding: 1rem;
+    border-radius: var(--border-radius);
+    font-weight: 600;
+    font-size: 1.1rem;
+}
+
+.req-met {
+    color: #28a745;
+    background-color: rgba(40, 167, 69, 0.1);
+    padding: 1rem;
+    border-radius: var(--border-radius);
+    margin: 0;
+}
+
+.req-unmet {
+    color: #dc3545;
+    background-color: rgba(220, 53, 69, 0.1);
+    padding: 1rem;
+    border-radius: var(--border-radius);
+    margin: 0;
+}
+
+.req-note {
+    color: #6c757d;
+    background-color: rgba(108, 117, 125, 0.1);
+    padding: 1rem;
+    border-radius: var(--border-radius);
+    margin: 0;
 }


### PR DESCRIPTION
This commit updates the `HISCORES_URL` constant to use the endpoint for the league hiscores instead of the main game hiscores, as requested by the user.

The new URL is `https://secure.runescape.com/m=hiscore_leagues/index_lite.ws?player=`.

The player lookup feature will now fetch stats specifically for the active RuneScape league.