### PR TITLE
fix: Improve styling of task requirements display

### DIFF
--- a/script.js
+++ b/script.js
@@ -136,7 +136,7 @@ function formatRequirements(requirements) {
             const wikiUrl = `https://runescape.wiki/w/${questName.replace(/ /g, '_')}`;
             return `<li><a href="${wikiUrl}" target="_blank">${matchText.trim()}</a></li>`;
         }).join('');
-        formattedHtml += `<strong>Quests:</strong><ul>${questLinks}</ul>`;
+        formattedHtml += `<div class="req-section"><strong>Quests:</strong><ul>${questLinks}</ul></div>`;
         // Remove the matched quests from the string
         questMatches.forEach(m => reqs = reqs.replace(m, ''));
     }
@@ -155,13 +155,13 @@ function formatRequirements(requirements) {
     if (skills.length > 0) {
         // Clean up skill names (e.g., "19 Mining Mining" -> "19 Mining")
         const cleanedSkills = skills.map(s => s.split(' ').slice(0, 2).join(' '));
-        formattedHtml += `<strong>Skills:</strong><ul>${cleanedSkills.map(s => `<li>${s}</li>`).join('')}</ul>`;
+        formattedHtml += `<div class="req-section"><strong>Skills:</strong><ul>${cleanedSkills.map(s => `<li>${s}</li>`).join('')}</ul></div>`;
     }
 
     // 3. Display other items
     const otherReqs = reqs.replace(/, ,/g, ',').replace(/,$/, '').replace(/\s\s+/g, ' ').trim();
     if (otherReqs && otherReqs !== ',') {
-        formattedHtml += `<strong>Other:</strong><ul><li>${otherReqs}</li></ul>`;
+        formattedHtml += `<div class="req-section"><strong>Other:</strong> ${otherReqs}</div>`;
     }
 
     return formattedHtml;

--- a/style.css
+++ b/style.css
@@ -199,6 +199,14 @@ button:hover {
     margin-bottom: 0;
 }
 
+.req-section {
+    margin-bottom: 1rem;
+}
+
+.req-section:last-child {
+    margin-bottom: 0;
+}
+
 #completed-tasks-container h2 {
     font-size: 1.5rem;
     color: var(--primary-accent);


### PR DESCRIPTION
This commit addresses a styling issue in the task requirements section.

- The HTML structure generated for requirements in `script.js` has been updated to wrap each category (Quests, Skills, Other) in a `div` for better layout control.
- The "Other" requirements category no longer uses a `<ul>` list, removing the unnecessary bullet point.
- CSS has been added in `style.css` to add vertical spacing between the requirement categories, improving readability and alignment.