### PR TITLE
fix: Verify completed tasks from API against player stats

### DIFF
--- a/script.js
+++ b/script.js
@@ -358,13 +358,21 @@ async function lookupPlayer() {
         displayPlayerStats(playerStats);
 
         if (playerData.completedTaskIds && playerData.completedTaskIds.length > 0) {
+            // Filter the incoming task IDs to only include those the player has the stats for.
+            const verifiedCompletedIds = playerData.completedTaskIds.filter(taskId => {
+                const task = allTasks.find(t => t.id === taskId);
+                if (!task) return false;
+                const unmetReqs = getUnmetRequirements(playerStats, task);
+                return unmetReqs.length === 0;
+            });
+
             const confirmOverwrite = confirm(
-                `Found ${playerData.completedTaskIds.length} completed tasks for ${playerName}. ` +
+                `Found ${verifiedCompletedIds.length} verifiable completed tasks for ${playerName}. ` +
                 `Do you want to replace your current completed task list with this player's progress?`
             );
 
             if (confirmOverwrite) {
-                completedTasks = new Set(playerData.completedTaskIds);
+                completedTasks = new Set(verifiedCompletedIds);
                 localStorage.setItem('completedTasks', JSON.stringify([...completedTasks]));
                 alert(`Completed tasks have been updated based on ${playerName}'s progress.`);
             }


### PR DESCRIPTION
This commit fixes a bug where the application would incorrectly mark tasks as complete based on unreliable API data.

When looking up a player, the application now performs a verification step:
- It iterates through the list of completed task IDs returned by the API.
- For each task, it checks if the player's stats (also from the API) meet the task's skill requirements.
- Only tasks for which the player meets the requirements are considered complete.

This ensures that the imported progress accurately reflects what the player could have genuinely completed, preventing incorrect tasks from being marked as done.