### PR TITLE
feat: Add toggle to filter by completable tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,13 @@
                 <select id="points-filter"></select>
                 <select id="skill-filter"></select>
                 <input type="text" id="keyword-filter" placeholder="Keyword search...">
+                <div class="toggle-container">
+                    <label class="switch">
+                        <input type="checkbox" id="completable-toggle">
+                        <span class="slider"></span>
+                    </label>
+                    <span>Only show completable tasks</span>
+                </div>
             </div>
 
             <div class="task-actions card">

--- a/style.css
+++ b/style.css
@@ -178,6 +178,70 @@ button:hover {
     border-left: 5px solid var(--primary-accent);
 }
 
+/* Toggle Switch Styles */
+.toggle-container {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: flex-start;
+    padding-top: 0.5rem;
+}
+
+.toggle-container span {
+    color: var(--secondary-accent);
+    font-size: 0.9rem;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 28px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+    border-radius: 28px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 20px;
+    width: 20px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+
+input:checked + .slider {
+    background-color: var(--primary-accent);
+}
+
+input:focus + .slider {
+    box-shadow: 0 0 1px var(--primary-accent);
+}
+
+input:checked + .slider:before {
+    transform: translateX(22px);
+}
+
+
 #req-check-container {
     margin-bottom: 1rem;
     padding: 1rem;


### PR DESCRIPTION
This commit introduces a new toggle switch that allows users to filter the task list to show only tasks for which they meet the skill level requirements.

Key changes:
- Refactored the requirement checking logic into a pure function separate from the UI display function.
- Added a toggle switch UI element to the filters section.
- Updated the main filtering logic in `updateAvailableTasks` to check the state of the toggle and exclude tasks that the currently looked-up player cannot complete.
- Ensured the toggle's state is included in the main event listener loop.