### PR TITLE
feat: Add player stats display panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,45 +9,53 @@
 </head>
 <body>
     <div class="container">
-        <h1>Task Randomizer</h1>
+        <div class="main-content">
+            <h1>Task Randomizer</h1>
 
-        <div class="controls-grid">
-            <div class="filters card">
-                <select id="location-filter"></select>
-                <select id="points-filter"></select>
-                <select id="skill-filter"></select>
-                <input type="text" id="keyword-filter" placeholder="Keyword search...">
-                <div class="toggle-container">
-                    <label class="switch">
-                        <input type="checkbox" id="completable-toggle">
-                        <span class="slider"></span>
-                    </label>
-                    <span>Only show completable tasks</span>
+            <div class="controls-grid">
+                <div class="filters card">
+                    <select id="location-filter"></select>
+                    <select id="points-filter"></select>
+                    <select id="skill-filter"></select>
+                    <input type="text" id="keyword-filter" placeholder="Keyword search...">
+                    <div class="toggle-container">
+                        <label class="switch">
+                            <input type="checkbox" id="completable-toggle">
+                            <span class="slider"></span>
+                        </label>
+                        <span>Only show completable tasks</span>
+                    </div>
+                </div>
+
+                <div class="task-actions card">
+                    <div class="player-lookup">
+                        <input type="text" id="player-name" placeholder="Enter your name...">
+                        <button id="lookup-btn">Look Up</button>
+                    </div>
+                    <button id="randomize-btn">Get Random Task</button>
+                    <button id="reset-btn">Reset All Tasks</button>
                 </div>
             </div>
 
-            <div class="task-actions card">
-                <div class="player-lookup">
-                    <input type="text" id="player-name" placeholder="Enter your name...">
-                    <button id="lookup-btn">Look Up</button>
-                </div>
-                <button id="randomize-btn">Get Random Task</button>
-                <button id="reset-btn">Reset All Tasks</button>
+            <p class="task-count-display">Available tasks: <span id="task-count">0</span></p>
+
+            <div id="task-container" class="card">
+                <div id="req-check-container"></div>
+                <h2 id="task-title"></h2>
+                <p id="task-info"></p>
+                <button id="complete-btn" style="display: none;">Complete Task</button>
+            </div>
+
+            <div id="completed-tasks-container" class="card">
+                <h2>Completed Tasks</h2>
+                <ul id="completed-tasks-list"></ul>
             </div>
         </div>
-
-        <p class="task-count-display">Available tasks: <span id="task-count">0</span></p>
-
-        <div id="task-container" class="card">
-            <div id="req-check-container"></div>
-            <h2 id="task-title"></h2>
-            <p id="task-info"></p>
-            <button id="complete-btn" style="display: none;">Complete Task</button>
-        </div>
-
-        <div id="completed-tasks-container" class="card">
-            <h2>Completed Tasks</h2>
-            <ul id="completed-tasks-list"></ul>
+        <div id="stats-panel" class="card">
+            <h2>Player Stats</h2>
+            <div id="stats-content">
+                <p>Look up a player to see their stats.</p>
+            </div>
         </div>
     </div>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1585,6 +1585,9 @@ async function lookupPlayer() {
         // Sync completed tasks
         syncCompletedTasks(playerData.completedTaskIds);
 
+        // Display the stats
+        displayPlayerStats(playerStats);
+
         alert(`Successfully looked up stats and synced completed tasks for ${playerName}.`);
 
         updateAvailableTasks();
@@ -1618,6 +1621,36 @@ function syncCompletedTasks(taskIds) {
         completedTasks.add(taskId);
     }
     localStorage.setItem('completedTasks', JSON.stringify([...completedTasks]));
+}
+
+function displayPlayerStats(stats) {
+    const statsContent = document.getElementById('stats-content');
+    if (!stats || Object.keys(stats).length === 0) {
+        statsContent.innerHTML = '<p>Look up a player to see their stats.</p>';
+        return;
+    }
+
+    let totalLevel = 0;
+    let statsHTML = '';
+
+    // Use the order from SKILL_LIST, but skip 'Overall' which doesn't exist in the new API response
+    const displaySkills = SKILL_LIST.filter(skill => skill !== 'Overall' && stats[skill]);
+
+    for (const skillName of displaySkills) {
+        const level = stats[skillName] || 0;
+        totalLevel += level;
+        statsHTML += `
+            <div class="stat-item">
+                <span class="level">${level}</span>
+                <span class="name">${skillName}</span>
+            </div>
+        `;
+    }
+
+    statsContent.innerHTML = `
+        <div id="total-level">Total Level: ${totalLevel}</div>
+        ${statsHTML}
+    `;
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/style.css
+++ b/style.css
@@ -18,8 +18,15 @@ body {
 }
 
 .container {
-    max-width: 900px;
+    max-width: 1400px;
     margin: 0 auto;
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 2rem;
+    align-items: flex-start;
+}
+
+.main-content {
     text-align: center;
 }
 
@@ -256,6 +263,49 @@ input:checked + .slider:before {
     padding: 1rem;
     border-radius: var(--border-radius);
     margin: 0;
+}
+
+#stats-panel {
+    position: sticky;
+    top: 2rem;
+    text-align: left;
+}
+
+#stats-panel h2 {
+    text-align: center;
+    color: var(--primary-accent);
+}
+
+#stats-content {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 1rem;
+}
+
+.stat-item {
+    background-color: var(--primary-bg);
+    padding: 0.5rem;
+    border-radius: var(--border-radius);
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--secondary-accent);
+}
+
+.stat-item .level {
+    font-weight: 700;
+    font-size: 1.2rem;
+    color: var(--primary-accent);
+}
+
+#total-level {
+    grid-column: 1 / -1; /* Span full width */
+    font-size: 1.5rem;
+    font-weight: 700;
+    text-align: center;
+    color: var(--secondary-accent);
+    background-color: var(--card-bg);
+    padding: 1rem;
+    border-radius: var(--border-radius);
 }
 
 .req-unmet {


### PR DESCRIPTION
This commit adds a new UI panel to the right-hand side of the application to display player stats after a successful lookup.

Key changes:
- Restructured `index.html` with a grid layout to accommodate the new stats panel.
- Added CSS in `style.css` to position and style the panel, including a grid for individual skills.
- Implemented a `displayPlayerStats` function in `script.js` which:
  - Calculates the total level from the sum of individual skills.
  - Dynamically generates HTML to display the total level and all skills with their levels.
- The stats panel is populated upon a successful player lookup via the wiki API.