### PR TITLE
fix: Correctly parse player stats from wiki API

### DIFF
--- a/script.js
+++ b/script.js
@@ -1575,13 +1575,8 @@ async function lookupPlayer() {
 }
 
 function parseWikiHiscores(data) {
-    const stats = {};
-    if (data.skills) {
-        for (const [skillName, skillData] of Object.entries(data.skills)) {
-            stats[skillName.charAt(0).toUpperCase() + skillName.slice(1)] = skillData.level;
-        }
-    }
-    return stats;
+    // The API returns a 'levels' object directly with skill names and levels.
+    return data.levels || {};
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
This commit fixes a bug in the player lookup feature where the application was failing to correctly parse the JSON response from the `sync.runescape.wiki` API.

The `parseWikiHiscores` function was expecting a `skills` object in the response, but the live API returns a `levels` object. The function has been corrected to look for the `levels` key, which resolves the bug and allows player skill requirements to be checked accurately.