### PR TITLE
feat: Import completed tasks from player API lookup

### DIFF
--- a/script.js
+++ b/script.js
@@ -357,10 +357,26 @@ async function lookupPlayer() {
         // Display the stats
         displayPlayerStats(playerStats);
 
-        alert(`Successfully looked up stats for ${playerName}.`);
+        if (playerData.completedTaskIds && playerData.completedTaskIds.length > 0) {
+            const confirmOverwrite = confirm(
+                `Found ${playerData.completedTaskIds.length} completed tasks for ${playerName}. ` +
+                `Do you want to replace your current completed task list with this player's progress?`
+            );
 
+            if (confirmOverwrite) {
+                completedTasks = new Set(playerData.completedTaskIds);
+                localStorage.setItem('completedTasks', JSON.stringify([...completedTasks]));
+                alert(`Completed tasks have been updated based on ${playerName}'s progress.`);
+            }
+        } else {
+            alert(`Successfully looked up stats for ${playerName}. No completed task data was found.`);
+        }
+
+
+        // Refresh all UI components that depend on task completion
         updateAvailableTasks();
         renderCompletedTasks();
+        renderTaskBrowser();
 
         if(currentTask) {
             displayRandomTask(true); // Re-check requirements for the current task


### PR DESCRIPTION
This commit introduces a new feature that allows users to import a player's completed tasks directly from the RuneScape Wiki API.

When a player is looked up:
- The application now fetches the list of completed task IDs from the API.
- It prompts the user with a confirmation dialog to prevent accidental overwriting of their manually tracked progress.
- If confirmed, the application's internal `completedTasks` list is replaced with the data from the API, and this state is saved to `localStorage`.
- The entire UI, including the available task count, the completed tasks list, and the task browser, is then refreshed to reflect the imported progress.