### PR TITLE
feat: Add player lookup for completed tasks

### DIFF
--- a/process_tasks.js
+++ b/process_tasks.js
@@ -12,13 +12,8 @@ const prefixes = [
 ];
 
 function isNewRecord(line) {
-    // A line is considered a new record if it starts with one of the known prefixes followed by a tab.
-    for (const prefix of prefixes) {
-        if (line.startsWith(prefix + '\t')) {
-            return true;
-        }
-    }
-    return false;
+    // A line is considered a new record if it starts with a digit (our new Task ID).
+    return /^\d/.test(line);
 }
 
 // This function takes an array of lines that constitute a single record,
@@ -33,13 +28,19 @@ function processRecord(recordLines, id) {
 
     const columns = fullRecordString.split('\t');
 
-    // After joining, a valid record should have exactly 6 columns.
-    if (columns.length !== 6) {
-        console.error(`Skipping malformed record (column count is ${columns.length}, expected 6): ${fullRecordString}`);
+    // After joining, a valid record should have exactly 7 columns.
+    if (columns.length !== 7) {
+        console.error(`Skipping malformed record (column count is ${columns.length}, expected 7): ${fullRecordString}`);
         return null;
     }
 
-    const points = parseInt(columns[4].trim(), 10);
+    const taskId = parseInt(columns[0].trim(), 10);
+    if (isNaN(taskId)) {
+        console.error(`Skipping malformed record (invalid taskId): ${fullRecordString}`);
+        return null;
+    }
+
+    const points = parseInt(columns[5].trim(), 10);
     if (isNaN(points)) {
         console.error(`Skipping malformed record (invalid points): ${fullRecordString}`);
         return null;
@@ -47,10 +48,11 @@ function processRecord(recordLines, id) {
 
     return {
         id: id,
-        locality: columns[0].trim(),
-        task: columns[1].trim(),
-        information: columns[2].trim(),
-        requirements: columns[3].trim(),
+        taskId: taskId,
+        locality: columns[1].trim(),
+        task: columns[2].trim(),
+        information: columns[3].trim(),
+        requirements: columns[4].trim(),
         points: points
     };
 }

--- a/raw_tasks.txt
+++ b/raw_tasks.txt
@@ -1,910 +1,1118 @@
-Locality	Task	Information	Requirements	Pts	Comp%
-Anachronia	Complete the base camp tutorial on Anachronia.	Complete the Anachronia base camp tutorial.	N/A	 10	48.5%
-Anachronia	Observe all the large dragonkin statues around Anachronia.	Observe all the large dragonkin statues around Anachronia.	N/A	 10	2.7%
-Anachronia	Surge under the spine on Anachronia.	Complete Spinal Surgery.	5 Agility Agility 	 10	27.6%
-Anachronia	Set sail for Anachronia.	Set sail for Anachronia on The Stormbreaker docked at Varrock Dig Site.	N/A	 10	49.5%
-Anachronia	Complete the quest: Helping Laniakea (miniquest).	Complete the Helping Laniakea miniquest.	See quest page	 10	0.1%
-Anachronia	Complete the quest: Raksha, the Shadow Colossus.	Complete Raksha, the Shadow Colossus quest.	See quest page	 10	6.6%
-Anachronia	Obtain 100 potent herbs from Herby Werby.	Obtain 100 potent herbs from Herby Werby.	1 Herblore Herblore 	 10	32.8%
-Asgarnia: Burthorpe	Complete a lap of the Burthorpe Agility course.	Complete a lap of the Burthorpe Agility Course.	1 Agility Agility 	 10	76.8%
-Asgarnia: Falador	Kill a goblin raider boss in the Goblin Village.	Kill 15 goblins in the Goblin Village to spawn a Goblin raider boss.	N/A	 10	46.9%
-Asgarnia: Falador	Complete the quest: Witch's House.	Complete Witch's House	See quest page	 10	34.9%
-Asgarnia: Falador	Sit down with Tiffy in Falador park.	Sit on the bench with Sir Tiffy Cashien in Falador Park.	N/A	 10	73.2%
-Asgarnia: Falador	Pray to Bandos's remains.	Pray to Bandos's remains (just south-east of Goblin Village.	N/A	 10	60.8%
-Asgarnia: Falador	Dance in the Falador party room.	Dance in the Falador party room.	N/A	 10	69.7%
-Asgarnia: Port Sarim	Give Thurgo a redberry pie.	Give Thurgo a redberry pie.	10 Cooking Cooking
-Partial completion of  The Knight's Sword	 10	30.8%
-Asgarnia: Taverley	Build a God statue in Taverley.	Build a God statue in Taverley.	N/A	 10	59.2%
-Desert: Menaphos	Enter Menaphos.	Enter Menaphos.	N/A	 10	50.5%
-Desert: General	Catch a whirligig at Het's Oasis.	Catch a whirligig at Het's Oasis.	1 Hunter Hunter 	 10	47.1%
-Desert: General	Search the Grand Gold Chest in room 1 of Pyramid Plunder in Sophanem.	Search the grand gold chest in room 1 of Pyramid Plunder in Sophanem.	21 Thieving Thieving
-Partial completion of  Icthlarin's Little Helper	 10	4%
-Desert: General	Search the Grand Gold Chest in room 2 of Pyramid Plunder in Sophanem.	Search the grand gold chest in room 2 of Pyramid Plunder in Sophanem.	31 Thieving Thieving
-Partial completion of  Icthlarin's Little Helper	 10	4%
-Desert: General	Search the Grand Gold Chest in room 3 of Pyramid Plunder in Sophanem.	Search the grand gold chest in room 3 of Pyramid Plunder in Sophanem.	41 Thieving Thieving
-Partial completion of  Icthlarin's Little Helper	 10	3.9%
-Desert: General	Mine a gem rock at the Al Kharid mine.	Mine a gem rock at the Al Kharid mine. A common gem rock can be mined with level 1 Mining.	1 Mining Mining 	 10	72.6%
-Desert: General	Kill a crocodile.	Kill a crocodile.	N/A	 10	36.2%
-Desert: General	Create a spirit kalphite pouch at the obelisk south west of Pollnivneach.	Create a spirit kalphite pouch at the obelisk south west of Pollnivneach.	25 Summoning Summoning
-A pouch, 51 spirit shards, a blue charm, and a potato cactus	 10	1.3%
-Desert: Menaphos	Squish 10 corrupted scarabs.	Squish 10 corrupted scarabs.	N/A	 10	13.3%
-Desert: General	Sell a pyramid top to Simon.	Hand Simon Templeton a pyramid top.	30 Agility Agility 	 10	11.5%
-Desert: General	Use any of the magic carpets in the desert.	Use any of the magic carpets in the desert.	1,000	 10	49.7%
-Desert: General	Harvest a rose at Het's Oasis.	Harvest a rose at Het's Oasis.	30 Farming Farming 	 10	26.6%
-Fremennik: Lunar Isles	Switch to the Lunar Spellbook at the astral altar.	Switch to the Lunar Spellbook at the astral altar.	Completion of  Lunar Diplomacy	 10	0.6%
-Fremennik: Mainland	Defeat a Rock Crab in the Fremennik Province.	Defeat a Rock Crab in the Fremennik Province.	N/A	 10	36.7%
-Fremennik: Mainland	Defeat a Cockatrice in the Fremennik Province.	Defeat a cockatrice in the Fremennik Province.	25 Slayer Slayer
-A mirror shield	 10	18.9%
-Fremennik: Mainland	Defeat a Troll in the Fremennik Province.	Defeat a troll in the Fremennik Province.	N/A	 10	10.6%
-Fremennik: Mainland	Deposit an item with Peer the Seer.	Deposit an item with Peer the Seer.	Completion of the easy Fremennik achievements	 10	0.6%
-Fremennik: Mainland	Use the Bank on Jatizso or Neitiznot.	Use the Bank on Jatizso or Neitiznot.	Partial completion of  The Fremennik Isles	 10	1.5%
-Fremennik: Mainland	Catch a Sapphire Glacialis.	Catch a Sapphire Glacialis.	25 Hunter Hunter
-A butterfly net and jar	 10	6.6%
-Global	Level up any of your skills for the first time.	Level up any of your skills for the first time.	N/A	 10	98.4%
-Global	Reach level 5 in any skill.	Reach level 5 in any skill.	N/A	 10	97.7%
-Global	Reach level 10 in any skill.	Reach level 10 in any skill.	N/A	 10	97%
-Global	Reach level 20 in any skill.	Reach level 20 in any skill.	N/A	 10	95.5%
-Global	Reach combat level 5.	Reach combat level 5.	N/A	 10	94.4%
-Global	Reach combat level 10.	Reach combat level 10.	N/A	 10	91.3%
-Global	Reach total level 50.	Reach total level 50.	N/A	 10	97.3%
-Global	Reach total level 100.	Reach total level 100.	N/A	 10	94.4%
-Global	Mine a copper ore.	Mine copper ore from a copper rock.	1 Mining Mining 	 10	93.1%
-Global	Mine 10 copper ore.	Mine 10 copper ore.	1 Mining Mining 	 10	92.2%
-Global	Mine a tin ore.	Mine tin ore from a tin rock.	1 Mining Mining 	 10	91.3%
-Global	Mine 10 tin ore.	Mine 10 tin ore.	1 Mining Mining 	 10	89.9%
-Global	Smelt a bronze bar.	Smelt a bronze bar.	1 Smithing Smithing 	 10	92.7%
-Global	Smelt 10 bronze bars.	Smelt 10 bronze bars.	1 Smithing Smithing 	 10	92.2%
-Global	Smith any bronze item.	Smith any bronze item.	1 Smithing Smithing 	 10	87.5%
-Global	Mine clay.	Mine clay.	1 Mining Mining 	 10	87.2%
-Global	Make some soft clay.	Make soft clay by using clay on a water source or with a container of water	N/A	 10	77.5%
-Global	Mine any ore 5 times.	Mine any ore 5 times.	1 Mining Mining 	 10	93.4%
-Global	Chop any tree 5 times.	Chop any tree 5 times.	1 Woodcutting Woodcutting 	 10	90.1%
-Global	Chop a basic tree.	Chop a basic tree.	1 Woodcutting Woodcutting 	 10	93.2%
-Global	Chop 10 basic trees.	Chop 10 basic trees.	1 Woodcutting Woodcutting 	 10	88.5%
-Global	Chop an oak tree.	Chop an oak tree.	10 Woodcutting Woodcutting 	 10	83.9%
-Global	Burn any logs.	Burn any logs.	1 Firemaking Firemaking 	 10	91.8%
-Global	Burn any logs 5 times.	Burn any logs 5 times.	1 Firemaking Firemaking 	 10	87.2%
-Global	Catch a shrimp.	Catch a raw shrimp.	1 Fishing Fishing 	 10	87.7%
-Global	Catch 10 shrimp.	Catch 10 raw shrimps.	1 Fishing Fishing 	 10	86.7%
-Global	Catch an anchovy.	Catch a raw anchovy.	15 Fishing Fishing 	 10	72%
-Global	Catch a herring.	Catch a raw herring.	10 Fishing Fishing 	 10	65.9%
-Global	Cook shrimp, meat, or chicken.	Cook raw shrimps, raw meat, or raw chicken.	1 Cooking Cooking 	 10	92.3%
-Global	Cook 10 shrimp, meat, or chicken.	Cook 10 raw shrimps, raw meat, or raw chicken.	1 Cooking Cooking 	 10	86.8%
-Global	Burn any food.	Burn any food.	1 Cooking Cooking 	 10	86.5%
-Global	Catch any fish 5 times.	Catch any fish 5 times.	1 Fishing Fishing 	 10	88.8%
-Global	Bury any bones.	Bury any bones.	1 Prayer Prayer 	 10	94.4%
-Global	Bury any bones 10 times.	Bury any bones 10 times.	1 Prayer Prayer 	 10	86.9%
-Global	Activate the thick skin, rock skin, or steel skin Prayer.	Activate the Thick Skin, Rock Skin, or Steel Skin prayer.	1 Prayer Prayer 	 10	86%
-Global	Run out of Prayer points.	Run out of Prayer points.	1 Prayer Prayer 	 10	85.1%
-Misthalin: Draynor Village	Harvest a memory from a pale wisp.	Harvest a pale memory from a pale wisp.	1 Divination Divination 	 10	82.6%
-Misthalin: Draynor Village	Harvest 10 memories from a pale wisp.	Harvest 10 pale memories from a pale wisp.	1 Divination Divination 	 10	81.8%
-Global	Harvest any memory from a wisp 5 times.	Harvest any memory from a wisp 5 times.	1 Divination Divination 	 10	82.5%
-Global	Pickpocket from a man or woman.	Pickpocket from a man or woman.	1 Thieving Thieving 	 10	89.2%
-Global	Pickpocket from a man or woman 10 times.	Pickpocket from a man or woman 10 times.	1 Thieving Thieving 	 10	86.2%
-Global	Steal from any stall.	Steal from any stall.	2 Thieving Thieving  for Vegetable Stalls	 10	86.2%
-Global	Steal from any stall 10 times.	Steal from any stall 10 times.	2 Thieving Thieving  for Vegetable Stalls	 10	84.7%
-Global	Pickpocket anyone 5 times.	Pickpocket anyone 5 times.	1 Thieving Thieving 	 10	88.1%
-Global	Rake any farming patch.	Rake any farming patch.	1 Farming Farming 	 10	81.7%
-Global	Plant seeds in any farming patch.	Plant seeds in any farming patch.	1 Farming Farming 	 10	72.6%
-Global	Plant seeds in any farming patch 10 times.	Plant seeds in any farming patch 10 times.	1 Farming Farming 	 10	58.5%
-Global	Add any compostable item to a compost bin.	Add any compostable item to a compost bin.	N/A	 10	66.6%
-Global	Have a tool leprechaun note any produce.	Have a tool leprechaun note any produce.	N/A	 10	59.5%
-Global	Use the Home Teleport spell to return to Lumbridge.	Use the Home Teleport spell to return to Lumbridge.	N/A	 10	91.2%
-Global	Eat a cabbage.	Eat a cabbage.	N/A	 10	83.3%
-Global	Eat a baked potato.	Eat a baked potato.	7 Cooking Cooking 	 10	60%
-Global	Eat an onion.	Eat an onion.	N/A	 10	75.3%
-Global	Kill an imp.	Kill an imp.	N/A	 10	81.2%
-Global	Kill a chicken.	Kill a chicken.	N/A	 10	85.3%
-Global	Claim a free item from any store.	Claim a free item from any store e.g. a tinderbox from Lumbridge General Store	N/A	 10	86.5%
-Global	Return a free item to any store.	Return a free item to any store e.g. a tinderbox from Lumbridge General Store	N/A	 10	74.2%
-Global	Sell an item to any store.	Sell an item to any store.	N/A	 10	86.4%
-Global	Listen to any musician.	Listen to any musician.	N/A	 10	79.2%
-Global	Pick wheat from a field.	Pick wheat from a field.	N/A	 10	83.3%
-Global	Prospect any rock.	Prospect any rock.	1 Mining Mining 	 10	76.8%
-Global	View the skillguide.	View the skill guide.	N/A	 10	94.9%
-Global	Create a Guthix Rest Potion.	Create a Guthix rest potion.	18 Herblore Herblore
-Partial completion of  One Small Favour	 10	1.6%
-Global	Make 5 potions of any kind.	Make 5 potions of any kind.	1 Herblore Herblore 	 10	54.5%
-Global	Drink a Strength Potion.	Drink a Strength Potion.	Giving a limpwurt root and red spiders' eggs to the Apothecary	 10	33%
-Global	Make an Attack Potion.	Make an Attack potion.	1 Herblore Herblore
-A clean guam and an eye of newt	 10	63.2%
-Global	Make a Necromancy Potion.	Make a Necromancy potion.	11 Herblore Herblore
-A clean marrentill and cadava berries	 10	18.6%
-Global	Clean 5 Grimy Guam.	Clean 5 grimy guam.	1 Herblore Herblore
-5 grimy guam	 10	61.9%
-Global	Clean 15 Grimy Tarromin.	Clean 15 grimy tarromin.	5 Herblore Herblore
-15 grimy tarromin	 10	36.1%
-Global	Clean 5 of any herb.	Clean 5 of any herb.	1 Herblore Herblore
-5 of any grimy herb	 10	64.9%
-Global	Clean 10 of any herb	Clean 10 of any herb	1 Herblore Herblore
-10 of any grimy herb	 10	61.6%
-Global	Fletch an Oak Shortbow (unstrung).	Fletch an unstrung oak shortbow.	20 Fletching Fletching
-Oak logs	 10	52.1%
-Global	Fletch some arrow shafts.	Fletch some arrow shafts.	1 Fletching Fletching
-Logs of any kind	 10	81.1%
-Global	Fletch 50 Bronze bolts.	Fletch 50 bronze bolts.	9 Fletching Fletching
-A bronze bar and 50 feathers	 10	52.9%
-Global	Complete 10 laps of any Agility course.	Complete 10 laps of any Agility course.	1 Agility Agility 	 10	67%
-Global	Smith 10 of any metal weapon or armour piece.	Smith 10 of any metal weapon or armour piece.	1 Smithing Smithing
-10 of any metal bar	 10	81.7%
-Global	Open 30 Sedimentary Geodes.	Open 30 sedimentary geodes. These are found randomly while mining.	1 Mining Mining 	 10	70.5%
-Global	Maintain nearly maximum stamina when mining for 60 seconds.	Maintain nearly maximum stamina when mining for 60 seconds.	1 Mining Mining 	 10	69.8%
-Global	Harvest a Grimy Marrentill.	Harvest a grimy marrentill.	9 Farming Farming
-Marrentill seed	 10	38.6%
-Global	Harvest 10 Grimy Tarromin.	Harvest 10 grimy tarromin.	19 Farming Farming
-Tarromin seeds	 10	37.3%
-Global	Cook 5 fish.	Cook 5 fish.	1 Cooking Cooking
-5 of any raw fish	 10	87.4%
-Global	Make some Bread.	Make some bread. Bread dough can be created by using a pot of flour with water, it must be cooked at a range.	1 Cooking Cooking
-Bread dough	 10	54.9%
-Global	Make some flour.	Make a pot of flour by grinding wheat at a windmill and collecting the flour in an empty pot.	Wheat and an empty pot	 10	77.8%
-Global	Offer 5 bones of any kind to an altar.	Offer 5 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel	1 Prayer Prayer 	 10	52.2%
-Global	Offer 25 bones of any kind to an altar.	Offer 25 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel	1 Prayer Prayer 	 10	49%
-Global	Scatter some Ashes.	Scatter some ashes.	1 Prayer Prayer
-Any demonic ashes	 10	74.3%
-Global	Scatter 25 ashes of any kind.	Scatter 25 ashes of any kind.	1 Prayer Prayer
-25 of any demonic ashes	 10	38.3%
-Global	Restore 50 Prayer Points at an Altar at once.	Restore 50 Prayer Points at an Altar at once.	5 Prayer Prayer 	 10	73.7%
-Global	Activate Superhuman or Ultimate Strength and Improved or Incredible Reflexes prayers at the same time.	Activate Superhuman or Ultimate Strength and Improved or Incredible Reflexes prayers at the same time.	16 Prayer Prayer 	 10	61.9%
-Global	Catch a Baby Impling.	Catch a baby impling.	17 Hunter Hunter 	 10	26%
-Global	Catch 10 Implings of any kind.	Catch 10 implings of any kind.	17 Hunter Hunter 	 10	9.7%
-Global	Catch 5 Hunter creatures.	Catch 5 Hunter creatures.	1 Hunter Hunter 	 10	56.1%
-Global	Complete 5 Slayer tasks.	Complete 5 Slayer assignments.	1 Slayer Slayer 	 10	45.9%
-Global	Pick 5 Flax.	Pick 5 flax from flax fields.	N/A	 10	70.1%
-Global	Spin 5 bowstring.	Spin 5 bowstrings by using flax on a spinning wheel.	1 Fletching Fletching
-5 flax	 10	68.1%
-Global	Surge a distance of one tile.	Surge a distance of one tile.	5 Agility Agility 	 10	68.7%
-Global	Spin a Ball of Wool.	Spin a ball of wool by using wool at a spinning wheel.	1 Fletching Fletching
-Wool	 10	74.4%
-Global	Equip a full set of Iron armour without any upgrades.	Equip an iron full helm, iron platebody, iron platelegs / iron plateskirt, iron gauntlets, iron armoured boots, and an iron kiteshield. Substitutes for pieces (e.g. med helm instead of full helm, chainbody instead of platebody, square shield instead of kite shield) will work. Iron armour can be bought at Horvik's Armour Shop.	10 Defence Defence 	 10	58.1%
-Global	Equip a full set of Green Dragonhide armour.	Equip a full set of green dragonhide armour.	40 Defence Defence 	 10	24.6%
-Global	Equip a full set of Imphide robes.	Equip a full set of imphide robes.	10 Defence Defence 	 10	50.3%
-Global	Equip a full set of Spider silk robes.	Equip a full set of spider silk robes.	20 Defence Defence 	 10	50.4%
-Global	Store the items required for an emote clue in a Treasure Trail hidey-hole.	Store the items required for an emote clue in a Treasure Trail hidey-hole.	27 Construction Construction
-4 planks and 10 of any nails for an easy hidey-hole	 10	9%
-Global	Complete an Easy clue scroll.	Complete an easy clue scroll.	N/A	 10	43.8%
-Global	Collect 10 unique items for the General clue rewards collection log.	Collect 10 unique items for the general clue rewards collection log.	N/A	 10	29.6%
-Kandarin: Gnomes	Complete the Gnome Stronghold Agility Course.	Complete the Gnome Stronghold Agility Course.	1 Agility Agility 	 10	39.8%
-Kandarin: Feldip Hills	Catch a Crimson Swift in the Feldip Hills.	Catch a crimson swift in the Feldip Hills.	1 Hunter Hunter
-A bird snare	 10	7.1%
-Kandarin: Ardougne	Defeat a Tortoise with riders in Kandarin.	Defeat a tortoise with riders in Kandarin.	N/A	 10	29.3%
-Kandarin: Seers Village	Complete the quest: You Are It.	Complete You Are It.	See quest page	 10	16.5%
-Kandarin: Gnomes	Let Brimstail teleport you to the Rune Essence mine.	Let Brimstail teleport you to the Rune Essence mine.	N/A	 10	19.4%
-Kandarin: Feldip Hills	Equip a Marksman hat.	Equip a marksman hat.	125 chompy bird kills	 10	<0.1%
-Global	Obtain a Naragi engram from Orla Fairweather.	Obtain a Naragi engram from Orla Fairweather. The engram is given to the player during the tutorial for Memorial to Guthix	1 Divination Divination 	 10	23.1%
-Kandarin: Ardougne	Learn how many beans make five (complete the Player Owned Farm tutorial).	Complete the player-owned farm tutorial at Manor Farm.	17 Farming Farming  20 Construction Construction 	 10	39.2%
-Global	Catch a Wild Kebbit.	Catch a wild kebbit.	23 Hunter Hunter
-Logs of any kind	 10	5%
-Kandarin: Ardougne	Teleport to the Wilderness using the lever in Ardougne.	Pull the lever in Ardougne.	N/A	 10	49%
-Kandarin: Yanille	Use a ring of duelling to teleport to Castle Wars.	Teleport to Castle Wars with a ring of duelling.	27 Magic Magic  27 Crafting Crafting
-Materials to make a ring of duelling	 10	14.4%
-Kandarin: Gnomes	Make a Pineapple Punch cocktail.	Make a pineapple punch cocktail.	8 Cooking Cooking
-See pineapple punch for ingredients	 10	7.4%
-Karamja	Collect 5 seaweed from anywhere on Karamja.	Collect 5 seaweed from anywhere on Karamja.	N/A	 10	43.5%
-Karamja	Fill up Luthas' crate near the Musa Point plantation with bananas and receive 30 coins for your work.	Fill up Luthas' crate near the Banana plantation with bananas and talk to him to receive 30 coins for your work.	N/A	 10	39.4%
-Karamja	Claim a ticket from Brimhaven Agility Arena.	Claim a ticket from Brimhaven Agility Arena.	1 Agility Agility 	 10	23.9%
-Karamja	Kill a snake.	Kill a snake.	N/A	 10	49.1%
-Karamja	Catch a Karambwanji.	Catch a raw karambwanji.	5 Fishing Fishing 	 10	21.2%
-Karamja	Be assigned a Slayer task in Shilo Village.	Be assigned a Slayer task in Shilo Village.	100 Combat Combat 50 Slayer Slayer
-Completion of  Shilo Village	 10	4.4%
-Karamja	Defeat a Greater Demon on Karamja.	Defeat a greater demon on Karamja.	N/A	 10	27.2%
-Karamja	Pick a pineapple on Karamja.	Pick a pineapple on Karamja from the pineapple plants near the lodestone.	N/A	 10	43.4%
-Karamja	Enter the Brimhaven Dungeon.	Enter the Brimhaven Dungeon.	875 coins	 10	48.1%
-Karamja	Cross the spiky pit using the stepping stones within Brimhaven Dungeon.	Cross the spiky pit using the stepping stones within Brimhaven Dungeon.	12 Agility Agility 	 10	37.3%
-Misthalin: Lumbridge	Progress through the Leagues tutorial to unlock your first relic.	Progress through the Leagues tutorial to unlock your first relic.	N/A	 10	100%
-Misthalin: Draynor Village	Climb to the top of the Wizards' Tower.	Climb to the top of the Wizards' Tower.	N/A	 10	78.8%
-Misthalin: Draynor Village	Have Ned make you some rope from balls of wool.	Have Ned make you some rope from 4 balls of wool.	N/A	 10	53%
-Misthalin: Draynor Village	Siphon from a fire essling in the Runespan.	Siphon from a fire essling in the Runespan.	14 Runecrafting Runecrafting 	 10	45.3%
-Misthalin: Draynor Village	Convert at least one pale memory into energy.	Convert at least one pale memory into energy.	1 Divination Divination 	 10	68.7%
-Misthalin: Edgeville	Kill a mugger near the Edgeville lodestone.	Kill a mugger near the Edgeville lodestone.	N/A	 10	71.7%
-Misthalin: Edgeville	Mine some coal in the centre of Barbarian village.	Mine some coal in the centre of Barbarian Village.	20 Mining Mining 	 10	69.1%
-Misthalin: Fort Forinthry	Use the bank in the workshop at Fort Forinthry.	Use the bank in the workshop at Fort Forinthry.	N/A	 10	52.4%
-Misthalin: Lumbridge	Kill a giant rat in Lumbridge Swamp.	Kill a giant rat in Lumbridge Swamp.	N/A	 10	90.9%
-Misthalin: Lumbridge	Kill a goblin in Lumbridge.	Kill a goblin in Lumbridge.	N/A	 10	94.7%
-Misthalin: Lumbridge	Kill a giant spider in Lumbridge or Lumbridge Swamp.	Kill a giant spider in Lumbridge or Lumbridge Swamp.	N/A	 10	90.9%
-Misthalin: Lumbridge	Milk a cow.	Milk a cow.	A bucket	 10	88.2%
-Misthalin: Lumbridge	Talk to Hans and find out how old you are.	Talk to Hans and find out how old you are.	N/A	 10	90.7%
-Misthalin: Lumbridge	Complete the quest: The Blood Pact.	Complete The Blood Pact.	See quest page	 10	79%
-Misthalin: Draynor Village	Catch some shrimp in the fishing spot to the east of Lumbridge Swamp.	Catch some shrimp in the fishing spot to the east of Lumbridge Swamp.	1 Fishing Fishing 	 10	84.8%
-Misthalin: Lumbridge	Smelt a steel bar in the furnace in Lumbridge.	Smelt a steel bar in the furnace in Lumbridge.	20 Smithing Smithing 	 10	63.1%
-Misthalin: Lumbridge	Cook some rat meat on a fire in Lumbridge Swamp.	Cook some rat meat on a campfire in Lumbridge Swamp.	1 Cooking Cooking 	 10	87.3%
-Misthalin: Lumbridge	Mine iron ore from the mining site south-west of Lumbridge Swamp.	Mine iron ore from the mining site south-west of Lumbridge Swamp.	10 Mining Mining 	 10	84.7%
-Misthalin: Lumbridge	Craft a water rune at the Water Altar.	Craft a water rune at the Water altar.	5 Runecrafting Runecrafting 	 10	44.7%
-Misthalin: Lumbridge	Complete a task from Jacquelyn, the Lumbridge Slayer master.	Complete a task from Jacquelyn, the Lumbridge Slayer master.	1 Slayer Slayer 	 10	79%
-Misthalin: Lumbridge	Fill a Charmed Sack with corruption at the Nexus in Lumbridge Swamp.	Fill a charmed sack with corruption at the Nexus in Lumbridge Swamp.	1 Prayer Prayer 	 10	78.4%
-Misthalin: Draynor Village	Complete the quest: Necromancy!.[sic]	Complete Necromancy!	See quest page	 10	70.2%
-Misthalin: City of Um	Upgrade a piece of Death Skull or Deathwarden equipment to tier 20.	Upgrade a piece of death skull or deathwarden equipment to tier 20.	20 Necromancy Necromancy , 15 Smithing Smithing  (death skull) OR 15 Crafting Crafting  (Deathwarden)
-Completion of  Kili Row	 10	27.3%
-Misthalin: City of Um	Craft some spirit or bone runes.	Craft some spirit or bone runes.	1 Runecrafting Runecrafting
-Partial completion of  Rune Mythos	 10	24.1%
-Misthalin: City of Um	Complete a Lesser Necroplasm ritual.	Complete a Lesser Necroplasm ritual.	5 Necromancy Necromancy 	 10	47.1%
-Misthalin: City of Um	Conjure a skeleton at the City of Um ritual site.	Conjure a Skeleton Warrior at the Um ritual site.	2 Necromancy Necromancy
-Conjure Skeleton Warrior unlocked at the Well of Souls	 10	45.1%
-Misthalin: City of Um	Conjure a zombie at the City of Um ritual site.	Conjure a Putrid Zombie at the Um ritual site.	40 Necromancy Necromancy
-Conjure Putrid Zombie unlocked at the Well of Souls	 10	7.8%
-Misthalin: City of Um	Conjure a ghost  at the City of Um ritual site.[sic]	Conjure a Vengeful Ghost at the Um ritual site.	40 Necromancy Necromancy
-Conjure Vengeful Ghost unlocked at the Well of Souls	 10	9.2%
-Misthalin: Varrock	Kill a dark wizard.	Kill a dark wizard.	N/A	 10	79.1%
-Misthalin: Varrock	Enter the Earth Altar using an earth tiara or talisman.	Enter the earth altar using an earth tiara or talisman.	1 Runecrafting Runecrafting 	 10	35%
-Misthalin: Varrock	Have Elsie tell you a story.	Have Elsie tell you a story, she is found upstairs in the church in Varrock. You must give her a cup of tea	A cup of tea	 10	60.3%
-Misthalin: Varrock	Give a bone to one of Varrock's stray dogs (or to your pet stray dog if you have one).	Use some bones on one of Varrock's stray dogs (or to your pet stray dog if you have one).	N/A	 10	69.8%
-Misthalin: Varrock	Claim a free clue scroll from Zaida at the Grand Exchange.	Claim a free clue scroll from Zaida at the Grand Exchange.	N/A	 10	69.1%
-Misthalin: Fort Forinthry	Give Bill a beer in Fort Forinthry.	Give Bill a beer in Fort Forinthry.	A beer, partial completion of  New Foundations	 10	29.1%
-Misthalin: Varrock	Complete the Archaeology tutorial.	Complete the Archaeology tutorial.	1 Archaeology Archaeology 	 10	72.2%
-Misthalin: Fort Forinthry	Make a plank yourself on the sawmill in Fort Forinthry.	Make a plank yourself on the sawmill in Fort Forinthry.	1 Construction Construction
-Partial completion of  New Foundations	 10	45%
-Misthalin: Varrock	Mine some iron ore in the mining spot south-west of Varrock.	Mine some iron ore in the mining spot south-west of Varrock.	10 Mining Mining 	 10	78.3%
-Misthalin: Varrock	Steal from the Varrock tea stall.	Steal from the Varrock tea stall.	5 Thieving Thieving 	 10	69.2%
-Misthalin: Varrock	Pan in the river at the Digsite.	This can only be completed after the point during The Dig Site quest where the panning guide teaches you how to pan for gold. You can then use the panning point. If you complete the quest without completing this achievement the task will be completed by attempting to pan with a panning tray in your inventory.	Partial completion of  The Dig Site	 10	12.6%
-Morytania	Take an easy companion through an easy route of Temple Trekking.	Complete an Easy Temple Trek.	Completion of  In Aid of the Myreque	 10	0.6%
-Morytania	Craft your own snelm in Morytania.	Craft a snelm.	15 Crafting Crafting
-Any blamish shell	 10	25.2%
-Morytania	Defeat a Werewolf in Morytania.	Defeat a Werewolf in Morytania.	N/A	 10	41.6%
-Morytania	Pass through the Holy barrier.	Pass through the Holy barrier.	Defeat a Ghoul (Paterdomus)	 10	57.9%
-Morytania	Enter through the western gate of Port Phasmatys.	Pass through the western gate of Port Phasmatys.	N/A	 10	9.9%
-Morytania	Activate the lodestone in Canifis.	Activate the Canifis lodestone.	Access to Morytania	 10	57.5%
-Morytania	Kill anything on the ground floor of the Slayer Tower.	Kill anything on the ground floor of the Slayer Tower.	1 Slayer Slayer
-Access to Morytania	 10	40.5%
-Morytania	Using either a Silver Sickle or the Ivandis Flail, grow some fungus in the swamp using Bloom.	Cast Bloom using a blessed sickle or the Ivandis flail in Mort Myre Swamp.	18 Crafting Crafting
-Completion of  Nature Spirit	 10	14%
-Morytania	Defeat 5 Feral Vampyres in the Haunted Woods.	Defeat 5 feral vampyres in the Haunted Woods.	Access to Morytania	 10	35.2%
-Morytania	Use an ectophial to return to Port Phasmatys.	Use an ectophial to return to Port Phasmatys.	Completion of  Ghosts Ahoy	 10	13.2%
-Morytania	Visit Dragontooth Island by boat.	Visit Dragontooth Island by boat.	Ghostspeak amulet	 10	16%
-Elven Lands: Tirranwn	Cook a Rabbit in Tirannwn.	Cook a raw rabbit in Tirannwn.	1 Cooking Cooking 	 10	27.4%
-Elven Lands: Tirranwn	Attempt to pass a leaf trap.	Attempt to pass a leaf trap.	N/A	 10	36.2%
-Elven Lands: Tirranwn	Use the Bank in Lletya.	Use the bank in Lletya.	N/A	 10	33%
-Elven Lands: Tirranwn	Charter a ship from Port Tyras.	Charter a ship from Port Tyras.	N/A	 10	25.2%
-Elven Lands: Tirranwn	Climb the Tower of Voices.	Climb the Tower of Voices.	N/A	 10	34.4%
-Elven Lands: Tirranwn	Burn some logs using the everlasting bonfire in the Tower of Voices.	Burn some logs using the everlasting bonfire in the Tower of Voices.	1 Firemaking Firemaking 	 10	38.1%
-Elven Lands: Tirranwn	Activate the lodestone in Prifddinas.	Activate the Prifddinas lodestone.	N/A	 10	60.5%
-Elven Lands: Tirranwn	Activate the lodestone in Tirannwn.	Activate the Tirannwn lodestone.	N/A	 10	37.1%
-Elven Lands: Tirranwn	Restore your prayer using the altar in Lletya.	Restore your prayer using the altar in Lletya.	1 Prayer Prayer 	 10	28.5%
-Wilderness: General	Use the bank at the Mage Arena.	Use the Mage Arena bank.	N/A	 10	45.7%
-Wilderness: General	Defeat the Chaos Elemental.	Defeat the Chaos Elemental once.	N/A	 10	19.3%
-Wilderness: General	Defeat the Chaos Elemental. (100 times)	Defeat the Chaos Elemental 100 times.	N/A	 10	1.4%
-Wilderness: General	Reach a score of 10 using the strange switches in the Wilderness.	Reach a score of 10 using the strange switches in the Wilderness.	N/A	 10	10.8%
-Wilderness: General	Jump over the Wilderness wall.	Jump over the Wilderness wall.	N/A	 10	74.1%
-Wilderness: General	Activate the lodestone near the Wilderness Crater.	Activate the Wilderness Crater lodestone.	N/A	 10	69.7%
-Wilderness: Daemonheim	Complete a Frozen floor in Daemonheim.	Complete a Frozen floor in Daemonheim.	1 Dungeoneering Dungeoneering 	 10	34.4%
-Wilderness: Daemonheim	Make use of either an autoheater, gem bag, herbicide, bonecrusher or charming imp.	Make use of either an autoheater, gem bag, herbicide, bonecrusher or charming imp.	The gem bag is the cheapest reward at 2000 dungeoneering token, and upgrading it is required for a later task.	 10	50.6%
-Wilderness: General	Enter the chaos tunnels from an entrance in the Wilderness.	Enter the Chaos Tunnels from an entrance in the Wilderness.	N/A	 10	43.2%
-Wilderness: General	Defeat a Black Unicorn in the Wilderness.	Defeat a black unicorn in the Wilderness.	N/A	 10	54.6%
-Anachronia	Build your Player Lodge on Anachronia.	Build your Player Lodge on Anachronia.	40 Construction Construction 	 30	0.4%
-Anachronia	Purchase the herb bag and the herb bag upgrade from the Herby Werby reward shop.	Purchase the herb bag and the herb bag upgrade from the Herby Werby reward shop.	1 Herblore Herblore
-Requires 4 weeks worth of potent herbs	 30	<0.1%
-Anachronia	Give Snoop some clean Dwarf weed.	Give Snoop some clean dwarf weed.	70 Herblore Herblore  if cleaning the herb yourself	 30	0.3%
-Anachronia	Harvest produce from 5 animals on Anachronia farm.	Harvest produce from 5 animals on Anachronia farm.	42 Farming Farming , 45 Construction Construction 	 30	0.2%
-Anachronia	Complete the beginner sections of the Anachronia agility course.	Complete the beginner sections of the Anachronia agility course.	30 Agility Agility 	 30	14.4%
-Anachronia	Complete the novice sections of the Anachronia agility course.	Complete the novice sections of the Anachronia agility course.	50 Agility Agility 	 30	9.2%
-Asgarnia: Burthorpe	Enter the Warriors Guild.	Enter the Warriors Guild.	Combined Attack and Strength level of 130, or 99 Attack Attack , or 99 Strength Strength 	 30	17.6%
-Asgarnia: Burthorpe	Equip a defender.	Equip a defender.	Combined Attack and Strength level of 130, or 99 Attack Attack , or 99 Strength Strength 	 30	7.9%
-Asgarnia: Burthorpe	Charge an Amulet of Glory in the Heroes' Guild.	Charge an amulet of glory in the Heroes' Guild.	If not as a drop from revenant knights, 80 Crafting Crafting  and 68 Magic Magic  to make it from scratch, or 83 Hunter Hunter  to catch dragon implings
-Completion of  Heroes' Quest	 30	0.3%
-Asgarnia: Falador	Enter the Crafting Guild.	Enter the Crafting Guild.	40 Crafting Crafting 	 30	40.9%
-Asgarnia: Falador	Complete the task set: Easy Falador.		See Easy Falador achievements page	 30	2.8%
-Asgarnia: Falador	Complete the task set: Medium Falador.		See Medium Falador achievements page	 30	<0.1%
-Asgarnia: Falador	Defeat the Giant Mole.	Kill the giant mole.	N/A	 30	31.1%
-Asgarnia: Falador	Defeat the Giant Mole. (50 times)	Kill the giant mole 50 times.	N/A	 30	0.2%
-Asgarnia: Falador	Steal some Wine of Zamorak from the Captured Temple, south of Goblin Village.	Steal some wine of Zamorak from the Captured Temple, south of Goblin Village.	33 Magic Magic  for Telekinetic Grab	 30	18.4%
-Asgarnia: Falador	Set up a dwarf cannon.	Set up a dwarf multicannon.	Completion of  Dwarf Cannon	 30	1.5%
-Asgarnia: Falador	Complete a ceremonial sword at the Artisans' Workshop.	Complete a ceremonial sword at the Artisans' Workshop.	1 Smithing Smithing 	 30	23.8%
-Asgarnia: Falador	Mine some orichalcite in the Mining Guild.	Mine some orichalcite ore in the Mining Guild.	60 Mining Mining 	 30	61.8%
-Asgarnia: Burthorpe	Harvest a herb from the troll stronghold herb patch.	Harvest a herb from the troll stronghold herb patch.	9 Farming Farming  to plant the lowest Herb seed.
-Completion of  My Arm's Big Adventure	 30	0.1%
-Asgarnia: Taverley	Kill a blue dragon in Taverley dungeon.	Kill a blue dragon in Taverley dungeon.	Dusty key or 70 Agility Agility 	 30	19.5%
-Asgarnia: Taverley	Open the crystal chest in Taverley.	Open the crystal chest in Taverley.	A crystal key	 30	14.9%
-Desert: General	Clear the Fort debris at the Kharid-et Dig Site.	Clear the fort debris at the Kharid-et Dig Site.	12 Archaeology Archaeology 	 30	60.1%
-Desert: General	Complete the quest: One Piercing Note.	Complete One Piercing Note.	See quest page	 30	20.9%
-Desert: General	Complete a lap of the Het's Oasis agility course.	Complete a lap of the Het's Oasis agility course.	65 Agility Agility 	 30	8.6%
-Desert: General	Defeat the Kalphite Queen.	Defeat the Kalphite Queen.	N/A	 30	7.2%
-Desert: General	Defeat the Kalphite Queen. (100 times)	Defeat the Kalphite Queen 100 times.	N/A	 30	<0.1%
-Desert: General	Defeat 100 bosses in the Dominion Tower.	Defeat 100 bosses in the Dominion Tower.	Completion of at least 20 various quests	 30	<0.1%
-Desert: General	Complete the task set: Easy Desert.	Easy desert tasks.	See Easy Desert achievements page	 30	0.3%
-Desert: General	Complete the task set: Medium Desert.	Medium desert tasks.	See Medium Desert achievements page	 30	<0.1%
-Desert: Menaphos	Steal from the lamp stall in Menaphos.	Steal from the lamp stall in Menaphos.	46 Thieving Thieving 	 30	9.3%
-Desert: General	Buy some runes from Ali Morrisane.	Buy some runes from Ali Morrisane.	Completion of the runes portion of Ali the Trader	 30	0.5%
-Desert: Menaphos	Catch a catfish.	Catch a raw catfish.	60 Fishing Fishing 	 30	12.1%
-Desert: General	Restore a Pontifex signet ring.	Restore a pontifex signet ring.	58 Archaeology Archaeology
-A cut dragonstone, which may require 55 Crafting Crafting 	 30	2.2%
-Desert: General	Search the Grand Gold Chest in room 4 of Pyramid Plunder in Sophanem.	Search the Grand Gold Chest in room 4 of Pyramid Plunder in Sophanem.	51 Thieving Thieving 	 30	3.3%
-Desert: General	Search the Grand Gold Chest in room 5 of Pyramid Plunder in Sophanem.	Search the Grand Gold Chest in room 5 of Pyramid Plunder in Sophanem.	61 Thieving Thieving 	 30	2.3%
-Desert: General	Search the Grand Gold Chest in room 6 of Pyramid Plunder in Sophanem.	Search the Grand Gold Chest in room 6 of Pyramid Plunder in Sophanem.	71 Thieving Thieving 	 30	1.7%
-Desert: General	Complete the quest: Smoking Kills.	Complete Smoking Kills.	See quest page	 30	4.5%
-Desert: General	Complete the quest: Desert Treasure.	Complete Desert Treasure.	See quest page	 30	0.5%
-Desert: General	Fully repair the statue of Het.	Repair the statue of Het at Het's Oasis.	200 pieces of Het	 30	0.9%
-Fremennik: Lunar Isles	Cast Moonclan Teleport.	Cast Moonclan Teleport.	69 Magic Magic 	 30	0.7%
-Fremennik: Mainland	Move Your House to Rellekka.	Move your player-owned house's location to Rellekka by speaking to an estate agent.	30 Construction Construction
-10,000	 30	12.9%
-Fremennik: Lunar Isles	Craft 50 Astral Runes.	Craft 50 astral runes.	40 Runecrafting Runecrafting
-Completion of  Lunar Diplomacy	 30	0.3%
-Fremennik: Mainland	Complete the Penguin Agility Course.	Complete the Penguin Agility Course.	30 Agility Agility
-Completion of  Cold War	 30	0.3%
-Fremennik: Mainland	Catch a Snowy Knight.	Catch a Snowy Knight.	35 Hunter Hunter
-A butterfly net and jar	 30	5.9%
-Fremennik: Mainland	Defeat a Kurask in the Fremennik Province.	Defeat a Kurask in the Fremennik Province.	70 Slayer Slayer
-Leaf-bladed spear or other special weapon	 30	5.8%
-Fremennik: Mainland	Defeat a Dagannoth in the Fremennik Province.	Defeat a dagannoth in the Fremennik Province.	N/A	 30	22.8%
-Fremennik: Mainland	Equip a Helm of Neitiznot.	Equip a Helm of Neitiznot.	55 Defence Defence
-Completion of  The Fremennik Isles	 30	1%
-Fremennik: Mainland	Defeat a Jelly in the Fremennik Province.	Defeat a jelly in the Fremennik Province.	52 Slayer Slayer 	 30	17.1%
-Fremennik: Mainland	Complete the quest: Throne of Miscellania.	Complete Throne of Miscellania.	See quest page	 30	1.6%
-Fremennik: Mainland	Complete the quest: Royal Trouble.	Complete Royal Trouble.	See quest page	 30	1.3%
-Fremennik: Mainland	Equip a Granite Shield.	Equip a granite shield.	55 Defence Defence , 55 Strength Strength
-Either completion of  Eadgar's Ruse or partial completion of  The Fremennik Isles	 30	0.4%
-Fremennik: Mainland	Equip a full set of Graahk, Larupia or Kyatt hunter gear.	Equip a full set of graahk, larupia or kyatt hunter gear.	31 Hunter Hunter  to hunt spined larupia	 30	1.7%
-Fremennik: Mainland	Defeat any of the Dagannoth Kings.	Defeat any of the Dagannoth Kings 1 time.	N/A	 30	7%
-Fremennik: Mainland	Defeat any of the Dagannoth Kings.	Defeat any of the Dagannoth Kings 100 times.	N/A	 30	0.4%
-Fremennik: Mainland	Complete the task set: Easy Fremennik.		N/A	 30	0.9%
-Fremennik: Mainland	Ride a mine cart into Keldagrim.	Ride a mine cart into Keldagrim.	Completion of  The Giant Dwarf	 30	2.7%
-Fremennik: Mainland	Travel to the Mammoth Iceberg.	Travel to the Mammoth Iceberg.	N/A	 30	11.4%
-Fremennik: Mainland	Steal from the fish stall in Rellekka.	Steal from the fish stall in Rellekka.	42 Thieving Thieving
-Completion of  The Fremennik Trials	 30	2%
-Fremennik: Mainland	Harvest 100 sparkling energy from Sparkling Wisps.	Harvest 100 sparkling energy from sparkling wisps.	40 Divination Divination 	 30	26.8%
-Fremennik: Mainland	Climb to the top of the lighthouse.	Climb to the top of the lighthouse.	Completion of  Horror from the Deep	 30	1.6%
-Fremennik: Mainland	Chop 10 Artic[sic] Pine trees.	Chop 10 arctic pine trees.	54 Woodcutting Woodcutting
-Partial completion of  The Fremennik Isles	 30	1.4%
-Fremennik: Mainland	Kill 25 Yaks.	Kill 25 yaks.	Partial completion of  The Fremennik Isles	 30	1.1%
-Fremennik: Mainland	Interact with a pet rock.	Interact with a pet rock.	Partial completion of  The Fremennik Trials	 30	2.2%
-Fremennik: Mainland	Complete the task set: Medium Fremennik.	Complete the Medium Fremennik achievements.	See Medium Fremennik achievements page	 30	<0.1%
-Global	Reach level 50 in any skill.	Reach level 50 in any skill.	Any skill at level 50	 30	84.8%
-Global	Reach at least level 5 in all non-elite skills.	Reach at least level 5 in all non-elite skills.	All skills except Invention at level 5	 30	41.8%
-Global	Reach at least level 10 in all non-elite skills.	Reach at least level 10 in all non-elite skills.	All skills except Invention at level 10	 30	36.9%
-Global	Reach at least level 20 in all non-elite skills.	Reach at least level 20 in all non-elite skills.	All skills except Invention at level 20	 30	24.3%
-Global	Reach combat level 50.	Reach combat level 50.	50 Combat level Combat level	 30	65.3%
-Global	Reach total level 500.	Reach total level 500. This task is currently bugged and may complete before you have reached 500 total levels	500 Skills Total level	 30	77%
-Global	Mine any ore 200 times.	Mine any ore 200 times.	1 Mining Mining 	 30	86.3%
-Global	Chop any tree 200 times.	Chop any tree 200 times.	1 Woodcutting Woodcutting 	 30	63%
-Global	Chop a willow tree.	Chop a willow tree.	20 Woodcutting Woodcutting 	 30	75.6%
-Global	Burn any logs 200 times.	Burn any logs 200 times.	1 Firemaking Firemaking 	 30	33.8%
-Global	Catch any fish 200 times.	Catch any fish 200 times.	1 Fishing Fishing 	 30	63.5%
-Global	Harvest any memory from a wisp 200 times.	Harvest any memory from a wisp 200 times.	1 Divination Divination 	 30	60%
-Global	Pickpocket anyone 200 times.	Pickpocket anyone 200 times.	1 Thieving Thieving 	 30	40.6%
-Global	Plant seeds in any farming patch 100 times.	Plant seeds in any farming patch 100 times.	1 Farming Farming 	 30	23.7%
-Global	Unlock all of the Free to Play Lodestones.	Unlock all of the Free to Play Lodestones.	N/A	 30	42.4%
-Global	Make 200 potions of any kind.	Make 200 potions of any kind.	1 Herblore Herblore 	 30	12.9%
-Global	Clean 200 of any herb.	Clean 200 of any herb.	1 Herblore Herblore 	 30	34.9%
-Global	Fletch 1,000 arrow shafts.	Fletch 1,000 Arrow Shafts.	1 Fletching Fletching 	 30	67%
-Global	Complete 25 laps of any Agility course.	Complete 25 laps of any Agility course.	1 Agility Agility 	 30	39.5%
-Global	Smith 25 of any metal weapon or armour piece.	Smith 25 of any metal weapon or armour piece.	1 Smithing Smithing 	 30	70.6%
-Global	Cook 200 fish.	Cook 200 fish.	1 Cooking Cooking 	 30	50.5%
-Global	Offer 100 bones of any kind to an altar.	Offer 100 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel	1 Prayer Prayer 	 30	37.7%
-Global	Scatter 100 ashes of any kind.	Scatter 100 ashes of any kind.	1 Prayer Prayer 	 30	20.4%
-Global	Restore 500 Prayer Points at an Altar at once.	Restore 500 Prayer Points at an Altar at once.	50 Prayer Prayer 	 30	37.1%
-Global	Catch 25 Implings of any kind.	Catch 25 implings of any kind.	17 Hunter Hunter 	 30	3.4%
-Global	Catch 35 Implings of any kind.	Catch 35 Implings of any kind.	17 Hunter Hunter 	 30	2.2%
-Global	Catch 200 Hunter creatures.	Catch 200 Hunter creatures.	1 Hunter Hunter 	 30	12.2%
-Global	Complete 25 Easy clue scrolls.	Complete 25 easy clue scrolls.	N/A	 30	3.6%
-Global	Complete 75 Easy clue scrolls.	Complete 75 easy clue scrolls.	N/A	 30	0.4%
-Global	Collect 25 unique items for the General clue rewards collection log.	Collect 25 unique items for the general clue rewards collection log.	N/A	 30	11.5%
-Global	Make 30 Prayer Potions.	Make 30 prayer potions.	38 Herblore Herblore 	 30	16%
-Global	Make a 4-dose Potion.	Make a 4-dose potion.	1 Herblore Herblore
-A botanist's amulet, Morytania legs 4, Underworld Grimoire 1, or a varanusaur pen with a farm totem at the Anachronia Dinosaur Farm	 30	3.6%
-Global	Make 20 Super Attack Potions.	Make 20 super attack potions.	45 Herblore Herblore 	 30	10%
-Global	Clean 50 Grimy Ranarr.	Clean 50 grimy ranarr.	25 Herblore Herblore 	 30	21.9%
-Global	Clean 50 Grimy Avantoe.	Clean 50 grimy avantoe.	48 Herblore Herblore 	 30	6.3%
-Global	Harvest 5 Grimy Ranarr.	Harvest 5 grimy ranarr.	32 Farming Farming 	 30	31.2%
-Global	Equip an Iron Crossbow.	Equip an iron crossbow.	10 Ranged Ranged 	 30	25.5%
-Global	Equip a Maple shieldbow.	Equip a maple shieldbow.	30 Ranged Ranged , 30 Defence Defence 	 30	17.7%
-Global	Fletch 50 Maple shieldbow (unstrung).	Fletch 50 unstrung maple shieldbows.	55 Fletching Fletching 	 30	16.4%
-Global	Fletch 400 Steel arrows.	Fletch 400 steel arrows.	30 Fletching Fletching 	 30	34.7%
-Global	Fletch 100 Iron bolts.	Fletch 100 iron bolts.	39 Fletching Fletching 	 30	27.2%
-Global	Mine some Ore With a Rune Pickaxe.	Mine some ore with a rune pickaxe.	50 Mining Mining 	 30	49.7%
-Global	Mine 20 Mithril Ore.	Mine 20 mithril ore.	30 Mining Mining 	 30	79%
-Global	Mine 30 Adamant Ore.	Mine 30 adamantite ore.	40 Mining Mining 	 30	74.3%
-Global	Mine 40 Runite Ore.	Mine 40 runite ore.	50 Mining Mining 	 30	68.5%
-Global	Open 20 Igenous[sic] Geodes.	Open 20 igneous geodes. These are found randomly while mining from rocks which require at least level 60 Mining	60 Mining Mining 	 30	41.6%
-Global	Check a grown Fruit Tree.	Check a tree grown in a fruit tree patch.	27 Farming Farming 	 30	27.8%
-Global	Catch 100 Lobsters.	Catch 100 lobsters.	40 Fishing Fishing 	 30	43.5%
-Global	Catch 50 Swordfish.	Catch 50 swordfish.	50 Fishing Fishing 	 30	31.7%
-Global	Catch 50 Salmon.	Catch 50 salmon.	30 Fishing Fishing 	 30	53.6%
-Global	Catch 10 Pike.	Catch 10 pike.	25 Fishing Fishing 	 30	51.9%
-Global	Make a Pineapple pizza.	Make a pineapple pizza by adding pineapple chunks or a pineapple ring to a plain pizza.	65 Cooking Cooking
-Plain pizza and pineapple	 30	1.7%
-Global	Make a Stew.	Make a stew: add a raw potato to a bowl of water, then add either cooked meat or chicken, and cook the stew at a range.	25 Cooking Cooking 	 30	9.7%
-Global	Make a Chocolate Cake.	Make a chocolate cake by adding a chocolate bar to a cooked cake.	50 Cooking Cooking
-Cake and chocolate bar	 30	10.2%
-Global	Bury some Baby Dragon bones.	Bury some baby dragon bones.	N/A	 30	24.4%
-Global	Bury 5 Dragon bones.	Bury 5 dragon bones.	1 Prayer Prayer 	 30	30.5%
-Global	Activate Protect from Melee prayer.	Activate the Protect from Melee prayer.	43 Prayer Prayer 	 30	48.8%
-Global	Catch a Gourmet Impling.	Catch a gourmet impling.	28 Hunter Hunter 	 30	22.4%
-Global	Light a Bullseye Lantern.	Light a bullseye lantern.	49 Firemaking Firemaking
-Either 36 Thieving Thieving  and completion of  Death to the Dorgeshuun; or 50 Quest points Quest points and the Lorehound pet unlocked; or 20 Smithing Smithing  and 49 Crafting Crafting  to create from scratch	 30	8.4%
-Global	Teleport using Law runes.	Teleport using law runes. The lowest level teleport spell is South Feldip Hills Teleport which also requires one air and one water rune	10 Magic Magic
-A law rune	 30	45.8%
-Global	Craft some Combination runes.	Craft some combination runes: mist runes have the lowest level requirement. They can made by using a pure essence and 1 water rune and a water talisman at the air altar or 1 air rune and an air talisman at the water altar	6 Runecrafting Runecrafting
-A pure essence	 30	20.3%
-Global	Craft 100 runes.	Craft 100 runes.	1 Runecrafting Runecrafting 	 30	48.8%
-Global	Craft 1,000 runes.	Craft 1,000 runes.	1 Runecrafting Runecrafting 	 30	14.4%
-Global	Equip a full set of Steel armour.	Equip a full set of steel armour (helm, body, legs, boots, and gauntlets).	20 Defence Defence 	 30	54%
-Global	Equip a full set of Mithril armour.	Equip a full set of mithril armour (full helm, platebody, legs, boots, and gauntlets).	30 Defence Defence 	 30	51.3%
-Global	Equip a full set of Adamant armour.	Equip a full set of adamant armour (full helm, platebody, legs, boots, and gauntlets).	40 Defence Defence 	 30	45.7%
-Global	Equip a full set of Rune armour.	Equip a full set of rune armour (full helm, platebody, legs, boots, and gauntlets).	50 Defence Defence 	 30	38.8%
-Global	Equip a full set of Blue Dragonhide armour.	Equip a full set of blue dragonhide armour.	50 Defence Defence 	 30	14%
-Global	Equip a full set of Red Dragonhide armour.	Equip a full set of red Dragonhide armour.	55 Defence Defence 	 30	4.4%
-Global	Equip a full set of Batwing robes.	Equip a full set of batwing robes.	30 Defence Defence 	 30	44.3%
-Global	Equip a full set of Mystic robes.	Equip a full set of mystic robes.	50 Defence Defence 	 30	17%
-Global	Create a Mithril Grapple.	Create a mithril grapple.	59 Fletching Fletching , 30 Smithing Smithing 	 30	6.5%
-Global	Burn 25 Willow logs.	Burn 25 willow logs.	30 Firemaking Firemaking 	 30	57.8%
-Global	Burn 50 Maple logs.	Burn 50 maple logs.	45 Firemaking Firemaking 	 30	28.9%
-Global	Equip any elemental battlestaff.	Equip any elemental battlestaff.	30 Magic Magic 	 30	32.1%
-Global	Equip a mystic staff.	Equip a mystic staff.	40 Magic Magic 	 30	23.2%
-Global	Obtain 50 Quest Points.	Obtain 50 quest points.	50 Quest points Quest points	 30	56.9%
-Global	Complete 100 clues of any tier.	Complete 100 clues of any tier.	N/A	 30	4.6%
-Global	Complete a Medium clue scroll.	Complete a medium clue scroll.	N/A	 30	36%
-Global	Complete 25 Medium clue scrolls.	Complete 25 medium clue scrolls.	N/A	 30	6.1%
-Global	Complete 75 Medium clue scrolls.	Complete 75 medium clue scrolls.	N/A	 30	0.5%
-Global	Complete a Hard clue scroll.	Complete a hard clue scroll.	N/A	 30	32.2%
-Global	Complete 25 Hard clue scrolls.	Complete 25 hard clue scrolls.	N/A	 30	10.4%
-Global	Collect 5 unique items for the Easy clue rewards collection log.	Collect 5 unique items for the easy clue rewards collection log.	N/A	 30	34.1%
-Global	Collect 10 unique items for the Easy clue rewards collection log.	Collect 10 unique items for the easy clue rewards collection log.	N/A	 30	27.7%
-Global	Collect 5 unique items for the Medium clue rewards collection log.	Collect 5 unique items for the medium clue rewards collection log.	N/A	 30	31.3%
-Global	Collect 10 unique items for the Medium clue rewards collection log.	Collect 10 unique items for the Medium clue rewards collection log.	N/A	 30	26.4%
-Global	Collect 5 unique items for the Hard clue rewards collection log.	Collect 5 unique items for the hard clue rewards collection log.	N/A	 30	27.8%
-Global	Equip any 2 pieces of an Elegant outfit.	Equip any 2 pieces of an elegant outfit.	N/A	 30	14.9%
-Global	Equip a composite bow of any kind.	Equip a composite bow of any kind.	20 Ranged Ranged 	 30	18.8%
-Global	Perform a Special Attack.	Perform a special attack.	5 Attack Attack  or 5 Ranged Ranged  or 5 Magic Magic  (claimed from Gudrik in Port Sarim)	 30	35.7%
-Global	Reach level 30 in any skill.	Reach level 30 in any skill.	N/A	 30	93.5%
-Global	Reach level 40 in any skill.	Reach level 40 in any skill.	N/A	 30	89.9%
-Global	Reach level 60 in any skill.	Reach level 60 in any skill.	N/A	 30	78.7%
-Global	Reach at least level 30 in all non-elite skills.	Reach at least level 30 in all non-elite skills.	All skills except Invention at level 30	 30	14.6%
-Kandarin: Ardougne	Fletch 50 Maple shieldbow (unstrung) in Kandarin.	Fletch 50 unstrung maple shieldbows in Kandarin.	55 Fletching Fletching 	 30	15.5%
-Kandarin: Ardougne	Pickpocket a Knight of Ardougne 50 times.	Pickpocket a knight of Ardougne 50 times.	55 Thieving Thieving 	 30	13%
-Kandarin: Ardougne	Complete the Barbarian Outpost Agility Course.	Complete the Barbarian Outpost Agility Course.	35 Agility Agility
-Completion of  Bar Crawl (miniquest)	 30	5.7%
-Global	Equip a Spottier Cape.	Equip a spottier cape.	66 Hunter Hunter 	 30	0.6%
-Kandarin: Ardougne	Catch a red salamander from the Hunter area outside of Ourania Altar.	Catch a red salamander.	59 Hunter Hunter 	 30	1.9%
-Kandarin: Ardougne	Enter the Fishing Guild.	Enter the Fishing Guild.	68 Fishing Fishing 	 30	9.7%
-Kandarin: Gnomes	Check a grown Papaya Tree inside Tree Gnome Stronghold.	Check a grown papaya tree inside Tree Gnome Stronghold.	57 Farming Farming 	 30	3.1%
-Kandarin: Ardougne	Kill a mithril dragon.	Defeat a mithril dragon.	N/A	 30	2.9%
-Kandarin: Yanille	Enter the Magic Guild in Yanille.	Enter the Wizards' Guild.	66 Magic Magic 	 30	11.8%
-Kandarin: Ardougne	Defeat a Fire Giant in Kandarin.	Defeat a fire giant in Kandarin.	N/A	 30	17.4%
-Kandarin: Seers Village	Use the Chivalry Prayer.	Use the Chivalry prayer.	60 Prayer Prayer , 65 Defence Defence
-Completion of Knight Waves training ground	 30	0.9%
-Kandarin: Yanille	Be on the winning side in a game of Castle Wars.	Win a game of Castle Wars.	N/A	 30	0.2%
-Kandarin: Seers Village	Complete the quest: Elemental Workshop II.	Complete Elemental Workshop II.	See quest page	 30	3.8%
-Kandarin: Feldip Hills	Equip an Ogre Forester Hat.	Equip an ogre forester hat.	300 chompy bird kills	 30	<0.1%
-Kandarin: Ardougne	Complete the task set: Easy Ardougne.	Complete the Easy Ardougne achievements.	See Easy Ardougne achievements page	 30	0.7%
-Kandarin: Gnomes	Create the listed gnome cocktails.	Make one of each type of cocktail.	37 Cooking Cooking 	 30	3.4%
-Kandarin: Ardougne	Earn a total amount of 10,000 beans.	Earn a total of 10,000 beans from selling animals in player-owned farm.	17 Farming Farming 	 30	<0.1%
-Global	Hunt 10 Spotted Kebbits with the help of a falcon.	Hunt 10 spotted kebbits with using falconry.	43 Hunter Hunter 	 30	3%
-Global	Complete the quest: The Needle Skips.	Complete The Needle Skips.	See quest page	 30	2.6%
-Kandarin: Ardougne	Complete the task set: Medium Ardougne.	Complete the Medium Ardougne achievements.	See Medium Ardougne achievements page	 30	<0.1%
-Karamja	Complete the task set: Easy Karamja.	Complete the Easy Karamja achievements.	See Easy Karamja achievements page	 30	9.2%
-Karamja	Craft 50 Nature runes.	Craft 50 nature runes.	44 Runecrafting Runecrafting 	 30	9.9%
-Karamja	Catch a salmon on Karamja.	Catch a salmon on Karamja.	30 Fishing Fishing
-Completion of  Shilo Village	 30	4.5%
-Karamja	Get Stiles to exchange some of your fish for bank notes.	Get Stiles to exchange some of your fish for bank notes.	N/A	 30	23.8%
-Karamja	Convert 100 gleaming memories in an energy rift.	Convert 100 gleaming memories in an energy rift.	50 Divination Divination 	 30	21.2%
-Karamja	Mine a drakolith rock in the Tai Bwo Wannai mine.	Mine a drakolith rock in the Tai Bwo Wannai mine.	60 Mining Mining 	 30	33.8%
-Karamja	Mine a ruby from a gem rock in Shilo Village.	Mine a ruby from a gem rock in Shilo Village.	30 Mining Mining
-Completion of  Shilo Village	 30	5.4%
-Karamja	Enter the Hardwood Grove in Tai Bwo Wannai.	Enter the Hardwood Grove in Tai Bwo Wannai.	Completion of  Jungle Potion	 30	3.5%
-Karamja	Complete the quest: Dragon Slayer.	Complete Dragon Slayer.	See quest page	 30	22.9%
-Karamja	Check a grown banana tree on Karamja.	Check a grown banana tree on Karamja.	33 Farming Farming 	 30	9%
-Karamja	Defeat a TzHaar.	Defeat a TzHaar.	N/A	 30	36%
-Karamja	Equip an Obsidian cape.	Equip an obsidian cape.	N/A	 30	2.2%
-Karamja	Kill a metal dragon in Brimhaven Dungeon.	Kill a metal dragon in Brimhaven Dungeon.	N/A	 30	12.6%
-Karamja	Catch 25 lobsters on Karamja.	Catch 25 lobsters on Karamja.	40 Fishing Fishing 	 30	38.9%
-Karamja	Equip a Toktz-Ket-Xil.	Equip a Toktz-Ket-Xil.	60 Defence Defence 	 30	0.8%
-Karamja	Equip a Tzhaar-Ket-Om.	Equip a Tzhaar-Ket-Om.	60 Strength Strength 	 30	0.7%
-Karamja	Equip a Toktz-Xil-Ak.	Equip a Toktz-Xil-Ak.	60 Attack Attack 	 30	0.4%
-Karamja	Equip a Toktz-Xil-Ek.	Equip a Toktz-Xil-Ek.	60 Attack Attack 	 30	0.4%
-Karamja	Complete the task set: Medium Karamja.	Complete the Medium Karamja achievements.	See Medium Karamja achievements page	 30	<0.1%
-Misthalin: Draynor Village	Kill the lesser demon in the Wizards' Tower.	Kill the lesser demon in the Wizards' Tower.	Cannot be attacked with short-range melee	 30	57.7%
-Misthalin: Draynor Village	Hunt a yellow wizard in the RuneSpan and give them some items.	Hunt a yellow wizard in the Runespan and give them some items.	1 Runecrafting Runecrafting 	 30	28.3%
-Misthalin: Draynor Village	Use the Rune Goldberg Machine to create Vis wax.	Use the Rune Goldberg Machine to create vis wax.	50 Runecrafting Runecrafting 	 30	19.5%
-Misthalin: Draynor Village	Siphon from a nature esshound in the Runespan.	Siphon from a nature esshound in the Runespan.	44 Runecrafting Runecrafting 	 30	28.4%
-Misthalin: Draynor Village	Siphon Rune dust from a RuneSphere in the RuneSpan.	Siphon rune dust from a Runesphere in the RuneSpan.	1 Runecrafting Runecrafting 	 30	11.2%
-Misthalin: Edgeville	Fully complete the Stronghold of Player Safety.	Fully complete the Stronghold of Player Safety by pulling an old lever on the upper floor and then opening the treasure chest in the secure sector.	N/A	 30	38.1%
-Misthalin: Fort Forinthry	Complete the quest: New Foundations.	Complete New Foundations.	See quest page	 30	35.7%
-Misthalin: Lumbridge	Complete the task set: Beginner Lumbridge.	Given by Explorer Jack in Lumbridge for completing all Beginner Tasks in Lumbridge.	See Beginner Lumbridge achievements page	 30	46.6%
-Misthalin: Draynor Village	Complete the quest: Duck Quest.	Complete Duck Quest.	See quest page	 30	26.3%
-Misthalin: Lumbridge	Complete the task set: Easy Lumbridge.	Given by Bob, the axe seller in Lumbridge, for completing all Easy Tasks in Lumbridge.	See Easy Lumbridge achievements page	 30	20.1%
-Misthalin: Lumbridge	Complete the task set: Medium Lumbridge.	Given by Ned in Draynor Village for completing all Medium Tasks in Lumbridge.	See Medium Lumbridge achievements page	 30	6%
-Misthalin: Lumbridge	Drink from the Tears of Guthix.	Drink from the Tears of Guthix.	Completion of  Tears of Guthix quest	 30	3.9%
-Misthalin: Lumbridge	Complete world 25 in Shattered Worlds.	Reach world 25 in Shattered Worlds.	N/A	 30	10.5%
-Misthalin: Lumbridge	Catch 20 implings in Puro-Puro.	Catch 20 implings in Puro-Puro.	17 Hunter Hunter 	 30	5.8%
-Misthalin: Lumbridge	Complete the quest: Sheep Shearer (miniquest).	Complete Sheep Shearer miniquest.	N/A	 30	61.6%
-Misthalin: Lumbridge	Cut a willow tree east of Lumbridge Castle.	Cut the willow tree east of Lumbridge Castle, by the bridge across the River Lum.	20 Woodcutting Woodcutting 	 30	64%
-Misthalin: Lumbridge	Craft 50 Water Runes.	Craft 50 water runes.	5 Runecrafting Runecrafting
-Water talisman or equivalent	 30	43.2%
-Misthalin: Lumbridge	Pickpocket a H.A.M. member.	Pickpocket a H.A.M. member.	15 Thieving Thieving 	 30	60.3%
-Misthalin: Lumbridge	Churn some butter.	Make a pat of butter by using a bucket of milk at a dairy churn	38 Cooking Cooking
-Bucket of milk	 30	24.5%
-Misthalin: Lumbridge	Craft 50 cosmic runes.	Craft 50 cosmic runes.	27 Runecrafting Runecrafting
-Cosmic talisman or equivalent, completion of  Lost City quest	 30	7.6%
-Misthalin: Lumbridge	Steal a lantern from a cave goblin.	Steal a lantern from a cave goblin (only the ones in Dorgesh-Kaan have the lantern as a possible loot from pickpocketting).	36 Thieving Thieving
-Completion of  Death to the Dorgeshuun quest	 30	0.7%
-Misthalin: Lumbridge	Use the range in Lumbridge Castle to bake a cake.	Use the range in Lumbridge Castle to bake a cake.	40 Cooking Cooking
-Completion of  Cook's Assistant quest	 30	20.1%
-Misthalin: City of Um	Have either a Putrid Zombie or Vengeful Ghost conjured while fighting the matching creature.	Have either a Putrid Zombie or Vengeful Ghost conjured while fighting the matching creature.	40 Necromancy Necromancy
-Unlock the ability to conjure at tier 3 of talents, conduit, ectoplasm?	 30	9.7%
-Misthalin: City of Um	Learn how to craft moonstone jewellery.	Learn how to craft moonstone jewellery.	50 Necromancy Necromancy
-Brown apron or keepsaked override	 30	3.7%
-Misthalin: City of Um	Disgruntle an inhabitant of Um by wearing a bedsheet.	Disgruntle an inhabitant of Um by wearing a bedsheet, see Poor Imitation for NPCs which can be disgruntled.	Completion of  Ghosts Ahoy quest, bedsheet	 30	3.1%
-Misthalin: City of Um	Upgrade a piece of Death Skull or Deathwarden equipment to tier 50.	Upgrade a piece of Death Skull or Deathwarden equipment to tier 50.	20 Necromancy Necromancy
-Completion of  Necromancy! and  Kili Row. See also Kili's Knowledge III	 30	12.8%
-Misthalin: City of Um	Complete a communion ritual using a memento.	Complete a communion ritual using a memento.	5 Necromancy Necromancy
-Completion of  Necromancy!	 30	28.5%
-Misthalin: City of Um	Conjure a Phantom Guardian at the City of Um ritual site.	Conjure a Phantom Guardian at the Um ritual site.	70 Necromancy Necromancy
-Conjure Phantom Guardian unlocked from the Well of Souls	 30	4.2%
-Misthalin: City of Um	Complete the task set: Easy Underworld.	Complete the Easy Underworld achievements.	See Easy Underworld achievements page	 30	19.4%
-Misthalin: City of Um	Complete the task set: Medium Underworld.	Complete the Medium Underworld achievements.	See Medium Underworld achievements page	 30	4.7%
-Misthalin: Varrock	Complete the task set: Easy Varrock.	Given by Rat Burgiss south of Varrock for completing all Easy Tasks in Varrock.	See Easy Varrock achievements page	 30	3.4%
-Misthalin: Varrock	Complete the task set: Medium Varrock.	Given by Reldo in Varrock Palace's library for completing all Medium Tasks in Varrock.	See Medium Varrock achievements page	 30	<0.1%
-Misthalin: Edgeville	Browse through Oziach's Armour Shop.	Browse through Oziach's Armour Shop.	Completion of  Dragon Slayer quest	 30	20.4%
-Misthalin: Varrock	Enter the Cooks' Guild.	Enter the Cooks' Guild.	32 Cooking Cooking
-Chef's hat of equivalent, see Cooks' Guild for alternatives	 30	37.9%
-Misthalin: Varrock	Complete the quest: Demon Slayer.	Complete Demon Slayer.	See quest page	 30	41.2%
-Misthalin: Varrock	Complete the quest: Vampyre Slayer.	Complete Vampyre Slayer.	See quest page	 30	45.4%
-Misthalin: Varrock	Mine 50 pure essence.	Mine 50 pure essence.	30 Mining Mining 	 30	66.4%
-Misthalin: Varrock	Pickpocket a guard in Varrock Palace's courtyard.	Pickpocket a Varrock guard.	40 Thieving Thieving 	 30	30.2%
-Misthalin: Varrock	Gather and convert 50 bright memories.	Gather and convert 50 bright memories.	20 Divination Divination 	 30	44.2%
-Morytania	Complete the task set: Easy Morytania.	Complete the Easy Morytania achievements.	See Easy Morytania achievements page	 30	0.1%
-Morytania	Take a medium companion through a medium route of Temple Trekking.	Take a medium companion through a medium route of Temple Trekking.	Completion of  In Aid of the Myreque	 30	0.3%
-Morytania	Visit Mos Le'Harmless.	Visit Mos Le'Harmless.	Partial completion of  Cabin Fever	 30	1.6%
-Morytania	Visit Harmony Island.	Visit Harmony Island.	Partial completion of  The Great Brain Robbery	 30	<0.1%
-Morytania	Visit the Everlight dig site.	Visit the Everlight dig site.	42 Archaeology Archaeology 	 30	17.1%
-Morytania	Finish a game of Werewolf Skullball.	Finish a game of Werewolf Skullball.	25 Agility Agility
-Completion of  Creature of Fenkenstrain	 30	0.4%
-Morytania	Defeat the six Barrows Brothers and loot their chest.	Defeat the six Barrows Brothers and loot their chest once.	N/A	 30	17.6%
-Morytania	Defeat the six Barrows Brothers and loot their chest. (100 times)	Defeat the six Barrows Brothers and loot their chest 100 times.	N/A	 30	0.1%
-Morytania	Equip a Barrows weapon.	Equip a barrows weapon.	Either 70 Magic Magic , 70 Attack Attack , or 70 Ranged Ranged 	 30	3.2%
-Morytania	Equip a piece of Barrows armour.	Equip a piece of barrows armour.	70 Defence Defence 	 30	7.6%
-Morytania	Equip a Salve Amulet (e).	Equip a salve amulet (e).	Completion of  Lair of Tarn Razorlor (miniquest)	 30	6.6%
-Morytania	Make a batch of cannonballs in Port Phasmatys.	Make a batch of cannonballs in Port Phasmatys.	35 Smithing Smithing
-Completion of  Dwarf Cannon	 30	1%
-Morytania	Catch 10 Green salamanders.	Catch 10 Green salamanders.	29 Hunter Hunter 	 30	8.8%
-Morytania	Complete the quest: Haunted Mine.	Complete Haunted Mine.	See quest page	 30	14%
-Morytania	Harvest bittercap mushrooms in the farming patch near Canifis.	Harvest bittercap mushrooms in the farming patch near Canifis.	53 Farming Farming 	 30	5.7%
-Morytania	Complete the task set: Medium Morytania.		N/A	 30	<0.1%
-Elven Lands: Tirranwn	Complete the task set: Easy Tirannwn.	Complete the Easy Tirannwn achievements.	See Easy Tirannwn achievements page	 30	<0.1%
-Elven Lands: Tirranwn	Check a grown Papaya Tree in Lletya.	Check a grown papaya tree in Lletya.	57 Farming Farming 	 30	3.8%
-Elven Lands: Tirranwn	Craft 50 Death Runes.	Craft 50 death runes.	65 Runecrafting Runecrafting 	 30	1.4%
-Elven Lands: Tirranwn	Move your house to Prifddinas.	Move your player-owned house's location to Prifddinas by speaking to an estate agent.	75 Construction Construction
-50,000	 30	1.2%
-Elven Lands: Tirranwn	Use an Elven Teleport Crystal.	Use a crystal teleport seed.	N/A	 30	16%
-Elven Lands: Tirranwn	Equip Iban's staff.	Equip Iban's staff.	50 Magic Magic 	 30	2.1%
-Elven Lands: Tirranwn	Catch 10 Pawyas in Isafdar.	Catch 10 pawyas in Isafdar.	66 Hunter Hunter 	 30	0.2%
-Elven Lands: Tirranwn	Mine 200 soft clay in Prifddinas.	Mine 200 soft clay in Prifddinas.	75 Mining Mining 	 30	23.2%
-Elven Lands: Tirranwn	Use the fairy ring in the Amlodd district.	Use the fairy ring in the Amlodd district.	Partial completion of  A Fairy Tale II - Cure a Queen	 30	3.7%
-Elven Lands: Tirranwn	Complete the task set: Medium Tirannwn.	Complete the Medium Tirannwn achievements.	See Medium Tirannwn achievements page	 30	<0.1%
-Wilderness: General	Complete the task set: Easy Wilderness.	Complete the Easy Wilderness achievements.	See Easy Wilderness achievements page	 30	8.5%
-Wilderness: General	Defeat the King Black Dragon.	Defeat the King Black Dragon once.	N/A	 30	24.5%
-Wilderness: General	Defeat the King Black Dragon. (100 times)	Defeat the King Black Dragon 100 times.	N/A	 30	0.4%
-Wilderness: General	Sacrifice Dragon bones on the Chaos Altar.	Sacrifice dragon bones on the chaos altar in the Wilderness.	1 Prayer Prayer 	 30	31.6%
-Wilderness: General	Cast the Claws of Guthix special attack.	Cast the Claws of Guthix special attack.	60 Magic Magic
-Completion of Mage Arena, Guthix staff	 30	5.2%
-Wilderness: General	Defeat 5 Green dragons.	Defeat 5 green dragons.	N/A	 30	31.5%
-Wilderness: General	Complete 10 laps of the Wilderness agility course.	Complete 10 laps of the Wilderness agility course.	52 Agility Agility 	 30	17.1%
-Wilderness: General	Equip a Saradomin, Zamorak, or Guthix cape.	Equip a Saradomin, Zamorak, or Guthix cape.	60 Magic Magic
-Completion of Mage Arena	 30	8.9%
-Wilderness: General	Visit any Runecrafting altar through the Abyss.	Visit any Runecrafting altar through the Abyss.	Completion of  Enter the Abyss (miniquest)	 30	29%
-Wilderness: General	Defeat 10 Fetid Zombies.	Defeat 10 fetid zombies.	N/A	 30	26.5%
-Wilderness: General	Defeat 20 Bound Skeletons.	Defeat 20 bound skeletons.	N/A	 30	13.5%
-Wilderness: Daemonheim	Defeat the Rammernaut.	Defeat the Rammernaut.	35 Dungeoneering Dungeoneering 	 30	1.8%
-Wilderness: General	Defeat Bossy McBoss Face.	Defeat Bossy McBoss Face.	N/A	 30	2%
-Wilderness: General	Activate and teleport from each of the Wilderness teleport obelisks.	Activate and teleport from each of the Wilderness teleport obelisks.	N/A	 30	10.2%
-Wilderness: General	Defeat Bossy McBossface's first mate.	Defeat Bossy McBossface's first mate.	N/A	 30	1%
-Wilderness: General	Complete the task set: Medium Wilderness.	Complete the Medium Wilderness achievements.	See Medium Wilderness achievements page	 30	0.7%
-Anachronia	Harvest produce from 25 animals on Anachronia farm.	Harvest produce from 25 animals on Anachronia farm.	42 Farming Farming , 45 Construction Construction 	 80	<0.1%
-Anachronia	Complete the ritual to activate a totem on Anachronia.	Complete the ritual to activate a totem on Anachronia.	N/A	 80	<0.1%
-Anachronia	Complete the Anachronia agility course in under 7 minutes.	Complete the Anachronia agility course in under 7 minutes.	85 Agility Agility 	 80	1.3%
-Anachronia	Complete all frog breeds.	Complete all frog breeds.	42 Farming Farming , 45 Construction Construction 	 80	<0.1%
-Anachronia	Purchase the Quick Traps upgrade from Irwinsson's Hunter Mark shop.	Purchase the quick traps upgrade from the Hunter Mark Shop.	50 hunter marks	 80	<0.1%
-Anachronia	Complete the quest: Osseous Rex.	Complete the Osseous Rex quest.	See quest page	 80	0.7%
-Anachronia	Clear an Overgrown idol on Anachronia.	Clear an overgrown idol on Anachronia.	81 Woodcutting Woodcutting 	 80	0.2%
-Anachronia	Defeat any of the Rex Matriarchs.	Defeat any of the Rex Matriarchs once.	N/A	 80	5.9%
-Anachronia	Defeat any of the Rex Matriarchs. (100 times)	Defeat any of the Rex Matriarchs 100 times.	N/A	 80	1.1%
-Anachronia	Complete the quest: Desperate Times.	Complete the Desperate Times quest.	See quest page	 80	1%
-Anachronia	Find all the hidden Zygomites on Anachronia.	Find all of the ancient zygomites on Anachronia. See the page for a route.	85 Agility Agility 	 80	<0.1%
-Anachronia	Equip Laniakea's spear.	Equip Laniakea's spear.	82 Attack Attack 	 80	1%
-Anachronia	Harvest an Arbuck herb.	Harvest an arbuck herb.	77 Farming Farming 	 80	3.1%
-Anachronia	Complete the advanced sections of the Anachronia agility course.	Complete the advanced sections of the Anachronia agility course.	70 Agility Agility 	 80	5%
-Anachronia	Equip a Dragon Mattock.	Equip a dragon mattock.	60 Archaeology Archaeology , (optional) 75 Hunter Hunter 	 80	<0.1%
-Anachronia	Take down each dinosaur in Big Game Hunter.	Take down each dinosaur in Big Game Hunter.	96 Hunter Hunter , 76 Slayer Slayer 	 80	<0.1%
-Anachronia	Get caught by each of the big game creatures once.	Get caught by each of the Big Game Hunter creatures once.	96 Hunter Hunter , 76 Slayer Slayer 	 80	<0.1%
-Anachronia	Complete a big game encounter without using movement abilities.	Complete a Big Game Hunter encounter without using movement abilities.	75 Hunter Hunter , 55 Slayer Slayer 	 80	0.2%
-Anachronia	Defeat Raksha, the Shadow Colossus.	Defeat Raksha, the Shadow Colossus once.	Completion of  Raksha, the Shadow Colossus	 80	0.3%
-Asgarnia: Falador	Reach 100% respect at the Artisans' Workshop.	Reach 100% respect at the Artisans' Workshop.	1 Smithing Smithing 	 80	22.3%
-Asgarnia: Falador	Complete the task set: Hard Falador.	Complete the Hard Falador achievements.	See Hard Falador achievements page	 80	<0.1%
-Asgarnia: Burthorpe	Defeat any God Wars Dungeon boss 100 times.	Defeat any God Wars Dungeon boss 100 times.	Partial completion of  Troll Stronghold	 80	12.4%
-Asgarnia: Burthorpe	Defeat any God Wars Dungeon boss 250 times.	Defeat any God Wars Dungeon boss 250 times.	Partial completion of  Troll Stronghold	 80	4.3%
-Asgarnia: Burthorpe	Defeat Commander Zilyana.	Defeat Commander Zilyana	70 Agility Agility
-Partial completion of  Troll Stronghold	 80	3%
-Asgarnia: Burthorpe	Defeat General Graardor.	Defeat General Graardor	70 Strength Strength
-Partial completion of  Troll Stronghold	 80	12.1%
-Asgarnia: Burthorpe	Defeat K'ril Tsutsaroth.	Defeat K'ril Tsutsaroth	70 Constitution Constitution
-Partial completion of  Troll Stronghold	 80	8.4%
-Asgarnia: Burthorpe	Defeat Kree'arra.	Defeat Kree'arra	70 Ranged Ranged
-Partial completion of  Troll Stronghold	 80	1.6%
-Asgarnia: Burthorpe	Defeat Nex.	Defeat Nex	70 Agility Agility , 70 Strength Strength , 70 Constitution Constitution , 70 Ranged Ranged
-Partial completion of  Troll Stronghold, completion of  The Dig Site, frozen key	 80	0.5%
-Asgarnia: Burthorpe	Defeat Kree'arra. (100 times)	Defeat Kree'arra 100 times.	70 Ranged Ranged
-Partial completion of  Troll Stronghold	 80	<0.1%
-Asgarnia: Burthorpe	Assemble any godsword from the God Wars Dungeon.	Assemble any godsword from the God Wars Dungeon.	80 Smithing Smithing  and one of 70 Agility Agility , 70 Strength Strength , 70 Constitution Constitution , or 70 Ranged Ranged 	 80	0.8%
-Asgarnia: Port Sarim	Defeat the Queen Black Dragon.	Defeat the Queen Black Dragon.	60 Summoning Summoning 	 80	2.7%
-Asgarnia: Port Sarim	Defeat the Queen Black Dragon. (100 times)	Defeat the Queen Black Dragon 100 times.	60 Summoning Summoning 	 80	<0.1%
-Asgarnia: Port Sarim	Bury some frost dragon bones.	Bury some frost dragon bones.	85 Dungeoneering Dungeoneering 	 80	0.6%
-Desert: General	Defeat the Kalphite King.	Defeat the Kalphite King.	N/A	 80	4.5%
-Desert: General	Defeat the Kalphite King. (100 times)	Defeat the Kalphite King 100 times.	N/A	 80	0.1%
-Desert: General	Equip a drygore weapon.	Equip a drygore weapon.	90 Attack Attack 	 80	1.4%
-Desert: General	Become an honorary druid at the Garden of Kharid.	Purchase the Druid/Druidess title for 50,000 Crux Eqal favour	50 Farming Farming 	 80	0.7%
-Desert: General	Deploy a dreadnip.	Deploy a dreadnip.	20 of a collection of quests (see Dominion Tower#Requirements), 450 Dominion Tower kills	 80	<0.1%
-Desert: General	Complete the task set: Hard Desert.	Complete the Hard Desert achievements.	See Hard Desert achievements page	 80	<0.1%
-Desert: General	Defeat Avaryss and Nymora.	Defeat the Twin Furies.	80 Ranged Ranged 	 80	1%
-Desert: General	Defeat Gregorovic.	Defeat Gregorivic.	80 Prayer Prayer 	 80	2.5%
-Desert: General	Defeat Vindicta and Gorvek.	Defeat Vindicta.	80 Attack Attack 	 80	11.2%
-Desert: General	Defeat Helwyr.	Defeat Helwyr.	80 Magic Magic 	 80	2.2%
-Desert: General	Defeat Avaryss and Nymora. (100 times)	Defeat the Twin Furies 100 times.	80 Ranged Ranged 	 80	<0.1%
-Desert: General	Defeat Gregorovic. (100 times)	Defeat Gregorivic 100 times.	80 Prayer Prayer 	 80	<0.1%
-Desert: General	Defeat Vindicta and Gorvek. (100 times)	Defeat Vindicta 100 times.	80 Attack Attack 	 80	1.6%
-Desert: General	Defeat Helwyr. (100 times)	Defeat Helwyr 100 times.	80 Magic Magic 	 80	0.1%
-Desert: General	Equip a Dragon Rider lance.	Equip a Dragon Rider lance.	85 Attack Attack 	 80	4%
-Desert: General	Equip a wand or orb of the Cywir elders.	Equip a wand or orb of the Cywir elders.	85 Magic Magic 	 80	0.3%
-Desert: General	Equip a shadow glaive.	Equip a shadow glaive.	85 Ranged Ranged 	 80	<0.1%
-Desert: General	Equip a blade of Nymora or Avaryss.	Equip a blade of Nymora or Avaryss.	85 Attack Attack 	 80	0.1%
-Desert: Menaphos	Slay a combination of 500 corrupted or devourer creatures.	Slay a combination of 500 corrupted creatures or soul devourers.	88 Slayer Slayer
-Completion of  Icthlarin's Little Helper	 80	0.1%
-Desert: General	Defeat the Magister.	Defeat the Magister.	115 Slayer Slayer
-Key to the Crossing	 80	<0.1%
-Desert: General	Defeat the Magister. (50 times)	Defeat the Magister 50 times.	115 Slayer Slayer
-Key to the Crossing	 80	<0.1%
-Desert: Menaphos	Find an Off-hand khopesh of the Kharidian in Shifting Tombs.	Find an off-hand khopesh of the Kharidian in Shifting Tombs.	At least one of 50 Dungeoneering Dungeoneering , 50 Agility Agility , 50 Thieving Thieving , or 50 Construction Construction 	 80	<0.1%
-Desert: General	Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.	Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.	81 Thieving Thieving
-Partial completion of  Icthlarin's Little Helper	 80	1.4%
-Desert: General	Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.	Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.	91 Thieving Thieving
-Partial completion of  Icthlarin's Little Helper	 80	1.3%
-Desert: Menaphos	Complete the quest: Beneath Scabaras' Sands.	Complete Beneath Scabaras' Sands.	See quest page	 80	<0.1%
-Desert: General	Kill a desert strykewyrm wearing a Full Slayer Helm and wielding an ancient staff.	Kill a desert strykewyrm wearing a full Slayer helm and wielding an ancient staff.	77 Slayer Slayer , 50 Magic Magic , 20 Defence Defence , 55 Crafting Crafting
-Completion of  Desert Treasure and  Smoking Kills, 400 slayer points to unlock crafting slayer helmets. See also Staff on Stryke.	 80	<0.1%
-Desert: General	Defeat Telos, the Warden.	Defeat Telos, the Warden.	80 Attack Attack , 80 Prayer Prayer , 80 Magic Magic , 80 Ranged Ranged 	 80	0.6%
-Fremennik: Lunar Isles	Cast Fertile Soil.	Cast Fertile Soil.	83 Magic Magic
-Completion of  Lunar Diplomacy unless tier 6 reached	 80	0.1%
-Fremennik: Mainland	Build a Gilded Altar.	Build a gilded altar in your player-owned house's chapel.	75 Construction Construction 	 80	0.2%
-Fremennik: Mainland	Trap a Sabre-Toothed Kyatt.	Trap a sabre-toothed kyatt.	55 Hunter Hunter 	 80	1.8%
-Fremennik: Mainland	Defeat all the Dagannoth Kings without leaving a solo boss instance.	Defeat all the Dagannoth Kings without leaving a solo boss instance.	N/A	 80	0.2%
-Fremennik: Mainland	Equip a Berserker, Warrior, Seers, or Archers Ring.	Equip a Berserker, Warrior, Seers, or Archers Ring.	N/A	 80	1.5%
-Fremennik: Mainland	Use the Special Attack of a Dragon Axe.	Use the special attack of a dragon hatchet.	60 Attack Attack 	 80	0.5%
-Fremennik: Mainland	Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.	Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.	25 Defence Defence
-Partial completion of  The Fremennik Isles	 80	0.1%
-Fremennik: Mainland	Equip a full set of Skeletal, Spined, or Rockshell armour.	Equip a full skeletal, spined, or rock-shell armour set.	50 Defence Defence
-Completion of  The Fremennik Trials	 80	0.1%
-Fremennik: Mainland	Collect Miscellania Resources at Full Approval.	Collect from Managing Miscellania with a 100% approval rating.	Completion of  Throne of Miscellania	 80	0.2%
-Fremennik: Mainland	Travel to the island of Ungael.	Travel to the island of Ungael.	Partial completion of  Ancient Awakening	 80	<0.1%
-Fremennik: Mainland	Adopt a baby yak.	Obtain an unchecked/baby Fremennik yak.	71 Farming Farming
-Partial completion of  The Fremennik Isles	 80	<0.1%
-Fremennik: Mainland	Catch 50 Azure Skillchompas.	Catch 50 Azure Skillchompas.	68 Hunter Hunter 	 80	0.3%
-Fremennik: Mainland	Mine 10 Banite Ore north of Rellekka.	Mine 10 Banite ore in the arctic (azure) habitat mine.	80 Mining Mining 	 80	22.3%
-Fremennik: Mainland	Smith a piece of Bane equipment to +4 in Rellekka.	Upgrade a piece of Bane equipment to +4 in Rellekka.	80 Smithing Smithing
-Completion of  The Fremennik Trials	 80	0.7%
-Fremennik: Mainland	Use a Crystal triskelion key to obtain some treasures.	Use a Crystal triskelion to obtain some treasures.	N/A	 80	3.4%
-Fremennik: Mainland	Create a Catherby Teleport Tablet.	Create a Catherby Teleport Tablet.	87 Magic Magic , 67 Construction Construction
-Completion of  Lunar Diplomacy unless tier 6 reached	 80	<0.1%
-Fremennik: Mainland	Gather a seed from an Aquanite using Seedicide.	Gather a seed from an aquanite using Seedicide.	78 Slayer Slayer
-2,200 renown, 10,000 beans, 360 thaler, or tier 4 reached	 80	1%
-Fremennik: Mainland	Complete the task set: Hard Fremennik.	Complete the Hard Fremennik achievements.	See Hard Fremennik achievements page	 80	<0.1%
-Global	Reach at least level 50 in all non-elite skills.	Reach at least level 50 in all non-elite skills.	All skills except Invention at level 50	 80	1.3%
-Global	Reach combat level 100.	Reach combat level 100.	100 Combat Combat	 80	16.6%
-Global	Reach total level 1000.	Reach total level 1000. This task is currently bugged and may complete before you have reached 1000 total levels	1000 Skills Total level	 80	48.4%
-Global	Mine any ore 1000 times.	Mine any ore 1000 times.	N/A	 80	67%
-Global	Chop any tree 1000 times.	Chop any tree 1000 times.	N/A	 80	9.7%
-Global	Burn any logs 1000 times.	Burn any logs 1000 times.	N/A	 80	2.3%
-Global	Catch any fish 1000 times.	Catch any fish 1000 times.	N/A	 80	9%
-Global	Harvest any memory from a wisp 1000 times.	Harvest any memory from a wisp 1000 times.	N/A	 80	11.5%
-Global	Pickpocket anyone 1000 times.	Pickpocket anyone 1000 times.	N/A	 80	8.9%
-Global	Unlock all of the Lodestones.	Unlock all of the Lodestones.	N/A	 80	<0.1%
-Global	Make 1,000 potions of any kind.	Make 1,000 potions of any kind.	N/A	 80	0.5%
-Global	Clean 1,000 of any herb.	Clean 1,000 of any herb.	N/A	 80	8.4%
-Global	Complete 50 laps of any Agility course.	Complete 50 laps of any Agility course.	N/A	 80	13.3%
-Global	Complete 100 laps of any Agility course.	Complete 100 laps of any Agility course.	N/A	 80	3.7%
-Global	Smith 50 of any metal weapon or armour piece.	Smith 50 of any metal weapon or armour piece.	N/A	 80	52.5%
-Global	Smith 100 of any metal weapon or armour piece.	Smith 100 of any metal weapon or armour piece.	N/A	 80	35.4%
-Global	Cook 1,000 fish.	Cook 1,000 fish.	N/A	 80	5.3%
-Global	Catch 1,000 Hunter creatures.	Catch 1,000 Hunter creatures.	N/A	 80	0.9%
-Global	Complete 15 Slayer tasks.	Complete 15 Slayer tasks.	N/A	 80	8.1%
-Global	Complete 150 Easy clue scrolls.	Complete 150 Easy clue scrolls.	N/A	 80	0.1%
-Global	Collect 50 unique items for the General clue rewards collection log.	Collect 50 unique items for the General clue rewards collection log.	N/A	 80	<0.1%
-Global	Craft 10,000 runes.	Craft 10,000 runes.	N/A	 80	<0.1%
-Global	Craft 20,000 runes.	Craft 20,000 runes.	N/A	 80	<0.1%
-Global	Obtain 75 Quest Points.	Obtain 75 quest points.	75 Quest points Quest points	 80	21.1%
-Global	Obtain 100 Quest Points.	Obtain 100 quest points.	100 Quest points Quest points	 80	6%
-Global	Complete 150 Medium clue scrolls.	Complete 150 Medium clue scrolls.	N/A	 80	0.1%
-Global	Complete 75 Hard clue scrolls.	Complete 75 Hard clue scrolls.	N/A	 80	0.8%
-Global	Complete 150 Hard clue scrolls.	Complete 150 Hard clue scrolls.	N/A	 80	0.1%
-Global	Collect 25 unique items for the Easy clue rewards collection log.	Collect 25 unique items for the Easy clue rewards collection log.	N/A	 80	7.1%
-Global	Collect 50 unique items for the Easy clue rewards collection log.	Collect 50 unique items for the Easy clue rewards collection log.	N/A	 80	1%
-Global	Collect 25 unique items for the Medium clue rewards collection log.	Collect 25 unique items for the Medium clue rewards collection log.	N/A	 80	10.1%
-Global	Collect 50 unique items for the Medium clue rewards collection log.	Collect 50 unique items for the Medium clue rewards collection log.	N/A	 80	3.7%
-Global	Collect 10 unique items for the Hard clue rewards collection log.	Collect 10 unique items for the Hard clue rewards collection log.	N/A	 80	17.1%
-Global	Collect 25 unique items for the Hard clue rewards collection log.	Collect 25 unique items for the Hard clue rewards collection log.	N/A	 80	12.2%
-Global	Equip any Dragon mask.	Equip any Dragon mask.	N/A	 80	11.3%
-Global	Make any Perfect Juju Potion.	Make any Perfect Juju Potion.	75 Herblore Herblore 	 80	<0.1%
-Global	Make 15 Antifire Potions.	Make 15 Antifire Potions.	69 Herblore Herblore 	 80	0.6%
-Global	Clean 50 Grimy Cadantine.	Clean 50 Grimy Cadantine.	65 Herblore Herblore 	 80	0.6%
-Global	Clean 100 Grimy Lantadyme.	Clean 100 Grimy Lantadyme.	67 Herblore Herblore 	 80	0.9%
-Global	Clean 100 Dwarf Weed.	Clean 100 Dwarf Weed.	70 Herblore Herblore 	 80	0.5%
-Global	Clean 100 Arbuck.	Clean 100 Arbuck.	77 Herblore Herblore , 77 Farming Farming 	 80	0.1%
-Global	Equip a Yew shortbow.	Equip a Yew shortbow.	40 Ranged Ranged 	 80	10%
-Global	Equip a Magic shortbow.	Equip a Magic shortbow.	50 Ranged Ranged 	 80	5.3%
-Global	Fletch some Broad Arrows or Bolts.	Fletch some Broad Arrows or Bolts.	52 Fletching Fletching
-Completion of  Smoking Kills, 300 slayer points	 80	1%
-Global	Fletch 100 Yew shortbows (unstrung).	Fletch 100 Yew shortbows (unstrung).	65 Fletching Fletching 	 80	2.3%
-Global	Fletch 100 Yew stocks.	Fletch 100 Yew stocks.	69 Fletching Fletching 	 80	1.9%
-Global	Fletch a Rune Crossbow.	Fletch a Rune Crossbow.	69 Fletching Fletching 	 80	2.2%
-Global	Fletch 35 or more arrow shafts from a single log.	Fletch 35 or more Arrow shafts from a single log.	60 Fletching Fletching
-Yew logs or higher	 80	4.7%
-Global	Fletch 500 Adamant arrows.	Fletch 500 Adamant arrows.	60 Fletching Fletching 	 80	9.6%
-Global	Fletch 750 Rune arrows.	Fletch 750 Rune arrows.	75 Fletching Fletching 	 80	4.9%
-Global	Fletch 75 Onyx bolts.	Fletch 75 Onyx bolts.	73 Fletching Fletching 	 80	0.6%
-Global	Equip a Rune Ceremonial Sword.	Equip a Rune ceremonial sword.	N/A	 80	0.1%
-Global	Equip a full set of the Blacksmith's outfit.	Equip a full set of the Blacksmith's outfit.	Total of 250% Artisans' Workshop respect, unless gained from ceremonial swords	 80	2.1%
-Global	Power up the Artisan's Workshop with a Luminite Injector.	Power up the Artisan's Workshop with a Luminite Injector.	100% Artisans' Workshop respect	 80	2.6%
-Global	Mine 50 Orichalcite Ore.	Mine 50 Orichalcite Ore.	60 Mining Mining 	 80	55%
-Global	Mine 50 Drakolith.	Mine 50 Drakolith.	60 Mining Mining 	 80	41.4%
-Global	Mine 60 Necrite Ore.	Mine 60 Necrite Ore.	70 Mining Mining 	 80	37.6%
-Global	Mine 60 Phasmatite.	Mine 60 Phasmatite.	70 Mining Mining 	 80	33%
-Global	Harvest 20 Grimy Kwuarm.	Harvest 20 Grimy Kwuarm.	56 Farming Farming 	 80	7.5%
-Global	Catch 100 Shark.	Catch 100 Shark.	76 Fishing Fishing 	 80	1.5%
-Global	Catch 100 Green Blubber Jellyfish.	Catch 100 Green Blubber Jellyfish.	68 Fishing Fishing 	 80	2.2%
-Global	Catch a Spirit Impling.	Catch a Spirit Impling.	54 Hunter Hunter 	 80	1.9%
-Global	Equip a Slayer helmet.	Equip a Slayer helmet.	55 Crafting Crafting , 35 Slayer Slayer
-Completion of  Smoking Kills, 400 slayer points Note: While it does not say it explicitly, this task requires the Full slayer helmet and therefore has an implicit requirement of 77 Slayer Slayer  for Desert Strykewyrms	 80	0.2%
-Global	Complete a Soul Reaper task.	Complete a Soul Reaper task.	N/A	 80	20.6%
-Global	Complete 5 Soul Reaper tasks.	Complete 5 Soul Reaper tasks.	N/A	 80	1.1%
-Global	Equip a full set of Orikalkum armour.	Equip a full set of Orikalkum armour.	60 Smithing Smithing , 60 Defence Defence 	 80	21.3%
-Global	Equip a full set of Necronium armour.	Equip a full set of Necronium armour.	70 Smithing Smithing , 70 Defence Defence 	 80	11.2%
-Global	Equip a full set of Black Dragonhide armour.	Equip a full set of Black Dragonhide armour.	60 Defence Defence
-60 Crafting Crafting  unless getting the pieces as a drop	 80	4.1%
-Global	Equip a full set of Royal Dragonhide armour.	Equip a full set of Royal Dragonhide armour.	65 Defence Defence , 65 Crafting Crafting 	 80	2.1%
-Global	Cast a Wave spell.	Cast a Wave spell.	62 Magic Magic 	 80	11.1%
-Global	Burn 75 Yew logs.	Burn 75 Yew logs.	60 Firemaking Firemaking 	 80	3.4%
-Global	Unlock the Ring of Quests from May's Quest Caravan.	Unlock the Ring of Quests from May's Quest Caravan.	75 Quest points Quest points	 80	5.4%
-Global	Complete 250 clues of any tier.	Complete 250 clues of any tier.	N/A	 80	0.1%
-Global	Complete 500 clues of any tier.	Complete 500 clues of any tier.	N/A	 80	<0.1%
-Global	Complete an Elite clue scroll.	Complete an Elite clue scroll.	N/A	 80	16.4%
-Global	Complete 25 Elite clue scrolls.	Complete 25 Elite clue scrolls.	N/A	 80	1%
-Global	Complete a Master clue scroll.	Complete a Master clue scroll.	N/A	 80	19.9%
-Global	Collect 5 unique items for the Elite clue rewards collection log.	Collect 5 unique items for the Elite clue rewards collection log.	N/A	 80	12%
-Global	Collect 10 unique items for the Elite clue rewards collection log.	Collect 10 unique items for the Elite clue rewards collection log.	N/A	 80	8.7%
-Global	Collect 20 unique items for the Elite clue rewards collection log.	Collect 20 unique items for the Elite clue rewards collection log.	N/A	 80	5.6%
-Global	Collect 5 unique items for the Master clue rewards collection log.	Collect 5 unique items for the Master clue rewards collection log.	N/A	 80	15.1%
-Global	Catch a Manta ray.	Catch a raw manta ray.	81 Fishing Fishing  (or 68 Fishing Fishing  via swarm fishing)	 80	1.6%
-Global	Reach level 70 in any skill.	Reach level 70 in any skill.	Any skill at level 70	 80	62.6%
-Global	Reach level 80 in any skill.	Reach level 80 in any skill.	Any skill at level 80	 80	45.8%
-Global	Reach at least level 40 in all non-elite skills.	Reach at least level 40 in all non-elite skills.	All skills except Invention at level 40	 80	3.6%
-Global	Reach at least level 60 in all non-elite skills.	Reach at least level 60 in all non-elite skills.	All skills except Invention at level 60	 80	0.2%
-Global	Reach at least level 70 in all non-elite skills.	Reach at least level 70 in all non-elite skills.	All skills except Invention at level 70	 80	<0.1%
-Kandarin: Ardougne	Throw coins into the deep sea whirlpool.	Throw some gold coins into the Whirlpool at the Deep Sea Fishing platform.	68 Fishing Fishing 	 80	0.7%
-Kandarin: Ardougne	Solve the Archaeology mystery: Leap of Faith.	Solve the Leap of Faith Archaeology mystery.	70 Archaeology Archaeology 	 80	1%
-Kandarin: Ardougne	Collect all breeds of chinchompa at the Player Owned Farm.	Breed all types of Chinchompas.	54 Farming Farming , 20 Construction Construction
-97 Hunter Hunter  to catch crystal chinchompas.	 80	<0.1%
-Kandarin: Ardougne	Equip one piece of the Fishing outfit.	Equip one piece of the Fishing outfit.	140 fishing tokens	 80	0.1%
-Kandarin: Ardougne	Defeat the Penance Queen.	Defeat the Penance Queen.	N/A	 80	<0.1%
-Kandarin: Ardougne	Pickpocket a Hero.	Pickpocket a Hero.	80 Thieving Thieving 	 80	25.9%
-Kandarin: Ardougne	Catch 50 Red Chinchompas in Kandarin.	Catch 50 carnivorous chinchompas in Kandarin.	63 Hunter Hunter 	 80	0.4%
-Kandarin: Feldip Hills	Equip an Ogre Expert hat.	Equip an Ogre Expert hat.	1,000 chompy bird kills	 80	<0.1%
-Global	Catch a Monkfish.	Catch a raw monkfish.	62 Fishing Fishing
-Completion of  Swan Song or from swarm fishing	 80	2.2%
-Global	Recover all data for one memory-storage bot in the Hall of Memories.	Recover all data for memory-storage bot (Aagi) in the Hall of Memories.	70 Divination Divination 	 80	2.7%
-Kandarin: Seers Village	Use the Piety Prayer.	Use the Piety Prayer.	70 Prayer Prayer , 70 Defence Defence
-Completion of Knight Waves training ground	 80	0.5%
-Kandarin: Ardougne	Complete the task set: Hard Ardougne.	Complete the Hard Ardougne Diary.	See Hard Ardougne achievements page	 80	<0.1%
-Karamja	Use the stepping stone across the river in Shilo village.	Use the Stepping Stones Agility Shortcut in Shilo Village.	74 Agility Agility
-Completion of  Shilo Village	 80	0.4%
-Karamja	Equip a full set of Obsidian armour.	Equip a full set of Obsidian armour.	60 Defence Defence
-Completion of  The Brink of Extinction, 80 Smithing Smithing 	 80	0.1%
-Karamja	Equip a Red Topaz Machete.	Equip a Red Topaz Machete.	N/A	 80	0.4%
-Karamja	Find a Gout Tuber.	Find a Gout Tuber.	10 Woodcutting Woodcutting
-Completion of  Jungle Potion	 80	0.1%
-Karamja	Defeat TzTok-Jad.	Defeat TzTok-Jad once.	N/A	 80	7.3%
-Karamja	Defeat TzTok-Jad.	Defeat TzTok-Jad 25 times.	N/A	 80	0.1%
-Karamja	Use your fire cape on TzTok-Jad before defeating them.	Use your fire cape on TzTok-Jad before defeating them.	N/A	 80	0.4%
-Karamja	Equip a Fire Cape.	Equip a Fire Cape.	N/A	 80	7.2%
-Karamja	Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.	Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.	60 Defence Defence  and one of 60 Attack Attack , 60 Strength Strength , 60 Magic Magic , or 60 Ranged Ranged
-Completion of  The Brink of Extinction	 80	<0.1%
-Karamja	Repair the fairy ring inside the Kharazi jungle.	Repair the fairy ring inside the Kharazi jungle.	Partial completion of  Legends' Quest, 5 bittercap mushrooms	 80	<0.1%
-Karamja	Access the Gemstone cavern.	Access the Gemstone cavern.	Hard Karamja achievements and either an uncut dragonstone or a gemstone dragon Slayer task (requires 95 Slayer Slayer )	 80	0.1%
-Karamja	Catch a Draconic jadinko at Herblore Habitat.	Catch a Draconic jadinko at Herblore Habitat.	80 Hunter Hunter 	 80	<0.1%
-Karamja	Craft a Bolas.	Craft a Bolas.	87 Fletching Fletching , 80 Slayer Slayer 	 80	0.1%
-Karamja	Complete the task set: Hard Karamja.	Complete the hard Karamja Diary.	See Hard Karamja achievements page	 80	<0.1%
-Karamja	Collect 60 Agility Arena tickets from the Brimhaven Agility Arena.	Receive 60 Agility Arena Tickets With No Mistakes.	N/A	 80	0.7%
-Karamja	Defeat TzTok-Jad in less than 45:00.	Defeat TzTok-Jad in less than 45:00.	N/A	 80	6.9%
-Karamja	Complete the Fight Kiln.	Complete the Fight Kiln.	Completion of  The Elder Kiln, hand in a fire cape	 80	0.9%
-Karamja	Equip a TokHaar-Kal-Ket.	Equip a TokHaar-Kal-Ket.	Completion of  The Elder Kiln, hand in a fire cape (once)	 80	0.7%
-Karamja	Equip a TokHaar-Kal-Xil.	Equip a TokHaar-Kal-Xil.	Completion of  The Elder Kiln, hand in a fire cape (once)	 80	<0.1%
-Karamja	Equip a TokHaar-Kal-Mej.	Equip a TokHaar-Kal-Mej.	Completion of  The Elder Kiln, hand in a fire cape (once)	 80	<0.1%
-Karamja	Equip a TokHaar-Kal-Mor.	Equip a TokHaar-Kal-Mor.	Completion of  The Elder Kiln, hand in a fire cape (once)	 80	0.1%
-Karamja	Complete the Fight Kiln and collect an uncut onyx.	Complete the Fight Kiln and collect an uncut onyx.	Completion of  The Elder Kiln, hand in a fire cape (once)	 80	0.1%
-Karamja	Complete all TzTok-Jad combat achievements.	Complete all TzTok-Jad combat achievements.	See TzTok-Jad achievements page	 80	<0.1%
-Misthalin: Draynor Village	Siphon from a death esswraith in the RuneSpan.	Siphon from a death esswraith in the RuneSpan.	66 Runecrafting Runecrafting 	 80	3.4%
-Misthalin: Draynor Village	Obtain the Massive Pouch from the RuneSpan.	Obtain the massive pouch from the RuneSpan.	90 Runecrafting Runecrafting
-1,000 Runespan points	 80	<0.1%
-Misthalin: Draynor Village	Equip the full Master Runecrafter skilling outfit.	Equip the full master runecrafter robes set.	50 Runecrafting Runecrafting
-60,000 Runecrafting guild tokens, 16,000 Runespan points, or 2,000 thaler	 80	<0.1%
-Misthalin: Edgeville	Complete the task set: Hard Varrock.	Complete all of the Hard Varrock achievements and claim rewards from Vannaka in Edgeville.	See Hard Varrock achievements page	 80	<0.1%
-Misthalin: Edgeville	Make a waka canoe near Edgeville.	Make a waka canoe near Edgeville.	57 Woodcutting Woodcutting 	 80	12.6%
-Misthalin: Edgeville	Chop down the Edgeville elder tree.	Chop down the Edgeville elder tree.	90 Woodcutting Woodcutting 	 80	0.1%
-Misthalin: Fort Forinthry	Upgrade the workshop in Fort Forinthry to Tier 3.	Upgrade the workshop in Fort Forinthry to tier 3.	75 Construction Construction
-Completion of  New Foundations	 80	0.1%
-Misthalin: Lumbridge	Enter Zanaris via Lumbridge Swamp.	Enter Zanaris via Lumbridge Swamp.	Partial completion of  Lost City	 80	16.8%
-Misthalin: Lumbridge	Complete the task set: Hard Lumbridge.	Complete all Hard Tasks in Lumbridge and claim rewards from Ned in Draynor Village.	See Hard Lumbridge achievements page	 80	0.6%
-Misthalin: Lumbridge	Unlock the Bladed Dive ability from Shattered Worlds.	Unlock the Bladed Dive ability from Shattered Worlds.	63,000,000 shattered anima	 80	0.1%
-Misthalin: Lumbridge	Smith a mithril platebody on the anvil in the jailhouse sewers.	Smith a mithril platebody on the anvil in the jailhouse sewers.	30 Smithing Smithing 	 80	37.4%
-Misthalin: Lumbridge	Fully grow a magic tree in Lumbridge.	Fully grow a magic tree in Lumbridge.	75 Farming Farming 	 80	0.6%
-Misthalin: City of Um	Defeat Hermod, the Spirit of War.	Defeat Hermod, the Spirit of War once.	Completion of  The Spirit of War	 80	<0.1%
-Misthalin: City of Um	Defeat Hermod, the Spirit of War.	Defeat Hermod, the Spirit of War 100 times.	Completion of  The Spirit of War	 80	<0.1%
-Misthalin: City of Um	Rest whilst listening to the Dead Beats in the City of Um.	Rest whilst listening to the Dead Beats in the City of Um.	Completion of  That Old Black Magic	 80	<0.1%
-Misthalin: City of Um	Smelt a necronium bar at the smithy in the City of Um.	Smelt a necronium bar at the smithy in the City of Um.	70 Smithing Smithing
-Partial completion of  Necromancy!	 80	4%
-Misthalin: City of Um	Create a passing bracelet, performing each step in the City of Um.	Create a passing bracelet, performing each step in the City of Um.	60 Necromancy Necromancy  for bar, 79 Crafting Crafting , 68 Magic Magic
-Ensouled bar, moonstone, runes for Lvl-5 Enchant. The moonstone is most easily obtained from completing  Housing of Parliament, which requires 54 Necromancy Necromancy .	 80	0.1%
-Misthalin: City of Um	Catch a ghostly impling while wearing a full set of ghostly robes.	Catch a ghostly impling while wearing a full set of ghostly robes.	68 Hunter Hunter
-Completion of  The Curse of Zaros (miniquest)	 80	<0.1%
-Misthalin: City of Um	Upgrade a set of Death Skull equipment to tier 70.	Upgrade a set of Death Skull equipment to tier 70.	70 Necromancy Necromancy
-Completion of  The Spirit of War. See also Kili's Knowledge V.	 80	2.1%
-Misthalin: City of Um	Complete a Powerful Communion ritual.	Complete a powerful communion ritual.	90 Necromancy Necromancy 	 80	0.2%
-Misthalin: City of Um	Conjure an undead army at the City of Um ritual site.	Conjure an undead army at the City of Um ritual site.	99 Necromancy Necromancy
-Conjure Undead Army unlocked in the Well of Souls	 80	0.2%
-Misthalin: Varrock	Obtain a new set of Family Crest gauntlets from Dimintheis.	Obtain a new set of Family Crest gauntlets from Dimintheis.	Completion of  Family Crest	 80	0.3%
-Misthalin: Varrock	Talk to Romily Weaklax and give him a wild pie.	Talk to Romily Weaklax and give him a wild pie.	85 Cooking Cooking  to make it from scratch, or 50 Hunter Hunter  to get it as a rare drop from eclectic implings	 80	<0.1%
-Misthalin: Varrock	Harness the power of three relics at once.	Activate 3 Archaeology relics at once	25 Archaeology Archaeology
-A Ring of Luck to unlock the Hand of Glory relic.	 80	1.1%
-Misthalin: Varrock	Mine 50 Dark Animica from the Empty Throne Room.	Mine 50 dark animica from the Empty Throne Room mine.	90 Mining Mining 	 80	5%
-Misthalin: Varrock	Defeat Kerapac, the bound.	Defeat Kerapac, the bound once.	N/A	 80	1.7%
-Misthalin: Varrock	Defeat the Arch-Glacor.	Defeat the Arch-Glacor.	N/A	 80	11.7%
-Misthalin: City of Um	Defeat Nakatra, Devourer Eternal.	Defeat Nakatra, Devourer Eternal.	Completion of  Necromancy!, completion of  Soul Searching	 80	0.1%
-Misthalin: City of Um	Cleanse the Gate of Elidinis.	Cleanse the Gate of Elidinis.	Completion of  Ode of the Devourer (or  Soul Searching if tier 4 reached)	 80	10%
-Misthalin: City of Um	Complete the task set: Hard Underworld.	Complete the Hard Underworld achievements.	See Hard Underworld achievements page	 80	<0.1%
-Morytania	Take a hard companion through a hard route of Temple Trekking.	Take a hard companion through a hard route of Temple Trekking.	Completion of  In Aid of the Myreque	 80	0.1%
-Morytania	Mine 30 Phasmatite.	Mine 30 phasmatite near Port Phasmatys.	70 Mining Mining 	 80	29.7%
-Morytania	Defeat 25 Gargoyles.	Defeat 25 Gargoyles.	75 Slayer Slayer 	 80	2.4%
-Morytania	Defeat 35 Aberrant Spectres.	Defeat 35 Aberrant Spectres.	60 Slayer Slayer 	 80	7.1%
-Morytania	Equip a full set of Ahrim's equipment, including the staff.	Equip a full set of Ahrim's equipment, including the staff.	70 Defence Defence , 70 Magic Magic 	 80	<0.1%
-Morytania	Equip a full set of Dharok's equipment, including the greataxe.	Equip a full set of Dharok's equipment, including the greataxe.	70 Defence Defence , 70 Attack Attack 	 80	<0.1%
-Morytania	Equip a full set of Guthan's equipment, including the warspear.	Equip a full set of Guthan's equipment, including the Guthan's warspear.	70 Defence Defence , 70 Attack Attack 	 80	<0.1%
-Morytania	Equip a full set of Torag's equipment, including the hammer.	Equip a full set of Torag's equipment, including the hammer.	70 Defence Defence , 70 Attack Attack 	 80	<0.1%
-Morytania	Equip a full set of Verac's equipment, including the flail.	Equip a full set of Verac's equipment, including the flail.	70 Defence Defence , 70 Attack Attack 	 80	<0.1%
-Morytania	Equip a full set of Karil's equipment, including the 2h crossbow.	Equip a full set of Karil's equipment, including the 2h crossbow.	70 Defence Defence , 70 Ranged Ranged 	 80	<0.1%
-Morytania	Complete the quest: The Branches of Darkmeyer.	Complete The Branches of Darkmeyer.	See quest page	 80	0.1%
-Morytania	Burn 20 Blisterwood logs.	Burn 20 Blisterwood logs.	76 Woodcutting Woodcutting , 76 Firemaking Firemaking
-Partial completion of  The Branches of Darkmeyer	 80	<0.1%
-Morytania	Fully level up all Temple Trekking companions.	Fully level up all Temple Trekking companions.	Completion of  In Aid of the Myreque	 80	<0.1%
-Morytania	Catch 5 sharks in Burgh de Rott.	Catch 5 sharks in Burgh de Rott.	76 Fishing Fishing
-Partial completion of  In Aid of the Myreque	 80	<0.1%
-Morytania	Complete the task set: Hard Morytania.	Complete the hard Morytania Diary.	See Hard Morytania achievements page	 80	<0.1%
-Elven Lands: Tirranwn	Plant a mushroom seed in the mushroom patch in Isafdar.	Plant a mushroom seed in the mushroom patch in Isafdar.	53 Farming Farming
-Completion of the medium Tirannwn achievements.	 80	<0.1%
-Elven Lands: Tirranwn	Defeat 30 Cadarn warriors in Prifddinas.	Defeat 30 Cadarn warriors in Prifddinas.	N/A	 80	4.4%
-Elven Lands: Tirranwn	Harvest some harmony moss from a harmony pillar.	Harvest some harmony moss from a harmony pillar.	75 Farming Farming 	 80	1%
-Elven Lands: Tirranwn	Complete the Hefin Agility course with a light creature familiar summoned.	Complete the Hefin Agility course with a light creature familiar summoned.	77 Agility Agility , 88 Summoning Summoning , 71 Divination Divination 	 80	<0.1%
-Elven Lands: Tirranwn	Cleanse the Corrupted Seren stone with 5 cleansing crystals.	Cleanse the Corrupted Seren stone with 5 cleansing crystals.	75 Prayer Prayer 	 80	3.9%
-Elven Lands: Tirranwn	Complete 10 laps of the Hefin agility course.	Complete 10 laps of the Hefin agility course.	77 Agility Agility 	 80	4.4%
-Elven Lands: Tirranwn	Harvest 100 Incandescent energy from Incandescent Wisps.	Harvest 100 Incandescent energy from Incandescent Wisps.	95 Divination Divination 	 80	0.1%
-Elven Lands: Tirranwn	Equip a Dark bow.	Equip a Dark bow.	90 Slayer Slayer , 70 Ranged Ranged , 70 Defence Defence 	 80	0.1%
-Elven Lands: Tirranwn	Defeat 30 Dark beasts in Tirannwn.	Defeat 30 Dark beasts in Tirannwn.	90 Slayer Slayer 	 80	0.8%
-Elven Lands: Tirranwn	Equip a Crystal halberd.	Equip a Crystal halberd.	50 Agility Agility , 70 Attack Attack 	 80	6.4%
-Elven Lands: Tirranwn	Equip a Crystal shield.	Equip a Crystal shield.	50 Agility Agility , 70 Defence Defence 	 80	1.4%
-Elven Lands: Tirranwn	Equip a Crystal bow.	Equip a Crystal bow.	50 Agility Agility , 70 Ranged Ranged 	 80	1%
-Elven Lands: Tirranwn	Catch 25 Grenwalls in Isafdar.	Catch 25 Grenwalls in Isafdar.	77 Hunter Hunter 	 80	<0.1%
-Elven Lands: Tirranwn	Defeat 10 Elf warriors in Lletya.	Defeat 10 Elf warriors in Lletya.	N/A	 80	14.1%
-Elven Lands: Tirranwn	Chop 50 Magic logs in Tirannwn.	Chop 50 Magic logs in Tirannwn.	80 Woodcutting Woodcutting 	 80	0.6%
-Elven Lands: Tirranwn	Open the crystal chest in Prifddinas 10 times.	Open the crystal chest in Prifddinas 10 times.	N/A	 80	4.1%
-Elven Lands: Tirranwn	Charge a piece of Dragonstone jewellery using the Tears of Seren.	Charge a piece of Dragonstone jewellery using the Tears of Seren.	Completion of  Legends' Quest	 80	<0.1%
-Elven Lands: Tirranwn	Complete the task set: Hard Tirannwn.	Complete the hard Tirannwn Diary.	See Hard Tirannwn achievements page	 80	<0.1%
-Wilderness: General	Defeat the King Black Dragon while wearing black dragonhide in six equipment slots. Can only be completed in a solo instance.	Defeat the King Black Dragon while wearing black dragonhide in six equipment slots.	60 Defence Defence 	 80	1.6%
-Wilderness: General	Defeat one of each revenant creature in the Forinthry dungeon.	Defeat one of each revenant creature in the Forinthry dungeon.	N/A	 80	2.1%
-Wilderness: General	Equip a Statius's warhammer.	Equip a Statius's warhammer.	78 Attack Attack 	 80	<0.1%
-Wilderness: General	Catch 25 Black Salamanders.	Catch 25 Black Salamanders.	67 Hunter Hunter 	 80	0.4%
-Wilderness: Daemonheim	Restore an artefact from the Daemonheim digsite.	Restore an artefact from the Daemonheim digsite.	73 Archaeology Archaeology 	 80	0.7%
-Wilderness: General	Defeat the Corporeal Beast.	Defeat the Corporeal Beast once.	Completion of  Summer's End	 80	<0.1%
-Wilderness: General	Defeat the Corporeal Beast.	Defeat the Corporeal Beast 100 times.	Completion of  Summer's End	 80	<0.1%
-Wilderness: Daemonheim	Defeat the Skeletal Trio.	Defeat the Skeletal Trio.	71 Dungeoneering Dungeoneering 	 80	0.4%
-Wilderness: Daemonheim	Upgrade your Gem bag.	Upgrade your Gem bag.	40 Dungeoneering Dungeoneering , 45 Crafting Crafting
-20,000 dungeoneering tokens	 80	0.4%
-Wilderness: General	Equip a pair of Steadfast boots.	Equip a pair of Steadfast boots.	85 Defence Defence 	 80	<0.1%
-Wilderness: General	Equip a pair of Glaiven boots.	Equip a pair of Glaiven boots.	85 Defence Defence 	 80	<0.1%
-Wilderness: General	Equip a pair of Ragefire boots.	Equip a pair of Ragefire boots.	85 Defence Defence 	 80	<0.1%
-Wilderness: General	Complete the task set: Hard Wilderness.	Complete the hard Wilderness Diary.	See Hard Wilderness achievements page	 80	<0.1%
-Wilderness: Daemonheim	Equip a Chaotic weapon or kiteshield.	Equip a Chaotic weapon or kiteshield.	80 Dungeoneering Dungeoneering , 80 Attack Attack  OR 80 Ranged Ranged  OR 80 Magic Magic  OR 80 Defence Defence 	 80	0.1%
-]
+Task ID	Locality	Task	Information	Requirements	Pts	Comp%
+462	Anachronia	Complete the base camp tutorial on Anachronia.	Complete the Anachronia base camp tutorial.	N/A	10	48.5%
+463	Anachronia	Observe all the large dragonkin statues around Anachronia.	Observe all the large dragonkin statues around Anachronia.	N/A	10	2.7%
+464	Anachronia	Surge under the spine on Anachronia.	Complete Spinal Surgery.	5 Agility	10	27.6%
+461	Anachronia	Set sail for Anachronia.	Set sail for Anachronia on The Stormbreaker docked at Varrock Dig Site.	N/A	10	49.5%
+465	Anachronia	Complete the quest: Helping Laniakea (miniquest).	Complete the Helping Laniakea miniquest.	See quest page	10	0.1%
+466	Anachronia	Complete the quest: Raksha, the Shadow Colossus.	Complete Raksha, the Shadow Colossus quest.	See quest page	10	6.6%
+467	Anachronia	Obtain 100 potent herbs from Herby Werby.	Obtain 100 potent herbs from Herby Werby.	1 Herblore	10	32.8%
+468	Anachronia	Build your Player Lodge on Anachronia.	Build your Player Lodge on Anachronia.	40 Construction	30	0.4%
+469	Anachronia	Purchase the herb bag and the herb bag upgrade from the Herby Werby reward shop.	Purchase the herb bag and the herb bag upgrade from the Herby Werby reward shop.	1 Herblore	30	<0.1%
+470	Anachronia	Give Snoop some clean Dwarf weed.	Give Snoop some clean dwarf weed.	70 Herblore	30	0.3%
+471	Anachronia	Harvest produce from 5 animals on Anachronia farm.	Harvest produce from 5 animals on Anachronia farm.	42 Farming, 45 Construction	30	0.2%
+473	Anachronia	Complete the beginner sections of the Anachronia agility course.	Complete the beginner sections of the Anachronia agility course.	30 Agility	30	14.4%
+474	Anachronia	Complete the novice sections of the Anachronia agility course.	Complete the novice sections of the Anachronia agility course.	50 Agility	30	9.2%
+472	Anachronia	Harvest produce from 25 animals on Anachronia farm.	Harvest produce from 25 animals on Anachronia farm.	42 Farming, 45 Construction	80	<0.1%
+475	Anachronia	Complete the ritual to activate a totem on Anachronia.	Complete the ritual to activate a totem on Anachronia.	N/A	80	<0.1%
+476	Anachronia	Complete the Anachronia agility course in under 7 minutes.	Complete the Anachronia agility course in under 7 minutes.	85 Agility	80	1.3%
+477	Anachronia	Complete all frog breeds.	Complete all frog breeds.	42 Farming, 45 Construction	80	<0.1%
+478	Anachronia	Purchase the Quick Traps upgrade from Irwinsson's Hunter Mark shop.	Purchase the quick traps upgrade from the Hunter Mark Shop.	50 hunter marks	80	<0.1%
+479	Anachronia	Complete the quest: Osseous Rex.	Complete the Osseous Rex quest.	See quest page	80	0.7%
+480	Anachronia	Clear an Overgrown idol on Anachronia.	Clear an overgrown idol on Anachronia.	81 Woodcutting	80	0.2%
+481	Anachronia	Defeat any of the Rex Matriarchs.	Defeat any of the Rex Matriarchs once.	N/A	80	5.9%
+482	Anachronia	Defeat any of the Rex Matriarchs. (100 times)	Defeat any of the Rex Matriarchs 100 times.	N/A	80	1.1%
+483	Anachronia	Complete the quest: Desperate Times.	Complete the Desperate Times quest.	See quest page	80	1%
+484	Anachronia	Find all the hidden Zygomites on Anachronia.	Find all of the ancient zygomites on Anachronia. See the page for a route.	85 Agility	80	<0.1%
+485	Anachronia	Equip Laniakea's spear.	Equip Laniakea's spear.	82 Attack	80	1%
+486	Anachronia	Harvest an Arbuck herb.	Harvest an arbuck herb.	77 Farming	80	3.1%
+487	Anachronia	Complete the advanced sections of the Anachronia agility course.	Complete the advanced sections of the Anachronia agility course.	70 Agility	80	5%
+488	Anachronia	Equip a Dragon Mattock.	Equip a dragon mattock.	60 Archaeology	80	<0.1%
+490	Anachronia	Take down each dinosaur in Big Game Hunter.	Take down each dinosaur in Big Game Hunter.	96 Hunter, 76 Slayer	80	<0.1%
+492	Anachronia	Get caught by each of the big game creatures once.	Get caught by each of the Big Game Hunter creatures once.	96 Hunter, 76 Slayer	80	<0.1%
+493	Anachronia	Complete a big game encounter without using movement abilities.	Complete a Big Game Hunter encounter without using movement abilities.	75 Hunter, 55 Slayer	80	0.2%
+500	Anachronia	Defeat Raksha, the Shadow Colossus.	Defeat Raksha, the Shadow Colossus once.	Completion of Raksha, the Shadow Colossus	80	0.3%
+489	Anachronia	Discover all the totem pieces on Anachronia.	Discover all the totem pieces on Anachronia.	N/A	150	<0.1%
+491	Anachronia	Unlock the double Surge or double Escape ability upgrade.	Unlock the double Surge or double Escape ability upgrade.	85 Agility	150	<0.1%
+494	Anachronia	Harvest a Dragonfruit plant in the cactus patch in the north of Anachronia.	Harvest a dragonfruit cactus in the cactus patch in the north of Anachronia.	81 Farming	150	0.2%
+495	Anachronia	Kill 50 Dinosaurs.	Kill 50 dinosaurs.	N/A	150	0.2%
+496	Anachronia	Kill 50 Vile Blooms.	Kill 50 vile blooms.	N/A	150	0.2%
+497	Anachronia	Solve the Archaeology mystery: Teleport Node On.	Activate all Orthen teleportation devices on Anachronia.	90 Archaeology	150	<0.1%
+498	Anachronia	Use Potterington Blend #102 Fertiliser or dinosaur 'propellant' on Prehistoric Potterington.	Use Potterington blend 102 fertiliser or dinosaur 'propellant' on Prehistoric Potterington.	102 Farming	150	<0.1%
+499	Anachronia	Find an unchecked egg in the pile of dinosaur eggs south of Anachronia dinosaur farm.	Find a dinosaur egg in the pile of dinosaur eggs on Anachronia Farm.	42 Farming, 45 Construction	150	<0.1%
+501	Anachronia	Defeat Raksha, the Shadow Colossus. (100 times)	Defeat Raksha, the Shadow Colossus 100 times.	Completion of Raksha, the Shadow Colossus	150	<0.1%
+502	Anachronia	Complete the quest: Desperate Measures.	Complete the Desperate Measures quest.	See quest page	150	0.2%
+503	Anachronia	Equip a Terrasaur maul.	Equip a terrasaur maul.	90 Attack	150	<0.1%
+505	Anachronia	Complete a big game encounter without stepping into the creature's vision ring.	Complete a Big Game Hunter encounter without stepping into the creature's vision ring.	75 Hunter, 55 Slayer	150	<0.1%
+508	Anachronia	Craft 500 Time Runes.	Craft 500 time runes.	102 Runecrafting	150	<0.1%
+509	Anachronia	Solve the Archaeology mystery: Fragmented Memories.	Complete the Fragmented Memories Archaeology mystery.	99 Archaeology	150	<0.1%
+512	Anachronia	Fletch any type of Elder God arrow.	Fletch any type of Elder God arrow.	95 Fletching	150	0.1%
+513	Anachronia	Cast the Crumble Undead spell.	Cast the Crumble Undead spell.	39 Magic	150	<0.1%
+504	Anachronia	Fully upgrade the Town Hall in the base camp on Anachronia.	Fully upgrade the town hall in the base camp on Anachronia.	90 Construction	150	<0.1%
+506	Anachronia	Complete a big game encounter with 3 creatures active.	Complete a Big Game Hunter encounter with 3 creatures active.	75 Hunter, 55 Slayer	150	<0.1%
+507	Anachronia	Breed a shiny dinosaur.	Breed a shiny dinosaur.	42 Farming, 45 Construction	150	<0.1%
+510	Anachronia	Equip Skeka's hypnowand.	Equip Skeka's hypnowand.	99 Archaeology	150	<0.1%
+511	Anachronia	Complete the quest: Extinction.	Complete the Extinction quest.	See quest page	150	<0.1%
+217	Asgarnia: Burthorpe	Complete a lap of the Burthorpe Agility course.	Complete a lap of the Burthorpe Agility Course.	1 Agility	10	76.8%
+221	Asgarnia: Falador	Kill a goblin raider boss in the Goblin Village.	Kill 15 goblins in the Goblin Village to spawn a Goblin raider boss.	N/A	10	46.9%
+222	Asgarnia: Falador	Complete the quest: Witch's House.	Complete Witch's House	See quest page	10	34.9%
+223	Asgarnia: Falador	Sit down with Tiffy in Falador park.	Sit on the bench with Sir Tiffy Cashien in Falador Park.	N/A	10	73.2%
+224	Asgarnia: Falador	Pray to Bandos's remains.	Pray to Bandos's remains (just south-east of Goblin Village.	N/A	10	60.8%
+225	Asgarnia: Falador	Dance in the Falador party room.	Dance in the Falador party room.	N/A	10	69.7%
+263	Asgarnia: Port Sarim	Give Thurgo a redberry pie.	Give Thurgo a redberry pie.	10 Cooking	10	30.8%
+268	Asgarnia: Taverley	Build a God statue in Taverley.	Build a God statue in Taverley.	N/A	10	59.2%
+218	Asgarnia: Burthorpe	Enter the Warriors Guild.	Enter the Warriors Guild.	Combined Attack and Strength level of 130	30	17.6%
+219	Asgarnia: Burthorpe	Equip a defender.	Equip a defender.	Combined Attack and Strength level of 130	30	7.9%
+220	Asgarnia: Burthorpe	Charge an Amulet of Glory in the Heroes' Guild.	Charge an amulet of glory in the Heroes' Guild.	80 Crafting, 68 Magic	30	0.3%
+226	Asgarnia: Falador	Enter the Crafting Guild.	Enter the Crafting Guild.	40 Crafting	30	40.9%
+227	Asgarnia: Falador	Complete the task set: Easy Falador.	See Easy Falador achievements page	See Easy Falador achievements page	30	2.8%
+228	Asgarnia: Falador	Complete the task set: Medium Falador.	See Medium Falador achievements page	See Medium Falador achievements page	30	<0.1%
+229	Asgarnia: Falador	Defeat the Giant Mole.	Kill the giant mole.	N/A	30	31.1%
+230	Asgarnia: Falador	Defeat the Giant Mole. (50 times)	Kill the giant mole 50 times.	N/A	30	0.2%
+231	Asgarnia: Falador	Steal some Wine of Zamorak from the Captured Temple, south of Goblin Village.	Steal some wine of Zamorak from the Captured Temple, south of Goblin Village.	33 Magic	30	18.4%
+232	Asgarnia: Falador	Set up a dwarf cannon.	Set up a dwarf multicannon.	Completion of Dwarf Cannon	30	1.5%
+233	Asgarnia: Falador	Complete a ceremonial sword at the Artisans' Workshop.	Complete a ceremonial sword at the Artisans' Workshop.	1 Smithing	30	23.8%
+234	Asgarnia: Falador	Mine some orichalcite in the Mining Guild.	Mine some orichalcite ore in the Mining Guild.	60 Mining	30	61.8%
+235	Asgarnia: Burthorpe	Harvest a herb from the troll stronghold herb patch.	Harvest a herb from the troll stronghold herb patch.	9 Farming	30	0.1%
+269	Asgarnia: Taverley	Kill a blue dragon in Taverley dungeon.	Kill a blue dragon in Taverley dungeon.	70 Agility	30	19.5%
+270	Asgarnia: Taverley	Open the crystal chest in Taverley.	Open the crystal chest in Taverley.	A crystal key	30	14.9%
+236	Asgarnia: Falador	Reach 100% respect at the Artisans' Workshop.	Reach 100% respect at the Artisans' Workshop.	1 Smithing	80	22.3%
+237	Asgarnia: Falador	Complete the task set: Hard Falador.	Complete the Hard Falador achievements.	See Hard Falador achievements page	80	<0.1%
+246	Asgarnia: Burthorpe	Defeat any God Wars Dungeon boss 100 times.	Defeat any God Wars Dungeon boss 100 times.	Partial completion of Troll Stronghold	80	12.4%
+247	Asgarnia: Burthorpe	Defeat any God Wars Dungeon boss 250 times.	Defeat any God Wars Dungeon boss 250 times.	Partial completion of Troll Stronghold	80	4.3%
+248	Asgarnia: Burthorpe	Defeat Commander Zilyana.	Defeat Commander Zilyana	70 Agility	80	3%
+249	Asgarnia: Burthorpe	Defeat General Graardor.	Defeat General Graardor	70 Strength	80	12.1%
+250	Asgarnia: Burthorpe	Defeat K'ril Tsutsaroth.	Defeat K'ril Tsutsaroth	70 Constitution	80	8.4%
+251	Asgarnia: Burthorpe	Defeat Kree'arra.	Defeat Kree'arra	70 Ranged	80	1.6%
+252	Asgarnia: Burthorpe	Defeat Nex.	Defeat Nex	70 Agility, 70 Strength, 70 Constitution, 70 Ranged	80	0.5%
+253	Asgarnia: Burthorpe	Defeat Kree'arra. (100 times)	Defeat Kree'arra 100 times.	70 Ranged	80	<0.1%
+254	Asgarnia: Burthorpe	Assemble any godsword from the God Wars Dungeon.	Assemble any godsword from the God Wars Dungeon.	80 Smithing	80	0.8%
+264	Asgarnia: Port Sarim	Defeat the Queen Black Dragon.	Defeat the Queen Black Dragon.	60 Summoning	80	2.7%
+265	Asgarnia: Port Sarim	Defeat the Queen Black Dragon. (100 times)	Defeat the Queen Black Dragon 100 times.	60 Summoning	80	<0.1%
+266	Asgarnia: Port Sarim	Bury some frost dragon bones.	Bury some frost dragon bones.	85 Dungeoneering	80	0.6%
+238	Asgarnia: Falador	Complete the task set: Elite Falador.	Complete the Elite Falador achievements.	See Elite Falador achievements page	150	<0.1%
+239	Asgarnia: Falador	Complete the Invention tutorial.	Complete the Invention tutorial.	80 Divination, 80 Smithing, 80 Crafting	150	1.7%
+240	Asgarnia: Falador	Defeat Vorago, if you think you're hard enough.	Defeat Vorago.	N/A	150	<0.1%
+241	Asgarnia: Falador	Defeat Vorago, if you think you're hard enough. (50 times)	Defeat Vorago 50 times.	N/A	150	<0.1%
+242	Asgarnia: Falador	Equip a seismic wand or seismic singularity.	Equip a seismic wand or singularity.	90 Magic	150	<0.1%
+243	Asgarnia: Falador	Harvest some starbloom flowers from the flower patch south of Falador.	Harvest some starbloom flowers from the flower patch south of Falador.	84 Farming	150	<0.1%
+244	Asgarnia: Falador	Unlock the Royale Cannon from the Artisans' Workshop reward shop.	Unlock the royale dwarf multicannon from the Artisans' Workshop Reward Shop.	100% respect	150	<0.1%
+245	Asgarnia: Falador	Equip a piece of masterwork melee armour.	Equip a piece of masterwork melee armour.	99 Smithing	150	0.1%
+255	Asgarnia: Burthorpe	Equip a full set of Bandos armour.	Equip a full set of Bandos armour.	70 Defence	150	1.9%
+256	Asgarnia: Burthorpe	Equip a full set of Armadyl armour.	Equip a full set of Armadyl armour.	70 Defence	150	<0.1%
+257	Asgarnia: Burthorpe	Equip a full set of subjugation armour.	Equip a full set of subjugation armour.	70 Defence	150	0.5%
+258	Asgarnia: Burthorpe	Equip a piece of Torva, Pernix or Virtus armour.	Equip a piece of Torva, Pernix or Virtus armour.	80 Defence	150	<0.1%
+259	Asgarnia: Burthorpe	Defeat Nex, the Angel of Death.	Kill Nex: Angel of Death.	N/A	150	<0.1%
+260	Asgarnia: Burthorpe	Defeat Nex, the Angel of Death. (50 times)	Kill Nex: Angel of Death 50 times.	N/A	150	<0.1%
+267	Asgarnia: Port Sarim	Kill a living wyvern.	Kill a wyvern.	96 Slayer	150	<0.1%
+261	Asgarnia: Burthorpe	Complete all of the Combat Achievements for God Wars Dungeon bosses, including Nex.	Complete all of the Combat Achievements for God Wars Dungeon bosses, including Nex.	N/A	150	<0.1%
+262	Asgarnia: Burthorpe	Unlock all the prayers from the Praesul Codex.	Unlock all the prayers from the Praesul codex.	99 Prayer	150	<0.1%
+271	Desert: Menaphos	Enter Menaphos.	Enter Menaphos.	N/A	10	50.5%
+272	Desert: General	Catch a whirligig at Het's Oasis.	Catch a whirligig at Het's Oasis.	1 Hunter	10	47.1%
+274	Desert: General	Search the Grand Gold Chest in room 1 of Pyramid Plunder in Sophanem.	Search the grand gold chest in room 1 of Pyramid Plunder in Sophanem.	21 Thieving	10	4%
+275	Desert: General	Search the Grand Gold Chest in room 2 of Pyramid Plunder in Sophanem.	Search the grand gold chest in room 2 of Pyramid Plunder in Sophanem.	31 Thieving	10	4%
+276	Desert: General	Search the Grand Gold Chest in room 3 of Pyramid Plunder in Sophanem.	Search the grand gold chest in room 3 of Pyramid Plunder in Sophanem.	41 Thieving	10	3.9%
+277	Desert: General	Mine a gem rock at the Al Kharid mine.	Mine a gem rock at the Al Kharid mine. A common gem rock can be mined with level 1 Mining.	1 Mining	10	72.6%
+279	Desert: General	Kill a crocodile.	Kill a crocodile.	N/A	10	36.2%
+280	Desert: General	Create a spirit kalphite pouch at the obelisk south west of Pollnivneach.	Create a spirit kalphite pouch at the obelisk south west of Pollnivneach.	25 Summoning	10	1.3%
+281	Desert: Menaphos	Squish 10 corrupted scarabs.	Squish 10 corrupted scarabs.	N/A	10	13.3%
+282	Desert: General	Sell a pyramid top to Simon.	Hand Simon Templeton a pyramid top.	30 Agility	10	11.5%
+283	Desert: General	Use any of the magic carpets in the desert.	Use any of the magic carpets in the desert.	1,000 gp	10	49.7%
+284	Desert: General	Harvest a rose at Het's Oasis.	Harvest a rose at Het's Oasis.	30 Farming	10	26.6%
+273	Desert: General	Clear the Fort debris at the Kharid-et Dig Site.	Clear the fort debris at the Kharid-et Dig Site.	12 Archaeology	30	60.1%
+278	Desert: General	Complete the quest: One Piercing Note.	Complete One Piercing Note.	See quest page	30	20.9%
+285	Desert: General	Complete a lap of the Het's Oasis agility course.	Complete a lap of the Het's Oasis agility course.	65 Agility	30	8.6%
+286	Desert: General	Defeat the Kalphite Queen.	Defeat the Kalphite Queen.	N/A	30	7.2%
+287	Desert: General	Defeat the Kalphite Queen. (100 times)	Defeat the Kalphite Queen 100 times.	N/A	30	<0.1%
+288	Desert: General	Defeat 100 bosses in the Dominion Tower.	Defeat 100 bosses in the Dominion Tower.	Completion of at least 20 various quests	30	<0.1%
+289	Desert: General	Complete the task set: Easy Desert.	Easy desert tasks.	See Easy Desert achievements page	30	0.3%
+290	Desert: General	Complete the task set: Medium Desert.	Medium desert tasks.	See Medium Desert achievements page	30	<0.1%
+291	Desert: Menaphos	Steal from the lamp stall in Menaphos.	Steal from the lamp stall in Menaphos.	46 Thieving	30	9.3%
+292	Desert: General	Buy some runes from Ali Morrisane.	Buy some runes from Ali Morrisane.	Completion of the runes portion of Ali the Trader	30	0.5%
+293	Desert: Menaphos	Catch a catfish.	Catch a raw catfish.	60 Fishing	30	12.1%
+294	Desert: General	Restore a Pontifex signet ring.	Restore a pontifex signet ring.	58 Archaeology	30	2.2%
+295	Desert: General	Search the Grand Gold Chest in room 4 of Pyramid Plunder in Sophanem.	Search the Grand Gold Chest in room 4 of Pyramid Plunder in Sophanem.	51 Thieving	30	3.3%
+296	Desert: General	Search the Grand Gold Chest in room 5 of Pyramid Plunder in Sophanem.	Search the Grand Gold Chest in room 5 of Pyramid Plunder in Sophanem.	61 Thieving	30	2.3%
+297	Desert: General	Search the Grand Gold Chest in room 6 of Pyramid Plunder in Sophanem.	Search the Grand Gold Chest in room 6 of Pyramid Plunder in Sophanem.	71 Thieving	30	1.7%
+298	Desert: General	Complete the quest: Smoking Kills.	Complete Smoking Kills.	See quest page	30	4.5%
+299	Desert: General	Complete the quest: Desert Treasure.	Complete Desert Treasure.	See quest page	30	0.5%
+300	Desert: General	Fully repair the statue of Het.	Repair the statue of Het at Het's Oasis.	200 pieces of Het	30	0.9%
+301	Desert: General	Defeat the Kalphite King.	Defeat the Kalphite King.	N/A	80	4.5%
+302	Desert: General	Defeat the Kalphite King. (100 times)	Defeat the Kalphite King 100 times.	N/A	80	0.1%
+303	Desert: General	Equip a drygore weapon.	Equip a drygore weapon.	90 Attack	80	1.4%
+304	Desert: General	Become an honorary druid at the Garden of Kharid.	Purchase the Druid/Druidess title for 50,000 Crux Eqal favour	50 Farming	80	0.7%
+305	Desert: General	Deploy a dreadnip.	Deploy a dreadnip.	450 Dominion Tower kills	80	<0.1%
+306	Desert: General	Complete the task set: Hard Desert.	Complete the Hard Desert achievements.	See Hard Desert achievements page	80	<0.1%
+307	Desert: General	Defeat Avaryss and Nymora.	Defeat the Twin Furies.	80 Ranged	80	1%
+308	Desert: General	Defeat Gregorovic.	Defeat Gregorovic.	80 Prayer	80	2.5%
+309	Desert: General	Defeat Vindicta and Gorvek.	Defeat Vindicta.	80 Attack	80	11.2%
+310	Desert: General	Defeat Helwyr.	Defeat Helwyr.	80 Magic	80	2.2%
+311	Desert: General	Defeat Avaryss and Nymora. (100 times)	Defeat the Twin Furies 100 times.	80 Ranged	80	<0.1%
+312	Desert: General	Defeat Gregorovic. (100 times)	Defeat Gregorovic 100 times.	80 Prayer	80	<0.1%
+313	Desert: General	Defeat Vindicta and Gorvek. (100 times)	Defeat Vindicta 100 times.	80 Attack	80	1.6%
+314	Desert: General	Defeat Helwyr. (100 times)	Defeat Helwyr 100 times.	80 Magic	80	0.1%
+315	Desert: General	Equip a Dragon Rider lance.	Equip a Dragon Rider lance.	85 Attack	80	4%
+316	Desert: General	Equip a wand or orb of the Cywir elders.	Equip a wand or orb of the Cywir elders.	85 Magic	80	0.3%
+317	Desert: General	Equip a shadow glaive.	Equip a shadow glaive.	85 Ranged	80	<0.1%
+318	Desert: General	Equip a blade of Nymora or Avaryss.	Equip a blade of Nymora or Avaryss.	85 Attack	80	0.1%
+319	Desert: Menaphos	Slay a combination of 500 corrupted or devourer creatures.	Slay a combination of 500 corrupted creatures or soul devourers.	88 Slayer	80	0.1%
+320	Desert: General	Defeat the Magister.	Defeat the Magister.	115 Slayer	80	<0.1%
+321	Desert: General	Defeat the Magister. (50 times)	Defeat the Magister 50 times.	115 Slayer	80	<0.1%
+322	Desert: Menaphos	Find an Off-hand khopesh of the Kharidian in Shifting Tombs.	Find an off-hand khopesh of the Kharidian in Shifting Tombs.	50 Dungeoneering, 50 Agility, 50 Thieving, or 50 Construction	80	<0.1%
+323	Desert: General	Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.	Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.	81 Thieving	80	1.4%
+324	Desert: General	Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.	Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.	91 Thieving	80	1.3%
+325	Desert: Menaphos	Complete the quest: Beneath Scabaras' Sands.	Complete Beneath Scabaras' Sands.	See quest page	80	<0.1%
+326	Desert: General	Kill a desert strykewyrm wearing a Full Slayer Helm and wielding an ancient staff.	Kill a desert strykewyrm wearing a full Slayer helm and wielding an ancient staff.	77 Slayer, 50 Magic, 20 Defence, 55 Crafting	80	<0.1%
+328	Desert: General	Defeat Telos, the Warden.	Defeat Telos, the Warden.	80 Attack, 80 Prayer, 80 Magic, 80 Ranged	80	0.6%
+327	Desert: General	Complete the task set: Elite Desert.	Complete the Elite Desert achievements.	See Elite Desert achievements page	150	<0.1%
+329	Desert: General	Defeat Telos, the Warden at 100% enrage.	Defeat Telos, the Warden at 100% enrage.	80 Attack, 80 Prayer, 80 Magic, 80 Ranged	150	0.1%
+330	Desert: General	Defeat Telos, the Warden at 500% enrage.	Defeat Telos, the Warden at 500% enrage.	80 Attack, 80 Prayer, 80 Magic, 80 Ranged	150	<0.1%
+331	Desert: Menaphos	Craft some Soul runes.	Craft some soul runes.	90 Runecrafting	150	<0.1%
+332	Desert: General	Defeat a Camel Warrior.	Defeat a camel warrior.	96 Slayer	150	<0.1%
+333	Desert: General	Escape Kharid-et by boat.	Complete the Aquatic Escape achievement.	93 Archaeology	150	<0.1%
+334	Desert: General	Defeat the Kalphite King solo.	Kill the Kalphite King solo.	N/A	150	<0.1%
+335	Desert: General	Cast Ice Barrage in the desert.	Cast Ice Barrage in the desert.	94 Magic	150	<0.1%
+337	Desert: General	Craft a Zaros godsword, Seren godbow or staff of Sliske.	Craft a Zaros godsword, Seren godbow or staff of Sliske.	92 Smithing	150	<0.1%
+1112	Desert: Menaphos	Defeat Amascut, the Devourer.	Defeat Amascut, the Devourer.	N/A	150	<0.1%
+336	Desert: General	Defeat Telos, the Warden at 1,000% enrage.	Defeat Telos, the Warden at 1000% enrage.	80 Attack, 80 Prayer, 80 Magic, 80 Ranged	150	<0.1%
+338	Desert: General	Complete all of the Combat Achievements for the Heart of Gielinor bosses (excluding Telos).	Complete all of the Combat Achievements for the Heart of Gielinor bosses (excluding Telos).	N/A	150	<0.1%
+1113	Desert: Menaphos	Defeat Amascut, the Devourer. (100 times)	Defeat Amascut, the Devourer 100 times.	N/A	150	<0.1%
+339	Fremennik: Lunar Isles	Switch to the Lunar Spellbook at the astral altar.	Switch to the Lunar Spellbook at the astral altar.	Completion of Lunar Diplomacy	10	0.6%
+340	Fremennik: Mainland	Defeat a Rock Crab in the Fremennik Province.	Defeat a Rock Crab in the Fremennik Province.	N/A	10	36.7%
+341	Fremennik: Mainland	Defeat a Cockatrice in the Fremennik Province.	Defeat a cockatrice in the Fremennik Province.	25 Slayer	10	18.9%
+342	Fremennik: Mainland	Defeat a Troll in the Fremennik Province.	Defeat a troll in the Fremennik Province.	N/A	10	10.6%
+343	Fremennik: Mainland	Deposit an item with Peer the Seer.	Deposit an item with Peer the Seer.	Completion of the easy Fremennik achievements	10	0.6%
+344	Fremennik: Mainland	Use the Bank on Jatizso or Neitiznot.	Use the Bank on Jatizso or Neitiznot.	Partial completion of The Fremennik Isles	10	1.5%
+346	Fremennik: Mainland	Catch a Sapphire Glacialis.	Catch a Sapphire Glacialis.	25 Hunter	10	6.6%
+347	Fremennik: Lunar Isles	Cast Moonclan Teleport.	Cast Moonclan Teleport.	69 Magic	30	0.7%
+348	Fremennik: Mainland	Move Your House to Rellekka.	Move your player-owned house's location to Rellekka by speaking to an estate agent.	30 Construction	30	12.9%
+349	Fremennik: Lunar Isles	Craft 50 Astral Runes.	Craft 50 astral runes.	40 Runecrafting	30	0.3%
+350	Fremennik: Mainland	Complete the Penguin Agility Course.	Complete the Penguin Agility Course.	30 Agility	30	0.3%
+351	Fremennik: Mainland	Catch a Snowy Knight.	Catch a Snowy Knight.	35 Hunter	30	5.9%
+352	Fremennik: Mainland	Defeat a Kurask in the Fremennik Province.	Defeat a Kurask in the Fremennik Province.	70 Slayer	30	5.8%
+353	Fremennik: Mainland	Defeat a Dagannoth in the Fremennik Province.	Defeat a dagannoth in the Fremennik Province.	N/A	30	22.8%
+354	Fremennik: Mainland	Equip a Helm of Neitiznot.	Equip a Helm of Neitiznot.	55 Defence	30	1%
+355	Fremennik: Mainland	Defeat a Jelly in the Fremennik Province.	Defeat a jelly in the Fremennik Province.	52 Slayer	30	17.1%
+356	Fremennik: Mainland	Complete the quest: Throne of Miscellania.	Complete Throne of Miscellania.	See quest page	30	1.6%
+357	Fremennik: Mainland	Complete the quest: Royal Trouble.	Complete Royal Trouble.	See quest page	30	1.3%
+358	Fremennik: Mainland	Equip a Granite Shield.	Equip a granite shield.	55 Defence, 55 Strength	30	0.4%
+359	Fremennik: Mainland	Equip a full set of Graahk, Larupia or Kyatt hunter gear.	Equip a full set of graahk, larupia or kyatt hunter gear.	31 Hunter	30	1.7%
+360	Fremennik: Mainland	Defeat any of the Dagannoth Kings.	Defeat any of the Dagannoth Kings 1 time.	N/A	30	7%
+361	Fremennik: Mainland	Defeat any of the Dagannoth Kings.	Defeat any of the Dagannoth Kings 100 times.	N/A	30	0.4%
+362	Fremennik: Mainland	Complete the task set: Easy Fremennik.	Complete the Easy Fremennik achievements.	See Easy Fremennik achievements page	30	0.9%
+363	Fremennik: Mainland	Ride a mine cart into Keldagrim.	Ride a mine cart into Keldagrim.	Completion of The Giant Dwarf	30	2.7%
+364	Fremennik: Mainland	Travel to the Mammoth Iceberg.	Travel to the Mammoth Iceberg.	N/A	30	11.4%
+365	Fremennik: Mainland	Steal from the fish stall in Rellekka.	Steal from the fish stall in Rellekka.	42 Thieving	30	2%
+366	Fremennik: Mainland	Harvest 100 sparkling energy from Sparkling Wisps.	Harvest 100 sparkling energy from sparkling wisps.	40 Divination	30	26.8%
+367	Fremennik: Mainland	Climb to the top of the lighthouse.	Climb to the top of the lighthouse.	Completion of Horror from the Deep	30	1.6%
+368	Fremennik: Mainland	Chop 10 Artic[sic] Pine trees.	Chop 10 arctic pine trees.	54 Woodcutting	30	1.4%
+369	Fremennik: Mainland	Kill 25 Yaks.	Kill 25 yaks.	Partial completion of The Fremennik Isles	30	1.1%
+370	Fremennik: Mainland	Interact with a pet rock.	Interact with a pet rock.	Partial completion of The Fremennik Trials	30	2.2%
+383	Fremennik: Mainland	Complete the task set: Medium Fremennik.	Complete the Medium Fremennik achievements.	See Medium Fremennik achievements page	30	<0.1%
+371	Fremennik: Lunar Isles	Cast Fertile Soil.	Cast Fertile Soil.	83 Magic	80	0.1%
+372	Fremennik: Mainland	Build a Gilded Altar.	Build a gilded altar in your player-owned house's chapel.	75 Construction	80	0.2%
+373	Fremennik: Mainland	Trap a Sabre-Toothed Kyatt.	Trap a sabre-toothed kyatt.	55 Hunter	80	1.8%
+374	Fremennik: Mainland	Defeat all the Dagannoth Kings without leaving a solo boss instance.	Defeat all the Dagannoth Kings without leaving a solo boss instance.	N/A	80	0.2%
+375	Fremennik: Mainland	Equip a Berserker, Warrior, Seers, or Archers Ring.	Equip a Berserker, Warrior, Seers, or Archers Ring.	N/A	80	1.5%
+376	Fremennik: Mainland	Use the Special Attack of a Dragon Axe.	Use the special attack of a dragon hatchet.	60 Attack	80	0.5%
+377	Fremennik: Mainland	Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.	Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.	25 Defence	80	0.1%
+378	Fremennik: Mainland	Equip a full set of Skeletal, Spined, or Rockshell armour.	Equip a full skeletal, spined, or rock-shell armour set.	50 Defence	80	0.1%
+379	Fremennik: Mainland	Collect Miscellania Resources at Full Approval.	Collect from Managing Miscellania with a 100% approval rating.	Completion of Throne of Miscellania	80	0.2%
+380	Fremennik: Mainland	Travel to the island of Ungael.	Travel to the island of Ungael.	Partial completion of Ancient Awakening	80	<0.1%
+381	Fremennik: Mainland	Adopt a baby yak.	Obtain an unchecked/baby Fremennik yak.	71 Farming	80	<0.1%
+382	Fremennik: Mainland	Catch 50 Azure Skillchompas.	Catch 50 azure skillchompas.	68 Hunter	80	0.3%
+384	Fremennik: Mainland	Mine 10 Banite Ore north of Rellekka.	Mine 10 Banite ore in the arctic (azure) habitat mine.	80 Mining	80	22.3%
+385	Fremennik: Mainland	Smith a piece of Bane equipment to +4 in Rellekka.	Upgrade a piece of bane equipment to +4 in Rellekka.	80 Smithing	80	0.7%
+386	Fremennik: Mainland	Use a Crystal triskelion key to obtain some treasures.	Use a crystal triskelion to obtain some treasures.	N/A	80	3.4%
+388	Fremennik: Mainland	Create a Catherby Teleport Tablet.	Create a Catherby teleport tablet.	87 Magic, 67 Construction	80	<0.1%
+392	Fremennik: Mainland	Gather a seed from an Aquanite using Seedicide.	Gather a seed from an aquanite using Seedicide.	78 Slayer	80	1%
+393	Fremennik: Mainland	Complete the task set: Hard Fremennik.	Complete the Hard Fremennik achievements.	See Hard Fremennik achievements page	80	<0.1%
+387	Fremennik: Lunar Isles	Cast Spellbook Swap from the Lunar spellbook.	Cast Spellbook Swap from the lunar spellbook.	96 Magic	150	<0.1%
+389	Fremennik: Mainland	Equip Every Dagannoth King Ring.	Equip every Dagannoth King ring.	N/A	150	0.2%
+390	Fremennik: Mainland	Equip a Completed God Book.	Equip a completed god book.	Completion of Horror from the Deep	150	0.1%
+391	Fremennik: Mainland	Defeat 20 Acheron Mammoths.	Defeat 20 acheron mammoths.	96 Slayer	150	<0.1%
+394	Fremennik: Mainland	Cast the Paradox spell on any tree, rock, fishing spot, or box trap.	Cast the Paradox spell on any tree, rock, fishing spot, or box trap.	99 Necromancy	150	<0.1%
+395	Fremennik: Mainland	Build a Demonic Throne.	Build a demonic throne.	99 Construction	150	<0.1%
+397	Fremennik: Lunar Isles	Perform a Powerful Necroplasm ritual at the Ungael ritual site.	Perform a powerful necroplasm ritual at the Ungael ritual site.	90 Necromancy	150	<0.1%
+398	Fremennik: Mainland	Defeat the Abomination once after Hero's Welcome.	Defeat the Abomination once after Hero's Welcome.	N/A	150	<0.1%
+399	Fremennik: Mainland	Summon a Pack Mammoth.	Summon a pack mammoth.	96 Summoning	150	<0.1%
+400	Fremennik: Mainland	Complete the task set: Elite Fremennik.	Complete the Elite Fremennik achievements.	See Elite Fremennik achievements page	150	<0.1%
+401	Fremennik: Mainland	Complete the Ungael combat activity on hard mode.	Complete the Ungael combat activity on hard mode.	N/A	150	<0.1%
+402	Fremennik: Mainland	Use the Trap Telekinesis spell to catch Azure Skillchompas 25 times.	Use the Trap Telekinesis spell to catch azure skillchompas 25 times.	70 Magic	150	<0.1%
+396	Fremennik: Mainland	Equip every completed God Book.	Equip every completed god book.	Completion of Horror from the Deep	150	<0.1%
+127	Global	Level up any of your skills for the first time.	Level up any of your skills for the first time.	N/A	10	98.4%
+128	Global	Reach level 5 in any skill.	Reach level 5 in any skill.	N/A	10	97.7%
+129	Global	Reach level 10 in any skill.	Reach level 10 in any skill.	N/A	10	97%
+130	Global	Reach level 20 in any skill.	Reach level 20 in any skill.	N/A	10	95.5%
+136	Global	Reach combat level 5.	Reach combat level 5.	N/A	10	94.4%
+137	Global	Reach combat level 10.	Reach combat level 10.	N/A	10	91.3%
+141	Global	Reach total level 50.	Reach total level 50.	N/A	10	97.3%
+142	Global	Reach total level 100.	Reach total level 100.	N/A	10	94.4%
+147	Global	Mine a copper ore.	Mine copper ore from a copper rock.	1 Mining	10	93.1%
+148	Global	Mine 10 copper ore.	Mine 10 copper ore.	1 Mining	10	92.2%
+149	Global	Mine a tin ore.	Mine tin ore from a tin rock.	1 Mining	10	91.3%
+150	Global	Mine 10 tin ore.	Mine 10 tin ore.	1 Mining	10	89.9%
+151	Global	Smelt a bronze bar.	Smelt a bronze bar.	1 Smithing	10	92.7%
+152	Global	Smelt 10 bronze bars.	Smelt 10 bronze bars.	1 Smithing	10	92.2%
+153	Global	Smith any bronze item.	Smith any bronze item.	1 Smithing	10	87.5%
+154	Global	Mine clay.	Mine clay.	1 Mining	10	87.2%
+155	Global	Make some soft clay.	Make soft clay by using clay on a water source or with a container of water	N/A	10	77.5%
+156	Global	Mine any ore 5 times.	Mine any ore 5 times.	1 Mining	10	93.4%
+159	Global	Chop any tree 5 times.	Chop any tree 5 times.	1 Woodcutting	10	90.1%
+162	Global	Chop a basic tree.	Chop a basic tree.	1 Woodcutting	10	93.2%
+163	Global	Chop 10 basic trees.	Chop 10 basic trees.	1 Woodcutting	10	88.5%
+164	Global	Chop an oak tree.	Chop an oak tree.	10 Woodcutting	10	83.9%
+166	Global	Burn any logs.	Burn any logs.	1 Firemaking	10	91.8%
+167	Global	Burn any logs 5 times.	Burn any logs 5 times.	1 Firemaking	10	87.2%
+170	Global	Catch a shrimp.	Catch a raw shrimp.	1 Fishing	10	87.7%
+171	Global	Catch 10 shrimp.	Catch 10 raw shrimps.	1 Fishing	10	86.7%
+172	Global	Catch an anchovy.	Catch a raw anchovy.	15 Fishing	10	72%
+173	Global	Catch a herring.	Catch a raw herring.	10 Fishing	10	65.9%
+174	Global	Cook shrimp, meat, or chicken.	Cook raw shrimps, raw meat, or raw chicken.	1 Cooking	10	92.3%
+175	Global	Cook 10 shrimp, meat, or chicken.	Cook 10 raw shrimps, raw meat, or raw chicken.	1 Cooking	10	86.8%
+176	Global	Burn any food.	Burn any food.	1 Cooking	10	86.5%
+177	Global	Catch any fish 5 times.	Catch any fish 5 times.	1 Fishing	10	88.8%
+180	Global	Bury any bones.	Bury any bones.	1 Prayer	10	94.4%
+181	Global	Bury any bones 10 times.	Bury any bones 10 times.	1 Prayer	10	86.9%
+182	Global	Activate the thick skin, rock skin, or steel skin Prayer.	Activate the Thick Skin, Rock Skin, or Steel Skin prayer.	1 Prayer	10	86%
+183	Global	Run out of Prayer points.	Run out of Prayer points.	1 Prayer	10	85.1%
+186	Global	Harvest any memory from a wisp 5 times.	Harvest any memory from a wisp 5 times.	1 Divination	10	82.5%
+189	Global	Pickpocket from a man or woman.	Pickpocket from a man or woman.	1 Thieving	10	89.2%
+190	Global	Pickpocket from a man or woman 10 times.	Pickpocket from a man or woman 10 times.	1 Thieving	10	86.2%
+191	Global	Steal from any stall.	Steal from any stall.	2 Thieving	10	86.2%
+192	Global	Steal from any stall 10 times.	Steal from any stall 10 times.	2 Thieving	10	84.7%
+193	Global	Pickpocket anyone 5 times.	Pickpocket anyone 5 times.	1 Thieving	10	88.1%
+196	Global	Rake any farming patch.	Rake any farming patch.	1 Farming	10	81.7%
+197	Global	Plant seeds in any farming patch.	Plant seeds in any farming patch.	1 Farming	10	72.6%
+198	Global	Plant seeds in any farming patch 10 times.	Plant seeds in any farming patch 10 times.	1 Farming	10	58.5%
+200	Global	Add any compostable item to a compost bin.	Add any compostable item to a compost bin.	N/A	10	66.6%
+201	Global	Have a tool leprechaun note any produce.	Have a tool leprechaun note any produce.	N/A	10	59.5%
+204	Global	Use the Home Teleport spell to return to Lumbridge.	Use the Home Teleport spell to return to Lumbridge.	N/A	10	91.2%
+205	Global	Eat a cabbage.	Eat a cabbage.	N/A	10	83.3%
+206	Global	Eat a baked potato.	Eat a baked potato.	7 Cooking	10	60%
+207	Global	Eat an onion.	Eat an onion.	N/A	10	75.3%
+208	Global	Kill an imp.	Kill an imp.	N/A	10	81.2%
+209	Global	Kill a chicken.	Kill a chicken.	N/A	10	85.3%
+210	Global	Claim a free item from any store.	Claim a free item from any store e.g. a tinderbox from Lumbridge General Store	N/A	10	86.5%
+211	Global	Return a free item to any store.	Return a free item to any store e.g. a tinderbox from Lumbridge General Store	N/A	10	74.2%
+212	Global	Sell an item to any store.	Sell an item to any store.	N/A	10	86.4%
+213	Global	Listen to any musician.	Listen to any musician.	N/A	10	79.2%
+214	Global	Pick wheat from a field.	Pick wheat from a field.	N/A	10	83.3%
+215	Global	Prospect any rock.	Prospect any rock.	1 Mining	10	76.8%
+216	Global	View the skillguide.	View the skill guide.	N/A	10	94.9%
+345	Global	Create a Guthix Rest Potion.	Create a Guthix rest potion.	18 Herblore	10	1.6%
+770	Global	Make 5 potions of any kind.	Make 5 potions of any kind.	1 Herblore	10	54.5%
+773	Global	Drink a Strength Potion.	Drink a Strength Potion.	Giving a limpwurt root and red spiders' eggs to the Apothecary	10	33%
+774	Global	Make an Attack Potion.	Make an Attack potion.	1 Herblore	10	63.2%
+775	Global	Make a Necromancy Potion.	Make a Necromancy potion.	11 Herblore	10	18.6%
+776	Global	Clean 5 Grimy Guam.	Clean 5 grimy guam.	1 Herblore	10	61.9%
+777	Global	Clean 15 Grimy Tarromin.	Clean 15 grimy tarromin.	5 Herblore	10	36.1%
+778	Global	Clean 5 of any herb.	Clean 5 of any herb.	1 Herblore	10	64.9%
+779	Global	Clean 10 of any herb	Clean 10 of any herb	1 Herblore	10	61.6%
+782	Global	Fletch an Oak Shortbow (unstrung).	Fletch an unstrung oak shortbow.	20 Fletching	10	52.1%
+783	Global	Fletch some arrow shafts.	Fletch some arrow shafts.	1 Fletching	10	81.1%
+785	Global	Fletch 50 Bronze bolts.	Fletch 50 bronze bolts.	9 Fletching	10	52.9%
+786	Global	Complete 10 laps of any Agility course.	Complete 10 laps of any Agility course.	1 Agility	10	67%
+790	Global	Smith 10 of any metal weapon or armour piece.	Smith 10 of any metal weapon or armour piece.	1 Smithing	10	81.7%
+794	Global	Open 30 Sedimentary Geodes.	Open 30 sedimentary geodes. These are found randomly while mining.	1 Mining	10	70.5%
+795	Global	Maintain nearly maximum stamina when mining for 60 seconds.	Maintain nearly maximum stamina when mining for 60 seconds.	1 Mining	10	69.8%
+796	Global	Harvest a Grimy Marrentill.	Harvest a grimy marrentill.	9 Farming	10	38.6%
+797	Global	Harvest 10 Grimy Tarromin.	Harvest 10 grimy tarromin.	19 Farming	10	37.3%
+798	Global	Cook 5 fish.	Cook 5 fish.	1 Cooking	10	87.4%
+801	Global	Make some Bread.	Make some bread. Bread dough can be created by using a pot of flour with water, it must be cooked at a range.	1 Cooking	10	54.9%
+802	Global	Make some flour.	Make a pot of flour by grinding wheat at a windmill and collecting the flour in an empty pot.	Wheat and an empty pot	10	77.8%
+803	Global	Offer 5 bones of any kind to an altar.	Offer 5 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel	1 Prayer	10	52.2%
+804	Global	Offer 25 bones of any kind to an altar.	Offer 25 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel	1 Prayer	10	49%
+806	Global	Scatter some Ashes.	Scatter some ashes.	1 Prayer	10	74.3%
+807	Global	Scatter 25 ashes of any kind.	Scatter 25 ashes of any kind.	1 Prayer	10	38.3%
+809	Global	Restore 50 Prayer Points at an Altar at once.	Restore 50 Prayer Points at an Altar at once.	5 Prayer	10	73.7%
+811	Global	Activate Superhuman or Ultimate Strength and Improved or Incredible Reflexes prayers at the same time.	Activate Superhuman or Ultimate Strength and Improved or Incredible Reflexes prayers at the same time.	16 Prayer	10	61.9%
+812	Global	Catch a Baby Impling.	Catch a baby impling.	17 Hunter	10	26%
+813	Global	Catch 10 Implings of any kind.	Catch 10 implings of any kind.	17 Hunter	10	9.7%
+816	Global	Catch 5 Hunter creatures.	Catch 5 Hunter creatures.	1 Hunter	10	56.1%
+819	Global	Complete 5 Slayer tasks.	Complete 5 Slayer assignments.	1 Slayer	10	45.9%
+823	Global	Pick 5 Flax.	Pick 5 flax from flax fields.	N/A	10	70.1%
+824	Global	Spin 5 bowstring.	Spin 5 bowstrings by using flax on a spinning wheel.	1 Fletching	10	68.1%
+825	Global	Surge a distance of one tile.	Surge a distance of one tile.	5 Agility	10	68.7%
+826	Global	Spin a Ball of Wool.	Spin a ball of wool by using wool at a spinning wheel.	1 Fletching	10	74.4%
+827	Global	Equip a full set of Iron armour without any upgrades.	Equip an iron full helm, iron platebody, iron platelegs / iron plateskirt, iron gauntlets, iron armoured boots, and an iron kiteshield. Substitutes for pieces (e.g. med helm instead of full helm, chainbody instead of platebody, square shield instead of kite shield) will work. Iron armour can be bought at Horvik's Armour Shop.	10 Defence	10	58.1%
+828	Global	Equip a full set of Green Dragonhide armour.	Equip a full set of green dragonhide armour.	40 Defence	10	24.6%
+829	Global	Equip a full set of Imphide robes.	Equip a full set of imphide robes.	10 Defence	10	50.3%
+830	Global	Equip a full set of Spider silk robes.	Equip a full set of spider silk robes.	20 Defence	10	50.4%
+831	Global	Store the items required for an emote clue in a Treasure Trail hidey-hole.	Store the items required for an emote clue in a Treasure Trail hidey-hole.	27 Construction	10	9%
+832	Global	Complete an Easy clue scroll.	Complete an easy clue scroll.	N/A	10	43.8%
+836	Global	Collect 10 unique items for the General clue rewards collection log.	Collect 10 unique items for the general clue rewards collection log.	N/A	10	29.6%
+409	Global	Obtain a Naragi engram from Orla Fairweather.	Obtain a Naragi engram from Orla Fairweather. The engram is given to the player during the tutorial for Memorial to Guthix	1 Divination	10	23.1%
+411	Global	Catch a Wild Kebbit.	Catch a wild kebbit.	23 Hunter	10	5%
+131	Global	Reach level 50 in any skill.	Reach level 50 in any skill.	Any skill at level 50	30	84.8%
+132	Global	Reach at least level 5 in all non-elite skills.	Reach at least level 5 in all non-elite skills.	All skills except Invention at level 5	30	41.8%
+133	Global	Reach at least level 10 in all non-elite skills.	Reach at least level 10 in all non-elite skills.	All skills except Invention at level 10	30	36.9%
+134	Global	Reach at least level 20 in all non-elite skills.	Reach at least level 20 in all non-elite skills.	All skills except Invention at level 20	30	24.3%
+138	Global	Reach combat level 50.	Reach combat level 50.	50 Combat level	30	65.3%
+143	Global	Reach total level 500.	Reach total level 500. This task is currently bugged and may complete before you have reached 500 total levels	500 Skills Total level	30	77%
+157	Global	Mine any ore 200 times.	Mine any ore 200 times.	1 Mining	30	86.3%
+160	Global	Chop any tree 200 times.	Chop any tree 200 times.	1 Woodcutting	30	63%
+165	Global	Chop a willow tree.	Chop a willow tree.	20 Woodcutting	30	75.6%
+168	Global	Burn any logs 200 times.	Burn any logs 200 times.	1 Firemaking	30	33.8%
+178	Global	Catch any fish 200 times.	Catch any fish 200 times.	1 Fishing	30	63.5%
+187	Global	Harvest any memory from a wisp 200 times.	Harvest any memory from a wisp 200 times.	1 Divination	30	60%
+194	Global	Pickpocket anyone 200 times.	Pickpocket anyone 200 times.	1 Thieving	30	40.6%
+199	Global	Plant seeds in any farming patch 100 times.	Plant seeds in any farming patch 100 times.	1 Farming	30	23.7%
+202	Global	Unlock all of the Free to Play Lodestones.	Unlock all of the Free to Play Lodestones.	N/A	30	42.4%
+771	Global	Make 200 potions of any kind.	Make 200 potions of any kind.	1 Herblore	30	12.9%
+780	Global	Clean 200 of any herb.	Clean 200 of any herb.	1 Herblore	30	34.9%
+784	Global	Fletch 1,000 arrow shafts.	Fletch 1,000 Arrow Shafts.	1 Fletching	30	67%
+787	Global	Complete 25 laps of any Agility course.	Complete 25 laps of any Agility course.	1 Agility	30	39.5%
+791	Global	Smith 25 of any metal weapon or armour piece.	Smith 25 of any metal weapon or armour piece.	1 Smithing	30	70.6%
+799	Global	Cook 200 fish.	Cook 200 fish.	1 Cooking	30	50.5%
+805	Global	Offer 100 bones of any kind to an altar.	Offer 100 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel	1 Prayer	30	37.7%
+808	Global	Scatter 100 ashes of any kind.	Scatter 100 ashes of any kind.	1 Prayer	30	20.4%
+810	Global	Restore 500 Prayer Points at an Altar at once.	Restore 500 Prayer Points at an Altar at once.	50 Prayer	30	37.1%
+814	Global	Catch 25 Implings of any kind.	Catch 25 implings of any kind.	17 Hunter	30	3.4%
+815	Global	Catch 35 Implings of any kind.	Catch 35 Implings of any kind.	17 Hunter	30	2.2%
+817	Global	Catch 200 Hunter creatures.	Catch 200 Hunter creatures.	1 Hunter	30	12.2%
+833	Global	Complete 25 Easy clue scrolls.	Complete 25 easy clue scrolls.	N/A	30	3.6%
+834	Global	Complete 75 Easy clue scrolls.	Complete 75 easy clue scrolls.	N/A	30	0.4%
+837	Global	Collect 25 unique items for the General clue rewards collection log.	Collect 25 unique items for the general clue rewards collection log.	N/A	30	11.5%
+839	Global	Make 30 Prayer Potions.	Make 30 prayer potions.	38 Herblore	30	16%
+840	Global	Make a 4-dose Potion.	Make a 4-dose potion.	1 Herblore	30	3.6%
+841	Global	Make 20 Super Attack Potions.	Make 20 super attack potions.	45 Herblore	30	10%
+842	Global	Clean 50 Grimy Ranarr.	Clean 50 grimy ranarr.	25 Herblore	30	21.9%
+843	Global	Clean 50 Grimy Avantoe.	Clean 50 grimy avantoe.	48 Herblore	30	6.3%
+844	Global	Harvest 5 Grimy Ranarr.	Harvest 5 grimy ranarr.	32 Farming	30	31.2%
+845	Global	Equip an Iron Crossbow.	Equip an iron crossbow.	10 Ranged	30	25.5%
+846	Global	Equip a Maple shieldbow.	Equip a maple shieldbow.	30 Ranged, 30 Defence	30	17.7%
+847	Global	Fletch 50 Maple shieldbow (unstrung).	Fletch 50 unstrung maple shieldbows.	55 Fletching	30	16.4%
+848	Global	Fletch 400 Steel arrows.	Fletch 400 steel arrows.	30 Fletching	30	34.7%
+849	Global	Fletch 100 Iron bolts.	Fletch 100 iron bolts.	39 Fletching	30	27.2%
+850	Global	Mine some Ore With a Rune Pickaxe.	Mine some ore with a rune pickaxe.	50 Mining	30	49.7%
+851	Global	Mine 20 Mithril Ore.	Mine 20 mithril ore.	30 Mining	30	79%
+852	Global	Mine 30 Adamant Ore.	Mine 30 adamantite ore.	40 Mining	30	74.3%
+853	Global	Mine 40 Runite Ore.	Mine 40 runite ore.	50 Mining	30	68.5%
+854	Global	Open 20 Igenous[sic] Geodes.	Open 20 igneous geodes. These are found randomly while mining from rocks which require at least level 60 Mining	60 Mining	30	41.6%
+855	Global	Check a grown Fruit Tree.	Check a tree grown in a fruit tree patch.	27 Farming	30	27.8%
+856	Global	Catch 100 Lobsters.	Catch 100 lobsters.	40 Fishing	30	43.5%
+857	Global	Catch 50 Swordfish.	Catch 50 swordfish.	50 Fishing	30	31.7%
+858	Global	Catch 50 Salmon.	Catch 50 salmon.	30 Fishing	30	53.6%
+859	Global	Catch 10 Pike.	Catch 10 pike.	25 Fishing	30	51.9%
+860	Global	Make a Pineapple pizza.	Make a pineapple pizza by adding pineapple chunks or a pineapple ring to a plain pizza.	65 Cooking	30	1.7%
+861	Global	Make a Stew.	Make a stew: add a raw potato to a bowl of water, then add either cooked meat or chicken, and cook the stew at a range.	25 Cooking	30	9.7%
+862	Global	Make a Chocolate Cake.	Make a chocolate cake by adding a chocolate bar to a cooked cake.	50 Cooking	30	10.2%
+863	Global	Bury some Baby Dragon bones.	Bury some baby dragon bones.	N/A	30	24.4%
+864	Global	Bury 5 Dragon bones.	Bury 5 dragon bones.	1 Prayer	30	30.5%
+865	Global	Activate Protect from Melee prayer.	Activate the Protect from Melee prayer.	43 Prayer	30	48.8%
+866	Global	Catch a Gourmet Impling.	Catch a gourmet impling.	28 Hunter	30	22.4%
+867	Global	Light a Bullseye Lantern.	Light a bullseye lantern.	49 Firemaking	30	8.4%
+868	Global	Teleport using Law runes.	Teleport using law runes. The lowest level teleport spell is South Feldip Hills Teleport which also requires one air and one water rune	10 Magic	30	45.8%
+869	Global	Craft some Combination runes.	Craft some combination runes: mist runes have the lowest level requirement. They can made by using a pure essence and 1 water rune and a water talisman at the air altar or 1 air rune and an air talisman at the water altar	6 Runecrafting	30	20.3%
+870	Global	Craft 100 runes.	Craft 100 runes.	1 Runecrafting	30	48.8%
+871	Global	Craft 1,000 runes.	Craft 1,000 runes.	1 Runecrafting	30	14.4%
+874	Global	Equip a full set of Steel armour.	Equip a full set of steel armour (helm, body, legs, boots, and gauntlets).	20 Defence	30	54%
+875	Global	Equip a full set of Mithril armour.	Equip a full set of mithril armour (full helm, platebody, legs, boots, and gauntlets).	30 Defence	30	51.3%
+876	Global	Equip a full set of Adamant armour.	Equip a full set of adamant armour (full helm, platebody, legs, boots, and gauntlets).	40 Defence	30	45.7%
+877	Global	Equip a full set of Rune armour.	Equip a full set of rune armour (full helm, platebody, legs, boots, and gauntlets).	50 Defence	30	38.8%
+878	Global	Equip a full set of Blue Dragonhide armour.	Equip a full set of blue dragonhide armour.	50 Defence	30	14%
+879	Global	Equip a full set of Red Dragonhide armour.	Equip a full set of red Dragonhide armour.	55 Defence	30	4.4%
+880	Global	Equip a full set of Batwing robes.	Equip a full set of batwing robes.	30 Defence	30	44.3%
+881	Global	Equip a full set of Mystic robes.	Equip a full set of mystic robes.	50 Defence	30	17%
+882	Global	Create a Mithril Grapple.	Create a mithril grapple.	59 Fletching, 30 Smithing	30	6.5%
+883	Global	Burn 25 Willow logs.	Burn 25 willow logs.	30 Firemaking	30	57.8%
+884	Global	Burn 50 Maple logs.	Burn 50 maple logs.	45 Firemaking	30	28.9%
+885	Global	Equip any elemental battlestaff.	Equip any elemental battlestaff.	30 Magic	30	32.1%
+886	Global	Equip a mystic staff.	Equip a mystic staff.	40 Magic	30	23.2%
+887	Global	Obtain 50 Quest Points.	Obtain 50 quest points.	50 Quest points	30	56.9%
+891	Global	Complete 100 clues of any tier.	Complete 100 clues of any tier.	N/A	30	4.6%
+892	Global	Complete a Medium clue scroll.	Complete a medium clue scroll.	N/A	30	36%
+893	Global	Complete 25 Medium clue scrolls.	Complete 25 medium clue scrolls.	N/A	30	6.1%
+894	Global	Complete 75 Medium clue scrolls.	Complete 75 medium clue scrolls.	N/A	30	0.5%
+896	Global	Complete a Hard clue scroll.	Complete a hard clue scroll.	N/A	30	32.2%
+897	Global	Complete 25 Hard clue scrolls.	Complete 25 hard clue scrolls.	N/A	30	10.4%
+900	Global	Collect 5 unique items for the Easy clue rewards collection log.	Collect 5 unique items for the easy clue rewards collection log.	N/A	30	34.1%
+901	Global	Collect 10 unique items for the Easy clue rewards collection log.	Collect 10 unique items for the easy clue rewards collection log.	N/A	30	27.7%
+904	Global	Collect 5 unique items for the Medium clue rewards collection log.	Collect 5 unique items for the medium clue rewards collection log.	N/A	30	31.3%
+905	Global	Collect 10 unique items for the Medium clue rewards collection log.	Collect 10 unique items for the Medium clue rewards collection log.	N/A	30	26.4%
+908	Global	Collect 5 unique items for the Hard clue rewards collection log.	Collect 5 unique items for the hard clue rewards collection log.	N/A	30	27.8%
+912	Global	Equip any 2 pieces of an Elegant outfit.	Equip any 2 pieces of an elegant outfit.	N/A	30	14.9%
+913	Global	Equip a composite bow of any kind.	Equip a composite bow of any kind.	20 Ranged	30	18.8%
+943	Global	Perform a Special Attack.	Perform a special attack.	5 Attack or 5 Ranged or 5 Magic	30	35.7%
+1098	Global	Reach level 30 in any skill.	Reach level 30 in any skill.	N/A	30	93.5%
+1099	Global	Reach level 40 in any skill.	Reach level 40 in any skill.	N/A	30	89.9%
+1100	Global	Reach level 60 in any skill.	Reach level 60 in any skill.	N/A	30	78.7%
+1105	Global	Reach at least level 30 in all non-elite skills.	Reach at least level 30 in all non-elite skills.	All skills except Invention at level 30	30	14.6%
+418	Global	Equip a Spottier Cape.	Equip a spottier cape.	66 Hunter	30	0.6%
+432	Global	Hunt 10 Spotted Kebbits with the help of a falcon.	Hunt 10 spotted kebbits with using falconry.	43 Hunter	30	3%
+433	Global	Complete the quest: The Needle Skips.	Complete The Needle Skips.	See quest page	30	2.6%
+443	Global	Catch a Monkfish.	Catch a raw monkfish.	62 Fishing	80	2.2%
+444	Global	Recover all data for one memory-storage bot in the Hall of Memories.	Recover all data for memory-storage bot (Aagi) in the Hall of Memories.	70 Divination	80	2.7%
+459	Global	Mine 25 Platinum Ore south of Piscatoris Fishing Colony.	Mine 25 platinum ores south of Piscatoris Fishing Colony.	70 Mining	80	<0.1%
+460	Global	Chop 50 Eternal Magic logs.	Chop 50 eternal magic logs.	75 Woodcutting	80	<0.1%
+135	Global	Reach at least level 50 in all non-elite skills.	Reach at least level 50 in all non-elite skills.	All skills except Invention at level 50	80	1.3%
+139	Global	Reach combat level 100.	Reach combat level 100.	100 Combat	80	16.6%
+144	Global	Reach total level 1000.	Reach total level 1000. This task is currently bugged and may complete before you have reached 1000 total levels	1000 Skills Total level	80	48.4%
+158	Global	Mine any ore 1000 times.	Mine any ore 1000 times.	N/A	80	67%
+161	Global	Chop any tree 1000 times.	Chop any tree 1000 times.	N/A	80	9.7%
+169	Global	Burn any logs 1000 times.	Burn any logs 1000 times.	N/A	80	2.3%
+179	Global	Catch any fish 1000 times.	Catch any fish 1000 times.	N/A	80	9%
+188	Global	Harvest any memory from a wisp 1000 times.	Harvest any memory from a wisp 1000 times.	N/A	80	11.5%
+195	Global	Pickpocket anyone 1000 times.	Pickpocket anyone 1000 times.	N/A	80	8.9%
+203	Global	Unlock all of the Lodestones.	Unlock all of the lodestones.	N/A	80	<0.1%
+772	Global	Make 1,000 potions of any kind.	Make 1,000 potions of any kind.	N/A	80	0.5%
+781	Global	Clean 1,000 of any herb.	Clean 1,000 of any herb.	N/A	80	8.4%
+788	Global	Complete 50 laps of any Agility course.	Complete 50 laps of any Agility course.	N/A	80	13.3%
+789	Global	Complete 100 laps of any Agility course.	Complete 100 laps of any Agility course.	N/A	80	3.7%
+792	Global	Smith 50 of any metal weapon or armour piece.	Smith 50 of any metal weapon or armour piece.	N/A	80	52.5%
+793	Global	Smith 100 of any metal weapon or armour piece.	Smith 100 of any metal weapon or armour piece.	N/A	80	35.4%
+800	Global	Cook 1,000 fish.	Cook 1,000 fish.	N/A	80	5.3%
+818	Global	Catch 1,000 Hunter creatures.	Catch 1,000 Hunter creatures.	N/A	80	0.9%
+820	Global	Complete 15 Slayer tasks.	Complete 15 Slayer tasks.	N/A	80	8.1%
+835	Global	Complete 150 Easy clue scrolls.	Complete 150 easy clue scrolls.	N/A	80	0.1%
+838	Global	Collect 50 unique items for the General clue rewards collection log.	Collect 50 unique items for the general clue rewards collection log.	N/A	80	<0.1%
+872	Global	Craft 10,000 runes.	Craft 10,000 runes.	N/A	80	<0.1%
+873	Global	Craft 20,000 runes.	Craft 20,000 runes.	N/A	80	<0.1%
+888	Global	Obtain 75 Quest Points.	Obtain 75 quest points.	75 Quest points	80	21.1%
+889	Global	Obtain 100 Quest Points.	Obtain 100 quest points.	100 Quest points	80	6%
+895	Global	Complete 150 Medium clue scrolls.	Complete 150 medium clue scrolls.	N/A	80	0.1%
+898	Global	Complete 75 Hard clue scrolls.	Complete 75 hard clue scrolls.	N/A	80	0.8%
+899	Global	Complete 150 Hard clue scrolls.	Complete 150 hard clue scrolls.	N/A	80	0.1%
+902	Global	Collect 25 unique items for the Easy clue rewards collection log.	Collect 25 unique items for the easy clue rewards collection log.	N/A	80	7.1%
+903	Global	Collect 50 unique items for the Easy clue rewards collection log.	Collect 50 unique items for the easy clue rewards collection log.	N/A	80	1%
+906	Global	Collect 25 unique items for the Medium clue rewards collection log.	Collect 25 unique items for the medium clue rewards collection log.	N/A	80	10.1%
+907	Global	Collect 50 unique items for the Medium clue rewards collection log.	Collect 50 unique items for the medium clue rewards collection log.	N/A	80	3.7%
+909	Global	Collect 10 unique items for the Hard clue rewards collection log.	Collect 10 unique items for the hard clue rewards collection log.	N/A	80	17.1%
+910	Global	Collect 25 unique items for the Hard clue rewards collection log.	Collect 25 unique items for the hard clue rewards collection log.	N/A	80	12.2%
+914	Global	Equip any Dragon mask.	Equip any dragon mask.	N/A	80	11.3%
+915	Global	Make any Perfect Juju Potion.	Make any perfect juju potion.	75 Herblore	80	<0.1%
+916	Global	Make 15 Antifire Potions.	Make 15 antifire potions.	69 Herblore	80	0.6%
+917	Global	Clean 50 Grimy Cadantine.	Clean 50 grimy cadantine.	65 Herblore	80	0.6%
+918	Global	Clean 100 Grimy Lantadyme.	Clean 100 grimy lantadyme.	67 Herblore	80	0.9%
+919	Global	Clean 100 Dwarf Weed.	Clean 100 grimy dwarf weed.	70 Herblore	80	0.5%
+920	Global	Clean 100 Arbuck.	Clean 100 grimy arbuck.	77 Herblore, 77 Farming	80	0.1%
+921	Global	Equip a Yew shortbow.	Equip a yew shortbow.	40 Ranged	80	10%
+922	Global	Equip a Magic shortbow.	Equip a magic shortbow.	50 Ranged	80	5.3%
+923	Global	Fletch some Broad Arrows or Bolts.	Fletch some broad arrows or bolts.	52 Fletching	80	1%
+924	Global	Fletch 100 Yew shortbows (unstrung).	Fletch 100 Yew shortbows (unstrung).	65 Fletching	80	2.3%
+925	Global	Fletch 100 Yew stocks.	Fletch 100 yew stocks.	69 Fletching	80	1.9%
+926	Global	Fletch a Rune Crossbow.	Fletch a rune crossbow.	69 Fletching	80	2.2%
+927	Global	Fletch 35 or more arrow shafts from a single log.	Fletch 35 or more arrow shafts from a single log.	60 Fletching	80	4.7%
+928	Global	Fletch 500 Adamant arrows.	Fletch 500 adamant arrows.	60 Fletching	80	9.6%
+929	Global	Fletch 750 Rune arrows.	Fletch 750 rune arrows.	75 Fletching	80	4.9%
+930	Global	Fletch 75 Onyx bolts.	Fletch 75 onyx bolts.	73 Fletching	80	0.6%
+931	Global	Equip a Rune Ceremonial Sword.	Equip a rune ceremonial sword.	N/A	80	0.1%
+932	Global	Equip a full set of the Blacksmith's outfit.	Equip a full set of the blacksmith's outfit.	Total of 250% Artisans' Workshop respect	80	2.1%
+933	Global	Power up the Artisan's Workshop with a Luminite Injector.	Power up the Artisan's Workshop with a luminite Injector.	100% Artisans' Workshop respect	80	2.6%
+934	Global	Mine 50 Orichalcite Ore.	Mine 50 orichalcite ore.	60 Mining	80	55%
+935	Global	Mine 50 Drakolith.	Mine 50 drakolith	60 Mining	80	41.4%
+936	Global	Mine 60 Necrite Ore.	Mine 60 necrite ore.	70 Mining	80	37.6%
+937	Global	Mine 60 Phasmatite.	Mine 60 phasmatite.	70 Mining	80	33%
+938	Global	Harvest 20 Grimy Kwuarm.	Harvest 20 grimy kwuarm.	56 Farming	80	7.5%
+939	Global	Catch 100 Shark.	Catch 100 raw sharks.	76 Fishing	80	1.5%
+940	Global	Catch 100 Green Blubber Jellyfish.	Catch 100 green blubber jellyfish.	68 Fishing	80	2.2%
+941	Global	Catch a Spirit Impling.	Catch a spirit impling.	54 Hunter	80	1.9%
+942	Global	Equip a Slayer helmet.	Equip a Slayer helmet.	55 Crafting, 35 Slayer	80	0.2%
+944	Global	Complete a Soul Reaper task.	Complete a Soul Reaper task.	N/A	80	20.6%
+945	Global	Complete 5 Soul Reaper tasks.	Complete 5 Soul Reaper tasks.	N/A	80	1.1%
+947	Global	Equip a full set of Orikalkum armour.	Equip a full set of orikalkum armour.	60 Smithing, 60 Defence	80	21.3%
+948	Global	Equip a full set of Necronium armour.	Equip a full set of necronium armour.	70 Smithing, 70 Defence	80	11.2%
+949	Global	Equip a full set of Black Dragonhide armour.	Equip a full set of black dragonhide armour.	60 Defence, 60 Crafting	80	4.1%
+950	Global	Equip a full set of Royal Dragonhide armour.	Equip a full set of royal dragonhide armour.	65 Defence, 65 Crafting	80	2.1%
+951	Global	Cast a Wave spell.	Cast a wave spell.	62 Magic	80	11.1%
+952	Global	Burn 75 Yew logs.	Burn 75 yew logs.	60 Firemaking	80	3.4%
+953	Global	Unlock the Ring of Quests from May's Quest Caravan.	Unlock the Ring of Quests from May's Quest Caravan.	75 Quest points	80	5.4%
+954	Global	Complete 250 clues of any tier.	Complete 250 clues of any tier.	N/A	80	0.1%
+955	Global	Complete 500 clues of any tier.	Complete 500 clues of any tier.	N/A	80	<0.1%
+956	Global	Complete an Elite clue scroll.	Complete an elite clue scroll.	N/A	80	16.4%
+957	Global	Complete 25 Elite clue scrolls.	Complete 25 elite clue scrolls.	N/A	80	1%
+960	Global	Complete a Master clue scroll.	Complete a master clue scroll.	N/A	80	19.9%
+964	Global	Collect 5 unique items for the Elite clue rewards collection log.	Collect 5 unique items for the elite clue rewards collection log.	N/A	80	12%
+965	Global	Collect 10 unique items for the Elite clue rewards collection log.	Collect 10 unique items for the elite clue rewards collection log.	N/A	80	8.7%
+966	Global	Collect 20 unique items for the Elite clue rewards collection log.	Collect 20 unique items for the elite clue rewards collection log.	N/A	80	5.6%
+968	Global	Collect 5 unique items for the Master clue rewards collection log.	Collect 5 unique items for the master clue rewards collection log.	N/A	80	15.1%
+1002	Global	Catch a Manta ray.	Catch a raw manta ray.	81 Fishing	80	1.6%
+1101	Global	Reach level 70 in any skill.	Reach level 70 in any skill.	Any skill at level 70	80	62.6%
+1102	Global	Reach level 80 in any skill.	Reach level 80 in any skill.	Any skill at level 80	80	45.8%
+1106	Global	Reach at least level 40 in all non-elite skills.	Reach at least level 40 in all non-elite skills.	All skills except Invention at level 40	80	3.6%
+1107	Global	Reach at least level 60 in all non-elite skills.	Reach at least level 60 in all non-elite skills.	All skills except Invention at level 60	80	0.2%
+1108	Global	Reach at least level 70 in all non-elite skills.	Reach at least level 70 in all non-elite skills.	All skills except Invention at level 70	80	<0.1%
+140	Global	Reach maximum combat level.	Reach maximum combat level.	138 Combat	150	1.6%
+145	Global	Reach total level 2000.	Reach total level 2000.	2000 Skills Total level	150	<0.1%
+821	Global	Complete 50 Slayer tasks.	Complete 50 Slayer tasks.	N/A	150	<0.1%
+822	Global	Complete 75 Slayer tasks.	Complete 75 Slayer tasks.	N/A	150	<0.1%
+890	Global	Obtain 125 Quest Points.	Obtain 125 quest points.	125 Quest points	150	0.2%
+911	Global	Collect 75 unique items for the Hard clue rewards collection log.	Collect 75 unique items for the hard clue rewards collection log.	N/A	150	<0.1%
+946	Global	Complete 10 Soul Reaper tasks.	Complete 10 Soul Reaper tasks.	N/A	150	0.2%
+958	Global	Complete 75 Elite clue scrolls.	Complete 75 elite clue scrolls.	N/A	150	<0.1%
+959	Global	Complete 150 Elite clue scrolls.	Complete 150 elite clue scrolls.	N/A	150	<0.1%
+961	Global	Complete 25 Master clue scrolls.	Complete 25 master clue scrolls.	N/A	150	1.2%
+962	Global	Complete 75 Master clue scrolls.	Complete 75 master clue scrolls.	N/A	150	<0.1%
+967	Global	Collect 35 unique items for the Elite clue rewards collection log.	Collect 35 unique items for the elite clue rewards collection log.	N/A	150	2.5%
+969	Global	Collect 10 unique items for the Master clue rewards collection log.	Collect 10 unique items for the master clue rewards collection log.	N/A	150	10.8%
+970	Global	Collect 15 unique items for the Master clue rewards collection log.	Collect 15 unique items for the master clue rewards collection log.	N/A	150	8.3%
+971	Global	Collect 30 unique items for the Master clue rewards collection log.	Collect 30 unique items for the master clue rewards collection log.	N/A	150	4.5%
+972	Global	Make 25 Powerburst Potions.	Make 25 powerbursts.	92 Herblore	150	<0.1%
+973	Global	Make 25 Bomb Potions.	Make 25 bomb potions.	93 Herblore	150	<0.1%
+974	Global	Make 5 Perfect Plus Potions.	Make 5 perfect plus potions.	84 Herblore	150	<0.1%
+975	Global	Make 15 Overload Potions.	Make 15 overloads.	96 Herblore	150	<0.1%
+976	Global	Make a Spiritual Prayer Potion.	Make a spiritual prayer potion.	97 Herblore	150	<0.1%
+977	Global	Fletch 200 Magic stocks.	Fletch 200 magic stocks.	82 Fletching	150	0.2%
+978	Global	Fletch 750 Elder arrow shafts.	Fletch 750 elder arrow shafts.	90 Fletching	150	<0.1%
+979	Global	Fletch 20 Elder shortbow (unstrung)	Fletch 20 unstrung elder shortbows	90 Fletching	150	<0.1%
+980	Global	Fletch an Eternal magic shortbow (Martial) or Primal crossbow (martial).	Fletch an eternal magic shortbow (martial) or primal crossbow (martial).	95 Fletching	150	<0.1%
+981	Global	Fletch 1,000 Eternal magic shafts.	Fletch 1,000 eternal magic shafts.	90 Fletching	150	<0.1%
+982	Global	Fletch 1,500 Primal arrows.	Fletch 1,500 primal arrows.	92 Fletching	150	<0.1%
+983	Global	Fletch an Eternal Magic Wood Box.	Fletch an eternal magic wood box.	90 Fletching	150	<0.1%
+984	Global	Fletch 350 Rune darts.	Fletch 350 rune darts.	81 Fletching	150	0.1%
+985	Global	Smith a Primal Ore Box.	Smith a primal ore box.	99 Smithing	150	<0.1%
+986	Global	Smith 10,000 Armour Spikes.	Smith 10,000 armour spikes.	80 Smithing	150	<0.1%
+987	Global	Smith 10,000 Primal Armour Spikes.	Smith 10,000 primal armour spikes.	99 Smithing	150	<0.1%
+988	Global	Mine each of the 10 ores on the surface of the Daemonheim peninsula in under 5 minutes.	Mine each of the 10 ores on the surface of the Daemonheim peninsula in under 5 minutes.	80 Mining	150	<0.1%
+989	Global	Mine 70 Banite Ore.	Mine 70 banite ore.	80 Mining	150	8.4%
+990	Global	Mine 100 Dark or Light Animica.	Mine 100 dark or light animica.	90 Mining	150	0.3%
+991	Global	Open 10 Metamorphic Geodes.	Open 10 metamorphic geodes. These are found randomly while mining from rocks which require at least level 60 Mining	60 Mining	150	0.3%
+992	Global	Harvest 40 Grimy Lantadyme.	Harvest 40 grimy lantadyme.	73 Farming	150	<0.1%
+993	Global	Harvest 50 Grimy Fellstalk.	Harvest 50 grimy fellstalk.	91 Farming	150	<0.1%
+994	Global	Plant an Avocado seed in a bush patch.	Plant an avocado seed in a bush patch.	69 Farming	150	<0.1%
+995	Global	Harvest 20 Lychee.	Harvest 20 lychee.	99 Farming	150	<0.1%
+996	Global	Harvest 24 Starbloom Flowers.	Harvest 24 starbloom flowers.	84 Farming	150	<0.1%
+997	Global	Catch 150 Rocktail.	Catch 150 raw rocktails.	90 Fishing	150	<0.1%
+998	Global	Catch 200 Sailfish.	Catch 200 raw sailfish.	97 Fishing	150	<0.1%
+999	Global	Catch 150 Blue Blubber Jellyfish.	Catch 150 raw blue blubber jellyfish.	91 Fishing	150	<0.1%
+1000	Global	Obtain the highest boost available in the 'Fishing Frenzy' activity.	Obtain the highest boost available in the 'Fishing Frenzy' activity at Deep Sea Fishing.	94 Fishing	150	<0.1%
+1001	Global	Catch a Cavefish.	Catch a raw cavefish.	85 Fishing, 80 Cooking	150	<0.1%
+1003	Global	Manually bury or scatter each of the listed bones and ashes.	Complete the Bury All achievement.	90 Prayer	150	<0.1%
+1004	Global	Activate Soul Split prayer.	Activate Soul Split prayer.	92 Prayer	150	<0.1%
+1005	Global	Catch a Dragon Impling.	Catch a dragon impling.	80 Hunter	150	<0.1%
+1006	Global	Catch a Kingly Impling.	Catch a kingly impling.	90 Hunter	150	<0.1%
+1007	Global	Equip a full set of Bane armour.	Equip a full set of bane armour.	80 Smithing, 80 Defence	150	0.2%
+1008	Global	Equip a full set of Elder Rune armour.	Equip a full set of elder rune armour.	90 Smithing, 90 Defence	150	0.2%
+1009	Global	Cast a Surge spell.	Cast a Surge spell.	81 Magic	150	0.3%
+1010	Global	Burn 100 Magic Logs	Burn 100 magic logs	75 Firemaking	150	0.1%
+1011	Global	Burn 10 Elder logs.	Burn 10 elder logs.	90 Firemaking	150	<0.1%
+1012	Global	Reach level 99 in the Agility skill.	Reach level 99 Agility.	99 Agility	150	<0.1%
+1013	Global	Reach level 99 in the Archaeology skill.	Reach level 99 Archaeology.	99 Archaeology	150	<0.1%
+1014	Global	Reach level 99 in the Attack skill.	Reach level 99 Attack.	99 Attack	150	<0.1%
+1015	Global	Reach level 99 in the Construction skill.	Reach level 99 Construction.	99 Construction	150	<0.1%
+1016	Global	Reach level 99 in the Cooking skill.	Reach level 99 Cooking.	99 Cooking	150	<0.1%
+1017	Global	Reach level 99 in the Crafting skill.	Reach level 99 Crafting.	99 Crafting	150	<0.1%
+1018	Global	Reach level 99 in the Defence skill.	Reach level 99 Defence.	99 Defence	150	<0.1%
+1019	Global	Reach level 99 in the Divination skill.	Reach level 99 Divination.	99 Divination	150	<0.1%
+1020	Global	Reach level 99 in the Dungeoneering skill.	Reach level 99 Dungeoneering.	99 Dungeoneering	150	<0.1%
+1021	Global	Reach level 99 in the Farming skill.	Reach level 99 Farming.	99 Farming	150	<0.1%
+1022	Global	Reach level 99 in the Firemaking skill. (Where arson is its own reward.)	Reach level 99 Firemaking.	99 Firemaking	150	<0.1%
+1023	Global	Reach level 99 in the Fishing skill.	Reach level 99 Fishing.	99 Fishing	150	<0.1%
+1024	Global	Reach level 99 in the Fletching skill.	Reach level 99 Fletching.	99 Fletching	150	<0.1%
+1025	Global	Reach level 99 in the Herblore skill.	Reach level 99 Herblore.	99 Herblore	150	<0.1%
+1026	Global	Reach level 99 in the Constitution skill.	Reach level 99 Constitution.	99 Constitution	150	<0.1%
+1027	Global	Reach level 99 in the Hunter skill.	Reach level 99 Hunter.	99 Hunter	150	<0.1%
+1028	Global	Reach level 99 in the Invention skill.	Reach level 99 Invention.	99 Invention	150	<0.1%
+1029	Global	Reach level 99 in the Magic skill.	Reach level 99 Magic.	99 Magic	150	<0.1%
+1030	Global	Reach level 99 in the Mining skill.	Reach level 99 Mining.	99 Mining	150	<0.1%
+1031	Global	Reach level 99 in the Necromancy skill.	Reach level 99 Necromancy.	99 Necromancy	150	<0.1%
+1032	Global	Reach level 99 in the Prayer skill.	Reach level 99 Prayer.	99 Prayer	150	<0.1%
+1033	Global	Reach level 99 in the Ranged skill.	Reach level 99 Ranged.	99 Ranged	150	<0.1%
+1034	Global	Reach level 99 in the Runecrafting skill.	Reach level 99 Runecrafting.	99 Runecrafting	150	<0.1%
+1035	Global	Reach level 99 in the Slayer skill.	Reach level 99 Slayer.	99 Slayer	150	<0.1%
+1036	Global	Reach level 99 in the Smithing skill.	Reach level 99 Smithing.	99 Smithing	150	<0.1%
+1037	Global	Reach level 99 in the Strength skill.	Reach level 99 Strength.	99 Strength	150	<0.1%
+1038	Global	Reach level 99 in the Summoning skill.	Reach level 99 Summoning.	99 Summoning	150	<0.1%
+1039	Global	Reach level 99 in the Thieving skill.	Reach level 99 Thieving.	99 Thieving	150	<0.1%
+1040	Global	Reach level 99 in the Woodcutting skill.	Reach level 99 Woodcutting.	99 Woodcutting	150	<0.1%
+1041	Global	Reach level 110 in the Mining skill.	Reach level 110 Mining.	110 Mining	150	<0.1%
+1042	Global	Reach level 110 in the Smithing skill.	Reach level 110 Smithing.	110 Smithing	150	<0.1%
+1043	Global	Reach level 110 in the Crafting skill.	Reach level 110 Crafting	110 Crafting	150	<0.1%
+1044	Global	Reach level 110 in the Firemaking skill.	Reach level 110 Firemaking.	110 Firemaking	150	<0.1%
+1045	Global	Reach level 110 in the Fletching skill.	Reach level 110 Fletching.	110 Fletching	150	<0.1%
+1046	Global	Reach level 110 in the Woodcutting skill.	Reach level 110 Woodcutting.	110 Woodcutting	150	<0.1%
+1047	Global	Reach level 110 in the Runecrafting skill.	Reach level 110 Runecrafting.	110 Runecrafting	150	<0.1%
+1048	Global	Reach level 120 in the Dungeoneering skill.	Reach level 120 Dungeoneering.	120 Dungeoneering	150	<0.1%
+1049	Global	Reach level 120 in the Farming skill.	Reach level 120 Farming.	120 Farming	150	<0.1%
+1050	Global	Reach level 120 in the Herblore skill.	Reach level 120 Herblore.	120 Herblore	150	<0.1%
+1051	Global	Reach level 120 in the Slayer skill.	Reach level 120 Slayer.	120 Slayer	150	<0.1%
+1052	Global	Reach level 120 in the Invention skill.	Reach level 120 Invention.	120 Invention	150	<0.1%
+1053	Global	Reach level 120 in the Archaeology skill.	Reach level 120 Archaeology	120 Archaeology	150	<0.1%
+1054	Global	Reach level 120 in the Necromancy skill.	Reach level 120 Necromancy.	120 Necromancy	150	<0.1%
+1055	Global	Obtain 50 Million Agility XP.	Obtain 50 million Agility XP.	50,000,000 Agility XP	150	<0.1%
+1056	Global	Obtain 50 Million Construction XP.	Obtain 50 million Construction XP.	50,000,000 Construction XP	150	<0.1%
+1057	Global	Obtain 50 Million Cooking XP.	Obtain 50 million Cooking XP.	50,000,000 Cooking XP	150	<0.1%
+1058	Global	Obtain 50 Million Crafting XP.	Obtain 50 million Crafting XP.	50,000,000 Crafting XP	150	<0.1%
+1059	Global	Obtain 50 Million Farming XP.	Obtain 50 million Farming XP.	50,000,000 Farming XP	150	<0.1%
+1060	Global	Obtain 50 Million Firemaking XP.	Obtain 50 million Firemaking XP.	50,000,000 Firemaking XP	150	<0.1%
+1061	Global	Obtain 50 Million Fishing XP.	Obtain 50 million Fishing XP.	50,000,000 Fishing XP	150	<0.1%
+1062	Global	Obtain 50 Million Fletching XP.	Obtain 50 million Fletching XP.	50,000,000 Fletching XP	150	<0.1%
+1063	Global	Obtain 50 Million Herblore XP.	Obtain 50 million Herblore XP.	50,000,000 Herblore XP	150	<0.1%
+1064	Global	Obtain 50 Million Hunter XP.	Obtain 50 million Hunter XP.	50,000,000 Hunter XP	150	<0.1%
+1065	Global	Obtain 50 Million Mining XP.	Obtain 50 million Mining XP.	50,000,000 Mining XP	150	<0.1%
+1066	Global	Obtain 50 Million Prayer XP.	Obtain 50 million Prayer XP.	50,000,000 Prayer XP	150	<0.1%
+1067	Global	Obtain 50 Million Runecrafting XP.	Obtain 50 million Runecrafting XP.	50,000,000 Runecrafting XP	150	<0.1%
+1068	Global	Obtain 50 Million Slayer XP.	Obtain 50 million Slayer XP.	50,000,000 Slayer XP	150	<0.1%
+1069	Global	Obtain 50 Million Smithing XP.	Obtain 50 million Smithing XP.	50,000,000 Smithing XP	150	<0.1%
+1070	Global	Obtain 50 Million Thieving XP.	Obtain 50 million Thieving XP.	50,000,000 Thieving XP	150	<0.1%
+1071	Global	Obtain 50 Million Woodcutting XP.	Obtain 50 million Woodcutting XP.	50,000,000 Woodcutting XP	150	<0.1%
+1072	Global	Obtain 50 Million Dungeoneering XP.	Obtain 50 million Dungeoneering XP.	50,000,000 Dungeoneering XP	150	<0.1%
+1073	Global	Obtain 50 Million Invention XP.	Obtain 50 million Invention XP.	50,000,000 Invention XP	150	<0.1%
+1074	Global	Obtain 50 Million Divination XP.	Obtain 50 million Divination XP.	50,000,000 Divination XP	150	<0.1%
+1075	Global	Obtain 50 Million Archaeology XP.	Obtain 50 million Archaeology XP.	50,000,000 Archaeology XP	150	<0.1%
+1076	Global	Obtain 50 Million Attack XP.	Obtain 50 million Attack XP.	50,000,000 Attack XP	150	<0.1%
+1077	Global	Obtain 50 Million Constitution XP.	Obtain 50 million Constitution XP.	50,000,000 Constitution XP	150	<0.1%
+1078	Global	Obtain 50 Million Strength XP.	Obtain 50 million Strength XP.	50,000,000 Strength XP	150	<0.1%
+1079	Global	Obtain 50 Million Defence XP.	Obtain 50 million Defence XP.	50,000,000 Defence XP	150	<0.1%
+1080	Global	Obtain 50 Million Ranged XP.	Obtain 50 million Ranged XP.	50,000,000 Ranged XP	150	<0.1%
+1081	Global	Obtain 50 Million Magic XP.	Obtain 50 million Magic XP.	50,000,000 Magic XP	150	<0.1%
+1082	Global	Obtain 50 Million Summoning XP.	Obtain 50 million Summoning XP.	50,000,000 Summoning XP	150	<0.1%
+1083	Global	Obtain 50 Million Necromancy XP.	Obtain 50 million Necromancy XP.	50,000,000 Necromancy XP	150	<0.1%
+1084	Global	Complete 750 clues of any tier.	Complete 750 clues of any tier.	N/A	150	<0.1%
+1085	Global	Complete 1000 clues of any tier.	Complete 1000 clues of any tier.	N/A	150	<0.1%
+1086	Global	Make 5 Elder Overload Salve Potions.	Make 5 elder overload salves.	107 Herblore	150	<0.1%
+1087	Global	Equip an Eternal Magic shortbow.	Equip an eternal magic shortbow.	95 Ranged, 90 Defence	150	<0.1%
+1094	Global	Equip a full set of Primal armour.	Equip a full set of primal armour.	99 Smithing, 99 Defence	150	<0.1%
+1103	Global	Reach level 90 in any skill.	Reach level 90 in any skill.	Any skill at level 90	150	11.3%
+1104	Global	Reach level 95 in any skill.	Reach level 95 in any skill.	Any skill at level 95	150	2.1%
+1109	Global	Reach at least level 80 in all non-elite skills.	Reach at least level 80 in all non-elite skills.	All skills except Invention at level 80	150	<0.1%
+1110	Global	Reach at least level 90 in all non-elite skills.	Reach at least level 90 in all non-elite skills.	All skills except Invention at level 90	150	<0.1%
+447	Global	Help the Archivist recover all core memory data in the Hall of Memories.	Recover all core memory data in the Hall of Memories.	70 Divination	150	<0.1%
+448	Global	Attune and hand all engrams in to the Memorial to Guthix.	Hand all engrams in to the Memorial to Guthix.	82 Divination	150	<0.1%
+146	Global	Reach maximum total level.	Reach maximum total level.	Maximum total level	150	<0.1%
+963	Global	Complete 150 Master clue scrolls.	Complete 150 master clue scrolls.	N/A	150	<0.1%
+1088	Global	Work with Ramarno (in Camdozaal) to obtain a pickaxe of life and death.	Create a pickaxe of life and death.	99 Mining	150	<0.1%
+1089	Global	Have something planted and living in every farming patch.	Have something planted and living in every farming patch.	99 Farming	150	<0.1%
+1090	Global	Work with Ramarno (in Camdozaal) to obtain a hatchet of bloom and blight.	Create a hatchet of bloom and blight.	99 Woodcutting	150	<0.1%
+1091	Global	Equip any Masterwork weapon.	Equip any masterwork weapon.	92 Attack	150	<0.1%
+1092	Global	Equip a full set of Masterwork armour.	Equip a full set of masterwork armour.	99 Smithing, 92 Defence	150	<0.1%
+1093	Global	Unlock the Richie pet from helping Richie accumulate wealth at the Grand Exchange.	Donate 100,000,000 GP to Richie.	100,000,000 gp	150	<0.1%
+1095	Global	Obtain 200 Million XP in any single skill.	Obtain 200 Million XP in any single skill.	200,000,000 XP in any skill	150	<0.1%
+1096	Global	Fill all of the Treasure Trail hidey-holes. You can find a complete list of hidey-holes at the noticeboard by Zaida.	Fill all of the Treasure Trail hidey-holes.	Various	150	<0.1%
+1097	Global	Obtain a dye, or a piece of Third-age or Second-age gear from a clue scroll.	Obtain a dye, or a piece of Third-age or Second-age gear from a clue scroll.	N/A	150	<0.1%
+1111	Global	Reach at least level 95 in all non-elite skills.	Reach at least level 95 in all non-elite skills.	All skills except Invention at level 95	150	<0.1%
+403	Kandarin: Gnomes	Complete the Gnome Stronghold Agility Course.	Complete the Gnome Stronghold Agility Course.	1 Agility	10	39.8%
+404	Kandarin: Feldip Hills	Catch a Crimson Swift in the Feldip Hills.	Catch a crimson swift in the Feldip Hills.	1 Hunter	10	7.1%
+405	Kandarin: Ardougne	Defeat a Tortoise with riders in Kandarin.	Defeat a tortoise with riders in Kandarin.	N/A	10	29.3%
+406	Kandarin: Seers Village	Complete the quest: You Are It.	Complete You Are It.	See quest page	10	16.5%
+407	Kandarin: Gnomes	Let Brimstail teleport you to the Rune Essence mine.	Let Brimstail teleport you to the Rune Essence mine.	N/A	10	19.4%
+408	Kandarin: Feldip Hills	Equip a Marksman hat.	Equip a marksman hat.	125 chompy bird kills	10	<0.1%
+410	Kandarin: Ardougne	Learn how many beans make five (complete the Player Owned Farm tutorial).	Complete the player-owned farm tutorial at Manor Farm.	17 Farming, 20 Construction	10	39.2%
+412	Kandarin: Ardougne	Teleport to the Wilderness using the lever in Ardougne.	Pull the lever in Ardougne.	N/A	10	49%
+413	Kandarin: Yanille	Use a ring of duelling to teleport to Castle Wars.	Teleport to Castle Wars with a ring of duelling.	27 Magic, 27 Crafting	10	14.4%
+414	Kandarin: Gnomes	Make a Pineapple Punch cocktail.	Make a pineapple punch cocktail.	8 Cooking	10	7.4%
+415	Kandarin: Ardougne	Fletch 50 Maple shieldbow (unstrung) in Kandarin.	Fletch 50 unstrung maple shieldbows in Kandarin.	55 Fletching	30	15.5%
+416	Kandarin: Ardougne	Pickpocket a Knight of Ardougne 50 times.	Pickpocket a knight of Ardougne 50 times.	55 Thieving	30	13%
+417	Kandarin: Ardougne	Complete the Barbarian Outpost Agility Course.	Complete the Barbarian Outpost Agility Course.	35 Agility	30	5.7%
+419	Kandarin: Ardougne	Catch a red salamander from the Hunter area outside of Ourania Altar.	Catch a red salamander.	59 Hunter	30	1.9%
+420	Kandarin: Ardougne	Enter the Fishing Guild.	Enter the Fishing Guild.	68 Fishing	30	9.7%
+421	Kandarin: Gnomes	Check a grown Papaya Tree inside Tree Gnome Stronghold.	Check a grown papaya tree inside Tree Gnome Stronghold.	57 Farming	30	3.1%
+422	Kandarin: Ardougne	Kill a mithril dragon.	Defeat a mithril dragon.	N/A	30	2.9%
+423	Kandarin: Yanille	Enter the Magic Guild in Yanille.	Enter the Wizards' Guild.	66 Magic	30	11.8%
+424	Kandarin: Ardougne	Defeat a Fire Giant in Kandarin.	Defeat a fire giant in Kandarin.	N/A	30	17.4%
+425	Kandarin: Seers Village	Use the Chivalry Prayer.	Use the Chivalry prayer.	60 Prayer, 65 Defence	30	0.9%
+426	Kandarin: Yanille	Be on the winning side in a game of Castle Wars.	Win a game of Castle Wars.	N/A	30	0.2%
+427	Kandarin: Seers Village	Complete the quest: Elemental Workshop II.	Complete Elemental Workshop II.	See quest page	30	3.8%
+428	Kandarin: Feldip Hills	Equip an Ogre Forester Hat.	Equip an ogre forester hat.	300 chompy bird kills	30	<0.1%
+429	Kandarin: Ardougne	Complete the task set: Easy Ardougne.	Complete the Easy Ardougne achievements.	See Easy Ardougne achievements page	30	0.7%
+430	Kandarin: Gnomes	Create the listed gnome cocktails.	Make one of each type of cocktail.	37 Cooking	30	3.4%
+431	Kandarin: Ardougne	Earn a total amount of 10,000 beans.	Earn a total of 10,000 beans from selling animals in player-owned farm.	17 Farming	30	<0.1%
+434	Kandarin: Ardougne	Complete the task set: Medium Ardougne.	Complete the Medium Ardougne achievements.	See Medium Ardougne achievements page	30	<0.1%
+435	Kandarin: Ardougne	Throw coins into the deep sea whirlpool.	Throw some gold coins into the whirlpool at the Deep Sea Fishing platform.	68 Fishing	80	0.7%
+436	Kandarin: Ardougne	Solve the Archaeology mystery: Leap of Faith.	Solve the Leap of Faith Archaeology mystery.	70 Archaeology	80	1%
+437	Kandarin: Ardougne	Collect all breeds of chinchompa at the Player Owned Farm.	Breed all types of chinchompas.	54 Farming, 20 Construction	80	<0.1%
+438	Kandarin: Ardougne	Equip one piece of the Fishing outfit.	Equip one piece of the fishing outfit.	140 fishing tokens	80	0.1%
+439	Kandarin: Ardougne	Defeat the Penance Queen.	Defeat the Penance Queen.	N/A	80	<0.1%
+440	Kandarin: Ardougne	Pickpocket a Hero.	Pickpocket a hero.	80 Thieving	80	25.9%
+441	Kandarin: Ardougne	Catch 50 Red Chinchompas in Kandarin.	Catch 50 carnivorous chinchompas in Kandarin.	63 Hunter	80	0.4%
+442	Kandarin: Feldip Hills	Equip an Ogre Expert hat.	Equip an Ogre Expert hat.	1,000 chompy bird kills	80	<0.1%
+445	Kandarin: Seers Village	Use the Piety Prayer.	Use the Piety Prayer.	70 Prayer, 70 Defence	80	0.5%
+446	Kandarin: Ardougne	Complete the task set: Hard Ardougne.	Complete the Hard Ardougne achievements.	See Hard Ardougne achievements page	80	<0.1%
+449	Kandarin: Ardougne	Equip a dragon full helm.	Equip a dragon full helm.	60 Defence	150	<0.1%
+450	Kandarin: Ardougne	Chop an Elder Tree until it no longer has logs remaining.	Chop an elder tree until it no longer has logs remaining.	90 Woodcutting	150	<0.1%
+451	Kandarin: Ardougne	Obtain a Crystal Geode from a Crystal Tree.	Obtain a crystal geode from a crystal tree.	94 Farming	150	<0.1%
+452	Kandarin: Ardougne	Reach Howl's Workshop in the Stormguard Citadel.	Partial completion of the Howl's Floating Workshop mystery.	95 Archaeology	150	<0.1%
+453	Kandarin: Feldip Hills	Equip a Dragon Archer hat.	Equip a Dragon Archer hat.	2,000 chompy bird kills	150	<0.1%
+454	Kandarin: Ardougne	Complete the task set: Elite Ardougne.	Complete the Elite Ardougne achievements.	See Elite Ardougne achievements page	150	<0.1%
+455	Kandarin: Ardougne	Successfully breed a royal dragon.	Breed a royal dragon.	92 Farming	150	<0.1%
+457	Kandarin: Ardougne	Defeat an Automaton after 'The World Wakes'.	Defeat an automaton after The World Wakes.	N/A	150	<0.1%
+456	Kandarin: Feldip Hills	Equip an Expert Dragon Archer hat.	Equip an Expert Dragon Archer hat.	4,000 chompy bird kills	150	<0.1%
+458	Kandarin: Ardougne	Throw 100,000,000 gold coins into the Whirlpool at the Deep Sea Fishing platform.	Throw 100,000,000 gold coins into the Whirlpool at the Deep Sea Fishing platform.	68 Fishing	150	<0.1%
+572	Karamja	Collect 5 seaweed from anywhere on Karamja.	Collect 5 seaweed from anywhere on Karamja.	N/A	10	43.5%
+573	Karamja	Fill up Luthas' crate near the Musa Point plantation with bananas and receive 30 coins for your work.	Fill up Luthas' crate near the Banana plantation with bananas and talk to him to receive 30 coins for your work.	N/A	10	39.4%
+574	Karamja	Claim a ticket from Brimhaven Agility Arena.	Claim a ticket from Brimhaven Agility Arena.	1 Agility	10	23.9%
+575	Karamja	Kill a snake.	Kill a snake.	N/A	10	49.1%
+576	Karamja	Catch a Karambwanji.	Catch a raw karambwanji.	5 Fishing	10	21.2%
+577	Karamja	Be assigned a Slayer task in Shilo Village.	Be assigned a Slayer task in Shilo Village.	100 Combat, 50 Slayer	10	4.4%
+578	Karamja	Defeat a Greater Demon on Karamja.	Defeat a greater demon on Karamja.	N/A	10	27.2%
+579	Karamja	Pick a pineapple on Karamja.	Pick a pineapple on Karamja from the pineapple plants near the lodestone.	N/A	10	43.4%
+580	Karamja	Enter the Brimhaven Dungeon.	Enter the Brimhaven Dungeon.	875 coins	10	48.1%
+581	Karamja	Cross the spiky pit using the stepping stones within Brimhaven Dungeon.	Cross the spiky pit using the stepping stones within Brimhaven Dungeon.	12 Agility	10	37.3%
+582	Karamja	Complete the task set: Easy Karamja.	Complete the Easy Karamja achievements.	See Easy Karamja achievements page	30	9.2%
+583	Karamja	Craft 50 Nature runes.	Craft 50 nature runes.	44 Runecrafting	30	9.9%
+584	Karamja	Catch a salmon on Karamja.	Catch a salmon on Karamja.	30 Fishing	30	4.5%
+585	Karamja	Get Stiles to exchange some of your fish for bank notes.	Get Stiles to exchange some of your fish for bank notes.	N/A	30	23.8%
+586	Karamja	Convert 100 gleaming memories in an energy rift.	Convert 100 gleaming memories in an energy rift.	50 Divination	30	21.2%
+587	Karamja	Mine a drakolith rock in the Tai Bwo Wannai mine.	Mine a drakolith rock in the Tai Bwo Wannai mine.	60 Mining	30	33.8%
+588	Karamja	Mine a ruby from a gem rock in Shilo Village.	Mine a ruby from a gem rock in Shilo Village.	30 Mining	30	5.4%
+589	Karamja	Enter the Hardwood Grove in Tai Bwo Wannai.	Enter the Hardwood Grove in Tai Bwo Wannai.	Completion of Jungle Potion	30	3.5%
+590	Karamja	Complete the quest: Dragon Slayer.	Complete Dragon Slayer.	See quest page	30	22.9%
+591	Karamja	Check a grown banana tree on Karamja.	Check a grown banana tree on Karamja.	33 Farming	30	9%
+592	Karamja	Defeat a TzHaar.	Defeat a TzHaar.	N/A	30	36%
+593	Karamja	Equip an Obsidian cape.	Equip an obsidian cape.	N/A	30	2.2%
+594	Karamja	Kill a metal dragon in Brimhaven Dungeon.	Kill a metal dragon in Brimhaven Dungeon.	N/A	30	12.6%
+595	Karamja	Catch 25 lobsters on Karamja.	Catch 25 lobsters on Karamja.	40 Fishing	30	38.9%
+596	Karamja	Equip a Toktz-Ket-Xil.	Equip a Toktz-Ket-Xil.	60 Defence	30	0.8%
+597	Karamja	Equip a Tzhaar-Ket-Om.	Equip a Tzhaar-Ket-Om.	60 Strength	30	0.7%
+598	Karamja	Equip a Toktz-Xil-Ak.	Equip a Toktz-Xil-Ak.	60 Attack	30	0.4%
+599	Karamja	Equip a Toktz-Xil-Ek.	Equip a Toktz-Xil-Ek.	60 Attack	30	0.4%
+600	Karamja	Complete the task set: Medium Karamja.	Complete the Medium Karamja achievements.	See Medium Karamja achievements page	30	<0.1%
+601	Karamja	Use the stepping stone across the river in Shilo village.	Use the stepping stones Agility Shortcut in Shilo Village.	74 Agility	80	0.4%
+602	Karamja	Equip a full set of Obsidian armour.	Equip a full set of obsidian armour.	60 Defence, 80 Smithing	80	0.1%
+603	Karamja	Equip a Red Topaz Machete.	Equip a red topaz machete.	N/A	80	0.4%
+604	Karamja	Find a Gout Tuber.	Find a gout tuber.	10 Woodcutting	80	0.1%
+605	Karamja	Defeat TzTok-Jad.	Defeat TzTok-Jad once.	N/A	80	7.3%
+606	Karamja	Defeat TzTok-Jad. (25 times)	Defeat TzTok-Jad 25 times.	N/A	80	0.1%
+607	Karamja	Use your fire cape on TzTok-Jad before defeating them.	Use your fire cape on TzTok-Jad before defeating them.	N/A	80	0.4%
+608	Karamja	Equip a Fire Cape.	Equip a fire cape.	N/A	80	7.2%
+609	Karamja	Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.	Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.	60 Defence	80	<0.1%
+610	Karamja	Repair the fairy ring inside the Kharazi jungle.	Repair the fairy ring inside the Kharazi jungle.	Partial completion of Legends' Quest	80	<0.1%
+611	Karamja	Access the Gemstone cavern.	Access the gemstone cavern.	Hard Karamja achievements	80	0.1%
+612	Karamja	Catch a Draconic jadinko at Herblore Habitat.	Catch a draconic jadinko at Herblore Habitat.	80 Hunter	80	<0.1%
+613	Karamja	Craft a Bolas.	Craft a bolas.	87 Fletching, 80 Slayer	80	0.1%
+614	Karamja	Complete the task set: Hard Karamja.	Complete the Hard Karamja achievements.	See Hard Karamja achievements page	80	<0.1%
+615	Karamja	Collect 60 Agility Arena tickets from the Brimhaven Agility Arena.	Receive 60 Agility Arena tickets	N/A	80	0.7%
+617	Karamja	Defeat TzTok-Jad in less than 45:00.	Defeat TzTok-Jad in less than 45:00.	N/A	80	6.9%
+618	Karamja	Complete the Fight Kiln.	Complete the Fight Kiln.	Completion of The Elder Kiln	80	0.9%
+620	Karamja	Equip a TokHaar-Kal-Ket.	Equip a TokHaar-Kal-Ket.	Completion of The Elder Kiln	80	0.7%
+621	Karamja	Equip a TokHaar-Kal-Xil.	Equip a TokHaar-Kal-Xil.	Completion of The Elder Kiln	80	<0.1%
+622	Karamja	Equip a TokHaar-Kal-Mej.	Equip a TokHaar-Kal-Mej.	Completion of The Elder Kiln	80	<0.1%
+623	Karamja	Equip a TokHaar-Kal-Mor.	Equip a TokHaar-Kal-Mor.	Completion of The Elder Kiln	80	0.1%
+624	Karamja	Complete the Fight Kiln and collect an uncut onyx.	Complete the Fight Kiln and collect an uncut onyx.	Completion of The Elder Kiln	80	0.1%
+629	Karamja	Complete all TzTok-Jad combat achievements.	Complete all TzTok-Jad combat achievements.	See TzTok-Jad achievements page	80	<0.1%
+616	Karamja	Purchase an uncut onyx from Tzhaar-Hur-Lek's ore and gem store.	Purchase an uncut onyx from TzHaar-Hur-Lek's Ore and Gem Store.	N/A	150	<0.1%
+619	Karamja	Defeat the Har-Aken. (10 times)	Defeat Har-Aken 10 times.	Completion of The Elder Kiln	150	<0.1%
+625	Karamja	Defeat 10 gemstone dragons inside the Gemstone cavern.	Defeat 10 gemstone dragons inside the Gemstone cavern.	95 Slayer	150	<0.1%
+626	Karamja	Equip a piece of Gemstone armour.	Equip a piece of gemstone armour.	95 Slayer, 80 Defence, 80 Smithing	150	<0.1%
+627	Karamja	Complete the task set: Elite Karamja.	Complete the Elite Karamja achievements.	See Elite Karamja achievements page	150	<0.1%
+628	Karamja	Complete all Har-Aken combat achievements.	Complete all Har-Aken combat achievements.	See Har-Aken achievements page	150	<0.1%
+0	Misthalin: Lumbridge	Progress through the Leagues tutorial to unlock your first relic.	Progress through the Leagues tutorial to unlock your first relic.	N/A	10	100%
+2	Misthalin: Draynor Village	Climb to the top of the Wizards' Tower.	Climb to the top of the Wizards' Tower.	N/A	10	78.8%
+3	Misthalin: Draynor Village	Have Ned make you some rope from balls of wool.	Have Ned make you some rope from 4 balls of wool.	N/A	10	53%
+4	Misthalin: Draynor Village	Siphon from a fire essling in the Runespan.	Siphon from a fire essling in the Runespan.	14 Runecrafting	10	45.3%
+5	Misthalin: Draynor Village	Convert at least one pale memory into energy.	Convert at least one pale memory into energy.	1 Divination	10	68.7%
+15	Misthalin: Edgeville	Kill a mugger near the Edgeville lodestone.	Kill a mugger near the Edgeville lodestone.	N/A	10	71.7%
+16	Misthalin: Edgeville	Mine some coal in the centre of Barbarian village.	Mine some coal in the centre of Barbarian Village.	20 Mining	10	69.1%
+22	Misthalin: Fort Forinthry	Use the bank in the workshop at Fort Forinthry.	Use the bank in the workshop at Fort Forinthry.	N/A	10	52.4%
+27	Misthalin: Lumbridge	Kill a giant rat in Lumbridge Swamp.	Kill a giant rat in Lumbridge Swamp.	N/A	10	90.9%
+28	Misthalin: Lumbridge	Kill a goblin in Lumbridge.	Kill a goblin in Lumbridge.	N/A	10	94.7%
+29	Misthalin: Lumbridge	Kill a giant spider in Lumbridge or Lumbridge Swamp.	Kill a giant spider in Lumbridge or Lumbridge Swamp.	N/A	10	90.9%
+30	Misthalin: Lumbridge	Milk a cow.	Milk a cow.	A bucket	10	88.2%
+32	Misthalin: Lumbridge	Talk to Hans and find out how old you are.	Talk to Hans and find out how old you are.	N/A	10	90.7%
+33	Misthalin: Lumbridge	Complete the quest: The Blood Pact.	Complete The Blood Pact.	See quest page	10	79%
+35	Misthalin: Draynor Village	Catch some shrimp in the fishing spot to the east of Lumbridge Swamp.	Catch some shrimp in the fishing spot to the east of Lumbridge Swamp.	1 Fishing	10	84.8%
+36	Misthalin: Lumbridge	Smelt a steel bar in the furnace in Lumbridge.	Smelt a steel bar in the furnace in Lumbridge.	20 Smithing	10	63.1%
+37	Misthalin: Lumbridge	Cook some rat meat on a fire in Lumbridge Swamp.	Cook some rat meat on a campfire in Lumbridge Swamp.	1 Cooking	10	87.3%
+38	Misthalin: Lumbridge	Mine iron ore from the mining site south-west of Lumbridge Swamp.	Mine iron ore from the mining site south-west of Lumbridge Swamp.	10 Mining	10	84.7%
+39	Misthalin: Lumbridge	Craft a water rune at the Water Altar.	Craft a water rune at the Water altar.	5 Runecrafting	10	44.7%
+40	Misthalin: Lumbridge	Complete a task from Jacquelyn, the Lumbridge Slayer master.	Complete a task from Jacquelyn, the Lumbridge Slayer master.	1 Slayer	10	79%
+41	Misthalin: Lumbridge	Fill a Charmed Sack with corruption at the Nexus in Lumbridge Swamp.	Fill a charmed sack with corruption at the Nexus in Lumbridge Swamp.	1 Prayer	10	78.4%
+61	Misthalin: Draynor Village	Complete the quest: Necromancy!.	Complete Necromancy!	See quest page	10	70.2%
+62	Misthalin: City of Um	Upgrade a piece of Death Skull or Deathwarden equipment to tier 20.	Upgrade a piece of death skull or deathwarden equipment to tier 20.	20 Necromancy, 15 Smithing or 15 Crafting	10	27.3%
+63	Misthalin: City of Um	Craft some spirit or bone runes.	Craft some spirit or bone runes.	1 Runecrafting	10	24.1%
+64	Misthalin: City of Um	Complete a Lesser Necroplasm ritual.	Complete a Lesser Necroplasm ritual.	5 Necromancy	10	47.1%
+65	Misthalin: City of Um	Conjure a skeleton at the City of Um ritual site.	Conjure a Skeleton Warrior at the Um ritual site.	2 Necromancy	10	45.1%
+66	Misthalin: City of Um	Conjure a zombie at the City of Um ritual site.	Conjure a Putrid Zombie at the Um ritual site.	40 Necromancy	10	7.8%
+67	Misthalin: City of Um	Conjure a ghost at the City of Um ritual site.	Conjure a Vengeful Ghost at the Um ritual site.	40 Necromancy	10	9.2%
+94	Misthalin: Varrock	Kill a dark wizard.	Kill a dark wizard.	N/A	10	79.1%
+95	Misthalin: Varrock	Enter the Earth Altar using an earth tiara or talisman.	Enter the earth altar using an earth tiara or talisman.	1 Runecrafting	10	35%
+96	Misthalin: Varrock	Have Elsie tell you a story.	Have Elsie tell you a story, she is found upstairs in the church in Varrock. You must give her a cup of tea	A cup of tea	10	60.3%
+97	Misthalin: Varrock	Give a bone to one of Varrock's stray dogs (or to your pet stray dog if you have one).	Use some bones on one of Varrock's stray dogs (or to your pet stray dog if you have one).	N/A	10	69.8%
+98	Misthalin: Varrock	Claim a free clue scroll from Zaida at the Grand Exchange.	Claim a free clue scroll from Zaida at the Grand Exchange.	N/A	10	69.1%
+99	Misthalin: Fort Forinthry	Give Bill a beer in Fort Forinthry.	Give Bill a beer in Fort Forinthry.	A beer	10	29.1%
+100	Misthalin: Varrock	Complete the Archaeology tutorial.	Complete the Archaeology tutorial.	1 Archaeology	10	72.2%
+101	Misthalin: Fort Forinthry	Make a plank yourself on the sawmill in Fort Forinthry.	Make a plank yourself on the sawmill in Fort Forinthry.	1 Construction	10	45%
+102	Misthalin: Varrock	Mine some iron ore in the mining spot south-west of Varrock.	Mine some iron ore in the mining spot south-west of Varrock.	10 Mining	10	78.3%
+103	Misthalin: Varrock	Steal from the Varrock tea stall.	Steal from the Varrock tea stall.	5 Thieving	10	69.2%
+104	Misthalin: Varrock	Pan in the river at the Digsite.	This can only be completed after the point during The Dig Site quest where the panning guide teaches you how to pan for gold. You can then use the panning point. If you complete the quest without completing this achievement the task will be completed by attempting to pan with a panning tray in your inventory.	Partial completion of The Dig Site	10	12.6%
+184	Misthalin: Draynor Village	Harvest a memory from a pale wisp.	Harvest a pale memory from a pale wisp.	1 Divination	10	82.6%
+185	Misthalin: Draynor Village	Harvest 10 memories from a pale wisp.	Harvest 10 pale memories from a pale wisp.	1 Divination	10	81.8%
+1	Misthalin: Draynor Village	Kill the lesser demon in the Wizards' Tower.	Kill the lesser demon in the Wizards' Tower.	Cannot be attacked with short-range melee	30	57.7%
+6	Misthalin: Draynor Village	Hunt a yellow wizard in the RuneSpan and give them some items.	Hunt a yellow wizard in the Runespan and give them some items.	1 Runecrafting	30	28.3%
+7	Misthalin: Draynor Village	Use the Rune Goldberg Machine to create Vis wax.	Use the Rune Goldberg Machine to create vis wax.	50 Runecrafting	30	19.5%
+8	Misthalin: Draynor Village	Siphon from a nature esshound in the Runespan.	Siphon from a nature esshound in the Runespan.	44 Runecrafting	30	28.4%
+9	Misthalin: Draynor Village	Siphon Rune dust from a RuneSphere in the RuneSpan.	Siphon rune dust from a Runesphere in the RuneSpan.	1 Runecrafting	30	11.2%
+17	Misthalin: Edgeville	Fully complete the Stronghold of Player Safety.	Fully complete the Stronghold of Player Safety by pulling an old lever on the upper floor and then opening the treasure chest in the secure sector.	N/A	30	38.1%
+23	Misthalin: Fort Forinthry	Complete the quest: New Foundations.	Complete New Foundations.	See quest page	30	35.7%
+26	Misthalin: Lumbridge	Complete the task set: Beginner Lumbridge.	Given by Explorer Jack in Lumbridge for completing all Beginner Tasks in Lumbridge.	See Beginner Lumbridge achievements page	30	46.6%
+34	Misthalin: Draynor Village	Complete the quest: Duck Quest.	Complete Duck Quest.	See quest page	30	26.3%
+42	Misthalin: Lumbridge	Complete the task set: Easy Lumbridge.	Given by Bob, the axe seller in Lumbridge, for completing all Easy Tasks in Lumbridge.	See Easy Lumbridge achievements page	30	20.1%
+43	Misthalin: Lumbridge	Complete the task set: Medium Lumbridge.	Given by Ned in Draynor Village for completing all Medium Tasks in Lumbridge.	See Medium Lumbridge achievements page	30	6%
+44	Misthalin: Lumbridge	Drink from the Tears of Guthix.	Drink from the Tears of Guthix.	Completion of Tears of Guthix quest	30	3.9%
+45	Misthalin: Lumbridge	Complete world 25 in Shattered Worlds.	Reach world 25 in Shattered Worlds.	N/A	30	10.5%
+46	Misthalin: Lumbridge	Catch 20 implings in Puro-Puro.	Catch 20 implings in Puro-Puro.	17 Hunter	30	5.8%
+47	Misthalin: Lumbridge	Complete the quest: Sheep Shearer (miniquest).	Complete Sheep Shearer miniquest.	N/A	30	61.6%
+48	Misthalin: Lumbridge	Cut a willow tree east of Lumbridge Castle.	Cut the willow tree east of Lumbridge Castle, by the bridge across the River Lum.	20 Woodcutting	30	64%
+49	Misthalin: Lumbridge	Craft 50 Water Runes.	Craft 50 water runes.	5 Runecrafting	30	43.2%
+50	Misthalin: Lumbridge	Pickpocket a H.A.M. member.	Pickpocket a H.A.M. member.	15 Thieving	30	60.3%
+51	Misthalin: Lumbridge	Churn some butter.	Make a pat of butter by using a bucket of milk at a dairy churn	38 Cooking	30	24.5%
+52	Misthalin: Lumbridge	Craft 50 cosmic runes.	Craft 50 cosmic runes.	27 Runecrafting	30	7.6%
+53	Misthalin: Lumbridge	Steal a lantern from a cave goblin.	Steal a lantern from a cave goblin (only the ones in Dorgesh-Kaan have the lantern as a possible loot from pickpocketting).	36 Thieving	30	0.7%
+54	Misthalin: Lumbridge	Use the range in Lumbridge Castle to bake a cake.	Use the range in Lumbridge Castle to bake a cake.	40 Cooking	30	20.1%
+68	Misthalin: City of Um	Have either a Putrid Zombie or Vengeful Ghost conjured while fighting the matching creature.	Have either a Putrid Zombie or Vengeful Ghost conjured while fighting the matching creature.	40 Necromancy	30	9.7%
+69	Misthalin: City of Um	Learn how to craft moonstone jewellery.	Learn how to craft moonstone jewellery.	50 Necromancy	30	3.7%
+70	Misthalin: City of Um	Disgruntle an inhabitant of Um by wearing a bedsheet.	Disgruntle an inhabitant of Um by wearing a bedsheet, see Poor Imitation for NPCs which can be disgruntled.	Completion of Ghosts Ahoy quest, bedsheet	30	3.1%
+71	Misthalin: City of Um	Upgrade a piece of Death Skull or Deathwarden equipment to tier 50.	Upgrade a piece of Death Skull or Deathwarden equipment to tier 50.	20 Necromancy	30	12.8%
+72	Misthalin: City of Um	Complete a communion ritual using a memento.	Complete a communion ritual using a memento.	5 Necromancy	30	28.5%
+73	Misthalin: City of Um	Conjure a Phantom Guardian at the City of Um ritual site.	Conjure a Phantom Guardian at the Um ritual site.	70 Necromancy	30	4.2%
+74	Misthalin: City of Um	Complete the task set: Easy Underworld.	Complete the Easy Underworld achievements.	See Easy Underworld achievements page	30	19.4%
+84	Misthalin: City of Um	Complete the task set: Medium Underworld.	Complete the Medium Underworld achievements.	See Medium Underworld achievements page	30	4.7%
+105	Misthalin: Varrock	Complete the task set: Easy Varrock.	Given by Rat Burgiss south of Varrock for completing all Easy Tasks in Varrock.	See Easy Varrock achievements page	30	3.4%
+106	Misthalin: Varrock	Complete the task set: Medium Varrock.	Given by Reldo in Varrock Palace's library for completing all Medium Tasks in Varrock.	See Medium Varrock achievements page	30	<0.1%
+107	Misthalin: Edgeville	Browse through Oziach's Armour Shop.	Browse through Oziach's Armour Shop.	Completion of Dragon Slayer quest	30	20.4%
+108	Misthalin: Varrock	Enter the Cooks' Guild.	Enter the Cooks' Guild.	32 Cooking	30	37.9%
+109	Misthalin: Varrock	Complete the quest: Demon Slayer.	Complete Demon Slayer.	See quest page	30	41.2%
+110	Misthalin: Varrock	Complete the quest: Vampyre Slayer.	Complete Vampyre Slayer.	See quest page	30	45.4%
+111	Misthalin: Varrock	Mine 50 pure essence.	Mine 50 pure essence.	30 Mining	30	66.4%
+112	Misthalin: Varrock	Pickpocket a guard in Varrock Palace's courtyard.	Pickpocket a Varrock guard.	40 Thieving	30	30.2%
+113	Misthalin: Varrock	Gather and convert 50 bright memories.	Gather and convert 50 bright memories.	20 Divination	30	44.2%
+10	Misthalin: Draynor Village	Siphon from a death esswraith in the RuneSpan.	Siphon from a death esswraith in the RuneSpan.	66 Runecrafting	80	3.4%
+12	Misthalin: Draynor Village	Obtain the Massive Pouch from the RuneSpan.	Obtain the massive pouch from the RuneSpan.	90 Runecrafting	80	<0.1%
+14	Misthalin: Draynor Village	Equip the full Master Runecrafter skilling outfit.	Equip the full master runecrafter robes set.	50 Runecrafting	80	<0.1%
+18	Misthalin: Edgeville	Complete the task set: Hard Varrock.	Complete all of the Hard Varrock achievements and claim rewards from Vannaka in Edgeville.	See Hard Varrock achievements page	80	<0.1%
+19	Misthalin: Edgeville	Make a waka canoe near Edgeville.	Make a waka canoe near Edgeville.	57 Woodcutting	80	12.6%
+20	Misthalin: Edgeville	Chop down the Edgeville elder tree.	Chop down the Edgeville elder tree.	90 Woodcutting	80	0.1%
+24	Misthalin: Fort Forinthry	Upgrade the workshop in Fort Forinthry to Tier 3.	Upgrade the workshop in Fort Forinthry to tier 3.	75 Construction	80	0.1%
+31	Misthalin: Lumbridge	Enter Zanaris via Lumbridge Swamp.	Enter Zanaris via Lumbridge Swamp.	Partial completion of Lost City	80	16.8%
+55	Misthalin: Lumbridge	Complete the task set: Hard Lumbridge.	Complete all Hard Tasks in Lumbridge and claim rewards from Ned in Draynor Village.	See Hard Lumbridge achievements page	80	0.6%
+56	Misthalin: Lumbridge	Unlock the Bladed Dive ability from Shattered Worlds.	Unlock the Bladed Dive ability from Shattered Worlds.	63,000,000 shattered anima	80	0.1%
+57	Misthalin: Lumbridge	Smith a mithril platebody on the anvil in the jailhouse sewers.	Smith a mithril platebody on the anvil in Draynor Sewers.	30 Smithing	80	37.4%
+58	Misthalin: Lumbridge	Fully grow a magic tree in Lumbridge.	Fully grow a magic tree in Lumbridge.	75 Farming	80	0.6%
+75	Misthalin: City of Um	Defeat Hermod, the Spirit of War.	Defeat Hermod, the Spirit of War once.	Completion of The Spirit of War	80	<0.1%
+76	Misthalin: City of Um	Defeat Hermod, the Spirit of War. (100 times)	Defeat Hermod, the Spirit of War 100 times.	Completion of The Spirit of War	80	<0.1%
+77	Misthalin: City of Um	Rest whilst listening to the Dead Beats in the City of Um.	Rest whilst listening to the Dead Beats in the City of Um.	Completion of That Old Black Magic	80	<0.1%
+78	Misthalin: City of Um	Smelt a necronium bar at the smithy in the City of Um.	Smelt a necronium bar at the smithy in the City of Um.	70 Smithing	80	4%
+79	Misthalin: City of Um	Create a passing bracelet, performing each step in the City of Um.	Create a passing bracelet, performing each step in the City of Um.	60 Necromancy, 79 Crafting, 68 Magic	80	0.1%
+80	Misthalin: City of Um	Catch a ghostly impling while wearing a full set of ghostly robes.	Catch a ghostly impling while wearing a full set of ghostly robes.	68 Hunter	80	<0.1%
+81	Misthalin: City of Um	Upgrade a set of Death Skull equipment to tier 70.	Upgrade a set of Death Skull equipment to tier 70.	70 Necromancy	80	2.1%
+82	Misthalin: City of Um	Complete a Powerful Communion ritual.	Complete a powerful communion ritual.	90 Necromancy	80	0.2%
+83	Misthalin: City of Um	Conjure an undead army at the City of Um ritual site.	Conjure an undead army at the City of Um ritual site.	99 Necromancy	80	0.2%
+114	Misthalin: Varrock	Obtain a new set of Family Crest gauntlets from Dimintheis.	Obtain a new set of family gauntlets from Dimintheis.	Completion of Family Crest	80	0.3%
+115	Misthalin: Varrock	Talk to Romily Weaklax and give him a wild pie.	Talk to Romily Weaklax and give him a wild pie.	85 Cooking	80	<0.1%
+116	Misthalin: Varrock	Harness the power of three relics at once.	Activate 3 Archaeology relics at once	25 Archaeology	80	1.1%
+117	Misthalin: Varrock	Mine 50 Dark Animica from the Empty Throne Room.	Mine 50 dark animica from the Empty Throne Room.	90 Mining	80	5%
+118	Misthalin: Varrock	Defeat Kerapac, the bound.	Defeat Kerapac, the bound once.	N/A	80	1.7%
+120	Misthalin: Varrock	Defeat the Arch-Glacor.	Defeat the Arch-Glacor.	N/A	80	11.7%
+762	Misthalin: City of Um	Defeat Nakatra, Devourer Eternal.	Defeat Nakatra, Devourer Eternal.	Completion of Soul Searching	80	0.1%
+764	Misthalin: City of Um	Cleanse the Gate of Elidinis.	Cleanse the Gate of Elidinis.	Completion of Ode of the Devourer	80	10%
+766	Misthalin: City of Um	Complete the task set: Hard Underworld.	Complete the Hard Underworld achievements.	See Hard Underworld achievements page	80	<0.1%
+11	Misthalin: Draynor Village	Navigate the RuneSpan using a Greater Conjuration Platorm.	Navigate the RuneSpan using a greater conjuration platform.	81 Runecrafting	150	<0.1%
+13	Misthalin: Draynor Village	Obtain the Greater Runic Staff from the RuneSpan.	Obtain the greater runic staff from the RuneSpan.	75 Runecrafting	150	<0.1%
+21	Misthalin: Edgeville	Complete the task set: Elite Varrock.	Given by Vannaka in Edgeville for completing all of the Elite Varrock achievements.	See Elite Varrock achievements page	150	<0.1%
+25	Misthalin: Fort Forinthry	Upgrade the guardhouse in Fort Forinthry to Tier 3.	Upgrade the guardhouse in Fort Forinthry to tier 3.	77 Construction	150	<0.1%
+59	Misthalin: Lumbridge	Defeat 150 tormented demons.	Defeat 150 tormented demons.	Completion of While Guthix Sleeps	150	<0.1%
+60	Misthalin: Lumbridge	Equip a dragon crossbow.	Equip a dragon crossbow.	64 Ranged	150	<0.1%
+85	Misthalin: City of Um	Defeat Rasial, the First Necromancer.	Defeat Rasial, the First Necromancer once.	Completion of all Necromancy quests	150	<0.1%
+86	Misthalin: City of Um	Defeat Rasial, the First Necromancer. (100 times)	Defeat Rasial, the First Necromancer 100 times.	Completion of all Necromancy quests	150	<0.1%
+87	Misthalin: City of Um	Equip an Omni guard.	Equip an omni guard.	95 Necromancy	150	<0.1%
+88	Misthalin: City of Um	Equip a Soulbound lantern.	Equip a soulbound lantern	95 Necromancy	150	<0.1%
+89	Misthalin: City of Um	Equip a full set of Robes of the First Necromancer.	Equip a full set of First Necromancer's equipment.	95 Defence	150	<0.1%
+90	Misthalin: City of Um	Give a blueberry pie to Thalmund in the City of Um.	Give a blueberry pie to Thalmund in the City of Um.	30 Cooking	150	<0.1%
+91	Misthalin: City of Um	Track 8 of the owls in the City of Um.	Track 8 of the owls in the City of Um. See Birds of Prey for details.	Completion of all Necromancy quests	150	<0.1%
+92	Misthalin: Varrock	Defeat Croesus.	Defeat Croesus 1 time.	88 Woodcutting, 88 Mining, 88 Fishing, 88 Hunter	150	<0.1%
+93	Misthalin: Varrock	Defeat Croesus. (100 times)	Defeat Croesus 100 times.	88 Woodcutting, 88 Mining, 88 Fishing, 88 Hunter	150	<0.1%
+119	Misthalin: Varrock	Defeat Kerapac, the bound. (100 times)	Defeat Kerapac, the bound 100 times.	N/A	150	<0.1%
+121	Misthalin: Varrock	Defeat the Arch-Glacor in hard mode. (100 times)	Defeat the Arch-Glacor in hard mode 100 times.	N/A	150	<0.1%
+124	Misthalin: Varrock	Equip either a Dark Shard of Leng or a Dark Sliver of Leng.	Equip either a Dark Shard of Leng or a Dark Sliver of Leng.	92 Attack	150	<0.1%
+125	Misthalin: Varrock	Craft 100 earth runes simultaneously without aid from an explorer's ring, pouches or familiars.	Craft 100 earth runes simultaneously without aid from an explorer's ring, Runecrafting pouches or familiars.	99 Runecrafting	150	<0.1%
+126	Misthalin: Varrock	Bake a summer pie in the Cooking Guild from scratch.	Bake a summer pie in the Cooking Guild from scratch.	95 Cooking	150	<0.1%
+758	Misthalin: Varrock	Defeat TzKal-Zuk.	Defeat TzKal-Zuk once.	N/A	150	<0.1%
+759	Misthalin: Varrock	Defeat TzKal-Zuk. (10 times)	Defeat TzKal-Zuk 10 times.	N/A	150	<0.1%
+760	Misthalin: City of Um	Craft a soul rune at the soul altar with a soul cape equipped.	Craft a soul rune at the soul altar with a soul cape equipped.	90 Runecrafting	150	<0.1%
+761	Misthalin: City of Um	Upgrade a set of Death Skull equipment to tier 90.	Upgrade a set of Death Skull equipment to tier 90.	90 Necromancy	150	<0.1%
+763	Misthalin: City of Um	Defeat Nakatra, Devourer Eternal. (100 times)	Defeat Nakatra, Devourer Eternal 100 times.	Completion of Soul Searching	150	<0.1%
+765	Misthalin: City of Um	Cleanse the Gate of Elidinis. (100 times)	Cleanse The Gate of Elidinis 100 times.	Completion of Ode of the Devourer	150	<0.1%
+769	Misthalin: City of Um	Complete the task set: Elite Underworld.	Complete the Elite Underworld achievements.	See Elite Underworld achievements page	150	<0.1%
+1114	Misthalin: Fort Forinthry	Defeat Zemouregal & Vorkath.	Defeat Zemouregal & Vorkath.	N/A	150	<0.1%
+1115	Misthalin: Fort Forinthry	Defeat Zemouregal & Vorkath. (100 times)	Defeat Zemouregal & Vorkath 100 times.	N/A	150	<0.1%
+122	Misthalin: Varrock	Equip an Ek-ZekKil.	Equip an Ek-ZekKil.	95 Melee	150	<0.1%
+123	Misthalin: Varrock	Equip a Fractured Staff of Armadyl.	Equip a Fractured Staff of Armadyl.	95 Magic	150	<0.1%
+767	Misthalin: City of Um	Complete all Sanctum of Rebirth combat achievements.	Complete all Sanctum of Rebirth combat achievements.	See Sanctum of Rebirth achievements page	150	<0.1%
+768	Misthalin: City of Um	Complete all of Rasial, the First Necromancer's combat achievements.	Complete all of Rasial, the First Necromancer's combat achievements.	See Rasial, the First Necromancer achievements page	150	<0.1%
+1116	Misthalin: Varrock	Equip an igneous Kal-Zuk cape.	Equip an igneous Kal-Zuk cape.	99 Defence	150	<0.1%
+693	Morytania	Take an easy companion through an easy route of Temple Trekking.	Complete an Easy Temple Trek.	Completion of In Aid of the Myreque	10	0.6%
+694	Morytania	Craft your own snelm in Morytania.	Craft a snelm.	15 Crafting	10	25.2%
+695	Morytania	Defeat a Werewolf in Morytania.	Defeat a Werewolf in Morytania.	N/A	10	41.6%
+696	Morytania	Pass through the Holy barrier.	Pass through the Holy barrier.	Defeat a Ghoul (Paterdomus)	10	57.9%
+697	Morytania	Enter through the western gate of Port Phasmatys.	Pass through the western gate of Port Phasmatys.	N/A	10	9.9%
+698	Morytania	Activate the lodestone in Canifis.	Activate the Canifis lodestone.	Access to Morytania	10	57.5%
+699	Morytania	Kill anything on the ground floor of the Slayer Tower.	Kill anything on the ground floor of the Slayer Tower.	1 Slayer	10	40.5%
+700	Morytania	Using either a Silver Sickle or the Ivandis Flail, grow some fungus in the swamp using Bloom.	Cast Bloom using a blessed sickle or the Ivandis flail in Mort Myre Swamp.	18 Crafting	10	14%
+701	Morytania	Defeat 5 Feral Vampyres in the Haunted Woods.	Defeat 5 feral vampyres in the Haunted Woods.	Access to Morytania	10	35.2%
+702	Morytania	Use an ectophial to return to Port Phasmatys.	Use an ectophial to return to Port Phasmatys.	Completion of Ghosts Ahoy	10	13.2%
+703	Morytania	Visit Dragontooth Island by boat.	Visit Dragontooth Island by boat.	Ghostspeak amulet	10	16%
+704	Morytania	Complete the task set: Easy Morytania.	Complete the Easy Morytania achievements.	See Easy Morytania achievements page	30	0.1%
+705	Morytania	Take a medium companion through a medium route of Temple Trekking.	Take a medium companion through a medium route of Temple Trekking.	Completion of In Aid of the Myreque	30	0.3%
+706	Morytania	Visit Mos Le'Harmless.	Visit Mos Le'Harmless.	Partial completion of Cabin Fever	30	1.6%
+707	Morytania	Visit Harmony Island.	Visit Harmony Island.	Partial completion of The Great Brain Robbery	30	<0.1%
+708	Morytania	Visit the Everlight dig site.	Visit the Everlight dig site.	42 Archaeology	30	17.1%
+709	Morytania	Finish a game of Werewolf Skullball.	Finish a game of Werewolf Skullball.	25 Agility	30	0.4%
+710	Morytania	Defeat the six Barrows Brothers and loot their chest.	Defeat the six Barrows Brothers and loot their chest once.	N/A	30	17.6%
+711	Morytania	Defeat the six Barrows Brothers and loot their chest. (100 times)	Defeat the six Barrows Brothers and loot their chest 100 times.	N/A	30	0.1%
+712	Morytania	Equip a Barrows weapon.	Equip a barrows weapon.	70 Magic, 70 Attack, or 70 Ranged	30	3.2%
+713	Morytania	Equip a piece of Barrows armour.	Equip a piece of barrows armour.	70 Defence	30	7.6%
+714	Morytania	Equip a Salve Amulet (e).	Equip a salve amulet (e).	Completion of Lair of Tarn Razorlor (miniquest)	30	6.6%
+715	Morytania	Make a batch of cannonballs in Port Phasmatys.	Make a batch of cannonballs in Port Phasmatys.	35 Smithing	30	1%
+716	Morytania	Catch 10 Green salamanders.	Catch 10 Green salamanders.	29 Hunter	30	8.8%
+717	Morytania	Complete the quest: Haunted Mine.	Complete Haunted Mine.	See quest page	30	14%
+718	Morytania	Harvest bittercap mushrooms in the farming patch near Canifis.	Harvest bittercap mushrooms in the farming patch near Canifis.	53 Farming	30	5.7%
+719	Morytania	Complete the task set: Medium Morytania.	Complete the Medium Morytania achievements.	See Medium Morytania achievements page	30	<0.1%
+720	Morytania	Take a hard companion through a hard route of Temple Trekking.	Take a hard companion through a hard route of Temple Trekking.	Completion of In Aid of the Myreque	80	0.1%
+721	Morytania	Mine 30 Phasmatite.	Mine 30 phasmatite at Port Phasmatys south mine.	70 Mining	80	29.7%
+722	Morytania	Defeat 25 Gargoyles.	Defeat 25 gargoyles.	75 Slayer	80	2.4%
+723	Morytania	Defeat 35 Aberrant Spectres.	Defeat 35 aberrant spectres.	60 Slayer	80	7.1%
+724	Morytania	Equip a full set of Ahrim's equipment, including the staff.	Equip a full set of Ahrim's equipment, including the staff.	70 Defence, 70 Magic	80	<0.1%
+725	Morytania	Equip a full set of Dharok's equipment, including the greataxe.	Equip a full set of Dharok's equipment, including the greataxe.	70 Defence, 70 Attack	80	<0.1%
+726	Morytania	Equip a full set of Guthan's equipment, including the warspear.	Equip a full set of Guthan's equipment, including the Guthan's warspear.	70 Defence, 70 Attack	80	<0.1%
+727	Morytania	Equip a full set of Torag's equipment, including the hammer.	Equip a full set of Torag's equipment, including the hammer.	70 Defence, 70 Attack	80	<0.1%
+728	Morytania	Equip a full set of Verac's equipment, including the flail.	Equip a full set of Verac's equipment, including the flail.	70 Defence, 70 Attack	80	<0.1%
+729	Morytania	Equip a full set of Karil's equipment, including the 2h crossbow.	Equip a full set of Karil's equipment, including the 2h crossbow.	70 Defence, 70 Ranged	80	<0.1%
+730	Morytania	Complete the quest: The Branches of Darkmeyer.	Complete The Branches of Darkmeyer.	See quest page	80	0.1%
+731	Morytania	Burn 20 Blisterwood logs.	Burn 20 blisterwood logs.	76 Woodcutting, 76 Firemaking	80	<0.1%
+732	Morytania	Fully level up all Temple Trekking companions.	Fully level up all Temple Trekking companions.	Completion of In Aid of the Myreque	80	<0.1%
+733	Morytania	Catch 5 sharks in Burgh de Rott.	Catch 5 sharks in Burgh de Rott.	76 Fishing	80	<0.1%
+734	Morytania	Complete the task set: Hard Morytania.	Complete the Hard Morytania achievements.	See Hard Morytania achievements page	80	<0.1%
+735	Morytania	Defeat 30 Abyssal Demons.	Defeat 30 abyssal demons.	85 Slayer	150	0.2%
+736	Morytania	Harvest 200 radiant energy from Radiant Wisps.	Harvest 200 radiant energy from radiant wisps.	85 Divination	150	0.1%
+737	Morytania	Defeat 20 Celestial Dragons.	Defeat 20 celestial dragons.	Completion of One of a Kind	150	<0.1%
+738	Morytania	Defeat Araxxi.	Defeat Araxxi once.	N/A	150	<0.1%
+739	Morytania	Defeat Araxxi. (100 times)	Defeat Araxxi 100 times.	N/A	150	<0.1%
+740	Morytania	Defeat the empowered Barrows Brothers.	Complete one Rise of the Six encounter.	N/A	150	<0.1%
+741	Morytania	Defeat the empowered Barrows Brothers.	Complete 100 Rise of the Six encounters.	N/A	150	<0.1%
+742	Morytania	Equip a Noxious Scythe.	Equip a noxious scythe.	90 Attack	150	<0.1%
+743	Morytania	Equip a Noxious Staff.	Equip a noxious staff.	90 Magic	150	<0.1%
+744	Morytania	Equip a Noxious Bow.	Equip a noxious bow.	90 Ranged	150	<0.1%
+745	Morytania	Equip a full set of Linza's equipment, including the hammer and shield.	Equip a full set of Linza the Disgraced's equipment, including the hammer and shield.	80 Defence, 80 Attack	150	<0.1%
+746	Morytania	Equip a full set of Akrisae's equipment, including the war mace.	Equip a full set of Akrisae the Doomed's equipment, including the war mace.	80 Defence, 80 Attack	150	<0.1%
+747	Morytania	Equip a Malevolent Kiteshield.	Equip a malevolent kiteshield.	90 Defence	150	<0.1%
+748	Morytania	Equip a Merciless Kiteshield.	Equip a merciless kiteshield.	90 Defence	150	<0.1%
+749	Morytania	Equip a Vengeful Kiteshield.	Equip a vengeful kiteshield.	90 Defence	150	<0.1%
+750	Morytania	Complete all the Everlight mysteries.	Complete all of the Everlight Dig Site mysteries.	98 Archaeology	150	<0.1%
+751	Morytania	Obtain an Araxyte Pheremone drop.	Obtain an araxyte pheremone drop.	N/A	150	<0.1%
+752	Morytania	Complete the task set: Elite Morytania.	Complete the Elite Morytania achievements.	See Elite Morytania achievements page	150	<0.1%
+753	Morytania	Enter the Morytania Slayer Tower resource dungeon.	Enter the Morytania Slayer Tower resource dungeon.	95 Dungeoneering	150	<0.1%
+757	Morytania	Read the book acquired from Roberta outside the Everlight porcelain clay mine.	Read On the Origin of Centaurs.	42 Archaeology	150	<0.1%
+754	Morytania	Fully explore the history of the Everlight Dig Site.	Complete the Mastery - Everlight achievements.	98 Archaeology	150	<0.1%
+755	Morytania	Complete all Araxxor and Araxxi combat achievements.	Complete all Araxxor and Araxxi combat achievements.	See Araxxor achievements page	150	<0.1%
+756	Morytania	Complete the quest: River of Blood.	Complete River of Blood.	See quest page	150	<0.1%
+514	Elven Lands: Tirranwn	Cook a Rabbit in Tirannwn.	Cook a raw rabbit in Tirannwn.	1 Cooking	10	27.4%
+515	Elven Lands: Tirranwn	Attempt to pass a leaf trap.	Attempt to pass a leaf trap.	N/A	10	36.2%
+516	Elven Lands: Tirranwn	Use the Bank in Lletya.	Use the bank in Lletya.	N/A	10	33%
+517	Elven Lands: Tirranwn	Charter a ship from Port Tyras.	Charter a ship from Port Tyras.	N/A	10	25.2%
+518	Elven Lands: Tirranwn	Climb the Tower of Voices.	Climb the Tower of Voices.	N/A	10	34.4%
+519	Elven Lands: Tirranwn	Burn some logs using the everlasting bonfire in the Tower of Voices.	Burn some logs using the everlasting bonfire in the Tower of Voices.	1 Firemaking	10	38.1%
+520	Elven Lands: Tirranwn	Activate the lodestone in Prifddinas.	Activate the Prifddinas lodestone.	N/A	10	60.5%
+521	Elven Lands: Tirranwn	Activate the lodestone in Tirannwn.	Activate the Tirannwn lodestone.	N/A	10	37.1%
+522	Elven Lands: Tirranwn	Restore your prayer using the altar in Lletya.	Restore your prayer using the altar in Lletya.	1 Prayer	10	28.5%
+523	Elven Lands: Tirranwn	Complete the task set: Easy Tirannwn.	Complete the Easy Tirannwn achievements.	See Easy Tirannwn achievements page	30	<0.1%
+524	Elven Lands: Tirranwn	Check a grown Papaya Tree in Lletya.	Check a grown papaya tree in Lletya.	57 Farming	30	3.8%
+525	Elven Lands: Tirranwn	Craft 50 Death Runes.	Craft 50 death runes.	65 Runecrafting	30	1.4%
+526	Elven Lands: Tirranwn	Move your house to Prifddinas.	Move your player-owned house's location to Prifddinas by speaking to an estate agent.	75 Construction	30	1.2%
+527	Elven Lands: Tirranwn	Use an Elven Teleport Crystal.	Use a crystal teleport seed.	N/A	30	16%
+528	Elven Lands: Tirranwn	Equip Iban's staff.	Equip Iban's staff.	50 Magic	30	2.1%
+529	Elven Lands: Tirranwn	Catch 10 Pawyas in Isafdar.	Catch 10 pawyas in Isafdar.	66 Hunter	30	0.2%
+530	Elven Lands: Tirranwn	Mine 200 soft clay in Prifddinas.	Mine 200 soft clay in Prifddinas.	75 Mining	30	23.2%
+531	Elven Lands: Tirranwn	Use the fairy ring in the Amlodd district.	Use the fairy ring in the Amlodd district.	Partial completion of A Fairy Tale II - Cure a Queen	30	3.7%
+532	Elven Lands: Tirranwn	Complete the task set: Medium Tirannwn.	Complete the Medium Tirannwn achievements.	See Medium Tirannwn achievements page	30	<0.1%
+533	Elven Lands: Tirranwn	Plant a mushroom seed in the mushroom patch in Isafdar.	Plant a mushroom seed in the mushroom patch in Isafdar.	53 Farming	80	<0.1%
+534	Elven Lands: Tirranwn	Defeat 30 Cadarn warriors in Prifddinas.	Defeat 30 Cadarn warriors in Prifddinas.	N/A	80	4.4%
+535	Elven Lands: Tirranwn	Harvest some harmony moss from a harmony pillar.	Harvest some harmony moss from a harmony pillar.	75 Farming	80	1%
+536	Elven Lands: Tirranwn	Complete the Hefin Agility course with a light creature familiar summoned.	Complete the Hefin Agility course with a light creature familiar summoned.	77 Agility, 88 Summoning, 71 Divination	80	<0.1%
+537	Elven Lands: Tirranwn	Cleanse the Corrupted Seren stone with 5 cleansing crystals.	Cleanse the corrupted Seren stone with 5 cleansing crystals.	75 Prayer	80	3.9%
+538	Elven Lands: Tirranwn	Complete 10 laps of the Hefin agility course.	Complete 10 laps of the Hefin agility course.	77 Agility	80	4.4%
+539	Elven Lands: Tirranwn	Harvest 100 Incandescent energy from Incandescent Wisps.	Harvest 100 incandescent energy from incandescent wisps.	95 Divination	80	0.1%
+540	Elven Lands: Tirranwn	Equip a Dark bow.	Equip a dark bow.	90 Slayer, 70 Ranged, 70 Defence	80	0.1%
+541	Elven Lands: Tirranwn	Defeat 30 Dark beasts in Tirannwn.	Defeat 30 dark beasts in Tirannwn.	90 Slayer	80	0.8%
+542	Elven Lands: Tirranwn	Equip a Crystal halberd.	Equip a crystal halberd.	50 Agility, 70 Attack	80	6.4%
+543	Elven Lands: Tirranwn	Equip a Crystal shield.	Equip a crystal shield.	50 Agility, 70 Defence	80	1.4%
+544	Elven Lands: Tirranwn	Equip a Crystal bow.	Equip a crystal bow.	50 Agility, 70 Ranged	80	1%
+545	Elven Lands: Tirranwn	Catch 25 Grenwalls in Isafdar.	Catch 25 grenwalls in Isafdar.	77 Hunter	80	<0.1%
+546	Elven Lands: Tirranwn	Defeat 10 Elf warriors in Lletya.	Defeat 10 elf warriors in Lletya.	N/A	80	14.1%
+547	Elven Lands: Tirranwn	Chop 50 Magic logs in Tirannwn.	Chop 50 magic logs in Tirannwn.	80 Woodcutting	80	0.6%
+548	Elven Lands: Tirranwn	Open the crystal chest in Prifddinas 10 times.	Open the crystal chest in Prifddinas 10 times.	N/A	80	4.1%
+549	Elven Lands: Tirranwn	Charge a piece of Dragonstone jewellery using the Tears of Seren.	Charge a piece of dragonstone jewellery using the Tears of Seren.	Completion of Legends' Quest	80	<0.1%
+550	Elven Lands: Tirranwn	Complete the task set: Hard Tirannwn.	Complete the Hard Tirannwn achievements.	See Hard Tirannwn achievements page	80	<0.1%
+551	Elven Lands: Tirranwn	Enter the Gorajo Hoardstalker resource dungeon.	Enter the Gorajo Hoardstalker resource dungeon.	95 Dungeoneering	150	<0.1%
+552	Elven Lands: Tirranwn	Have Lady Ithell create a crystal pickaxe, hatchet, or mattock.	Have Lady Ithell create a crystal pickaxe, hatchet, or mattock.	70 Smithing, 70 Invention	150	<0.1%
+553	Elven Lands: Tirranwn	Find all of the memoriam crystals in Prifddinas.	Find all of the memoriam crystals in Prifddinas.	N/A	150	<0.1%
+554	Elven Lands: Tirranwn	Aid Lord Amlodd in cleansing shadow cores.	Complete the I'm Forever Washing Shadows achievement.	71 Divination	150	<0.1%
+555	Elven Lands: Tirranwn	Help Lady Ithell with crystal singing research.	Complete the Sing for the Lady achievement.	75 Smithing, 75 Crafting	150	<0.1%
+556	Elven Lands: Tirranwn	Aid Lady Trahaearn in removing some corruption by smelting 100 corrupted ore.	Complete the Uncorrupted Ore achievement.	75 Mining, 75 Smithing	150	<0.1%
+557	Elven Lands: Tirranwn	Check a grown Crystal Tree in the Tower of Voices.	Check a grown crystal tree in the Tower of Voices.	94 Farming	150	<0.1%
+558	Elven Lands: Tirranwn	Have 4 elven clans suspect you of thieving at the same time.	Have 4 elven clans suspect you of thieving at the same time. If you have the Five Finger Discount relic this task is completed when pickpocketing an elf.	75 Thieving	150	<0.1%
+559	Elven Lands: Tirranwn	Chop a log from an elder tree you have grown in the Prifddinas farming patch, then fletch it into a shortbow.	Chop a log from an elder tree you have grown in the Prifddinas farming patch, then fletch it into an elder shortbow.	90 Farming, 90 Woodcutting, 90 Fletching	150	<0.1%
+560	Elven Lands: Tirranwn	Catch a Crystal impling.	Catch a crystal impling.	80 Hunter	150	<0.1%
+561	Elven Lands: Tirranwn	Craft an Attuned crystal teleport seed.	Craft an attuned crystal teleport seed.	85 Crafting, 85 Smithing	150	<0.1%
+562	Elven Lands: Tirranwn	Mine 50 Light animica in Isafdar.	Mine 50 light animica in Isafdar.	90 Mining	150	<0.1%
+563	Elven Lands: Tirranwn	Chop 25 Elder logs in Tirannwn.	Chop 25 elder logs in Tirannwn.	90 Woodcutting	150	<0.1%
+564	Elven Lands: Tirranwn	Catch 75 Crystal skillchompas in Isafdar.	Catch 75 crystal skillchompas in Isafdar.	97 Hunter	150	<0.1%
+565	Elven Lands: Tirranwn	Complete the task set: Elite Tirannwn.	Complete the Elite Tirannwn achievements.	See Elite Tirannwn achievements page	150	<0.1%
+566	Elven Lands: Tirranwn	Complete a Seren symbol.	Create a Seren's symbol.	75 Farming, 75 Prayer	150	<0.1%
+567	Elven Lands: Tirranwn	Obtain the titles of the elven clans.	Obtain the titles of the elven clans.	Various	150	<0.1%
+568	Elven Lands: Tirranwn	Perform well enough in Rush of Blood to impress Morvran.	Complete the Make Them Bleed achievement.	N/A	150	<0.1%
+569	Elven Lands: Tirranwn	Reach inside the Motherlode Maw 5 times.	Reach inside the Motherlode Maw 5 times.	115 Dungeoneering	150	<0.1%
+570	Elven Lands: Tirranwn	Obtain 'the Elven' title by purchasing each of the elven clan capes.	Obtain the Elven title by purchasing each of the elven clan capes.	Various	150	<0.1%
+571	Elven Lands: Tirranwn	Obtain the 'Dark Lord' title by unlocking a selection of titles from Prifddinas.	Obtain the Dark Lord title by completing the Sort of Crystally achievement.	Various	150	<0.1%
+630	Wilderness: General	Use the bank at the Mage Arena.	Use the Mage Arena bank.	N/A	10	45.7%
+631	Wilderness: General	Defeat the Chaos Elemental.	Defeat the Chaos Elemental once.	N/A	10	19.3%
+632	Wilderness: General	Defeat the Chaos Elemental. (100 times)	Defeat the Chaos Elemental 100 times.	N/A	10	1.4%
+633	Wilderness: General	Reach a score of 10 using the strange switches in the Wilderness.	Reach a score of 10 using the strange switches in the Wilderness.	N/A	10	10.8%
+634	Wilderness: General	Jump over the Wilderness wall.	Jump over the Wilderness wall.	N/A	10	74.1%
+635	Wilderness: General	Activate the lodestone near the Wilderness Crater.	Activate the Wilderness Crater lodestone.	N/A	10	69.7%
+636	Wilderness: Daemonheim	Complete a Frozen floor in Daemonheim.	Complete a Frozen floor in Daemonheim.	1 Dungeoneering	10	34.4%
+637	Wilderness: Daemonheim	Make use of either an autoheater, gem bag, herbicide, bonecrusher or charming imp.	Make use of either an autoheater, gem bag, herbicide, bonecrusher or charming imp.	2000 dungeoneering token	10	50.6%
+638	Wilderness: General	Enter the chaos tunnels from an entrance in the Wilderness.	Enter the Chaos Tunnels from an entrance in the Wilderness.	N/A	10	43.2%
+639	Wilderness: General	Defeat a Black Unicorn in the Wilderness.	Defeat a black unicorn in the Wilderness.	N/A	10	54.6%
+640	Wilderness: General	Complete the task set: Easy Wilderness.	Complete the Easy Wilderness achievements.	See Easy Wilderness achievements page	30	8.5%
+641	Wilderness: General	Defeat the King Black Dragon.	Defeat the King Black Dragon once.	N/A	30	24.5%
+642	Wilderness: General	Defeat the King Black Dragon. (100 times)	Defeat the King Black Dragon 100 times.	N/A	30	0.4%
+643	Wilderness: General	Sacrifice Dragon bones on the Chaos Altar.	Sacrifice dragon bones on the chaos altar in the Wilderness.	1 Prayer	30	31.6%
+644	Wilderness: General	Cast the Claws of Guthix special attack.	Cast the Claws of Guthix special attack.	60 Magic	30	5.2%
+645	Wilderness: General	Defeat 5 Green dragons.	Defeat 5 green dragons.	N/A	30	31.5%
+646	Wilderness: General	Complete 10 laps of the Wilderness agility course.	Complete 10 laps of the Wilderness agility course.	52 Agility	30	17.1%
+647	Wilderness: General	Equip a Saradomin, Zamorak, or Guthix cape.	Equip a Saradomin, Zamorak, or Guthix cape.	60 Magic	30	8.9%
+648	Wilderness: General	Visit any Runecrafting altar through the Abyss.	Visit any Runecrafting altar through the Abyss.	Completion of Enter the Abyss (miniquest)	30	29%
+649	Wilderness: General	Defeat 10 Fetid Zombies.	Defeat 10 fetid zombies.	N/A	30	26.5%
+650	Wilderness: General	Defeat 20 Bound Skeletons.	Defeat 20 bound skeletons.	N/A	30	13.5%
+651	Wilderness: Daemonheim	Defeat the Rammernaut.	Defeat the Rammernaut.	35 Dungeoneering	30	1.8%
+652	Wilderness: General	Defeat Bossy McBoss Face.	Defeat Bossy McBoss Face.	N/A	30	2%
+653	Wilderness: General	Activate and teleport from each of the Wilderness teleport obelisks.	Activate and teleport from each of the Wilderness teleport obelisks.	N/A	30	10.2%
+654	Wilderness: General	Defeat Bossy McBossface's first mate.	Defeat Bossy McBossface's first mate.	N/A	30	1%
+655	Wilderness: General	Complete the task set: Medium Wilderness.	Complete the Medium Wilderness achievements.	See Medium Wilderness achievements page	30	0.7%
+656	Wilderness: General	Defeat the King Black Dragon while wearing black dragonhide in six equipment slots. Can only be completed in a solo instance.	Defeat the King Black Dragon while wearing black dragonhide in six equipment slots.	60 Defence	80	1.6%
+657	Wilderness: General	Defeat one of each revenant creature in the Forinthry dungeon.	Defeat one of each revenant creature in the Forinthry dungeon.	N/A	80	2.1%
+658	Wilderness: General	Equip a Statius's warhammer.	Equip a Statius's warhammer.	78 Attack	80	<0.1%
+659	Wilderness: General	Catch 25 Black Salamanders.	Catch 25 black salamanders.	67 Hunter	80	0.4%
+660	Wilderness: Daemonheim	Restore an artefact from the Daemonheim digsite.	Restore an artefact from the Daemonheim digsite.	73 Archaeology	80	0.7%
+661	Wilderness: General	Defeat the Corporeal Beast.	Defeat the Corporeal Beast once.	Completion of Summer's End	80	<0.1%
+662	Wilderness: General	Defeat the Corporeal Beast. (100 times)	Defeat the Corporeal Beast 100 times.	Completion of Summer's End	80	<0.1%
+663	Wilderness: Daemonheim	Defeat the Skeletal Trio.	Defeat the Skeletal Trio.	71 Dungeoneering	80	0.4%
+664	Wilderness: Daemonheim	Upgrade your Gem bag.	Upgrade your gem bag.	40 Dungeoneering, 45 Crafting	80	0.4%
+665	Wilderness: General	Equip a pair of Steadfast boots.	Equip a pair of steadfast boots.	85 Defence	80	<0.1%
+666	Wilderness: General	Equip a pair of Glaiven boots.	Equip a pair of glaiven boots.	85 Defence	80	<0.1%
+667	Wilderness: General	Equip a pair of Ragefire boots.	Equip a pair of ragefire boots.	85 Defence	80	<0.1%
+668	Wilderness: General	Complete the task set: Hard Wilderness.	Complete the Hard Wilderness achievements.	See Hard Wilderness achievements page	80	<0.1%
+678	Wilderness: Daemonheim	Equip a Chaotic weapon or kiteshield.	Equip a chaotic weapon or kiteshield.	80 Dungeoneering, 80 Attack OR 80 Ranged OR 80 Magic OR 80 Defence	80	0.1%
+669	Wilderness: General	Equip the Hellfire bow.	Equip the hellfire bow.	N/A	150	<0.1%
+670	Wilderness: General	Complete a slayer task from Mandrith.	Complete a slayer task from Mandrith.	N/A	150	<0.1%
+671	Wilderness: General	Chop 20 Bloodwood logs in the Wilderness.	Chop 20 bloodwood logs in the Wilderness.	85 Woodcutting	150	<0.1%
+672	Wilderness: General	Unlock the Greater Flurry, Barge, and Fury abilities.	Unlock the Greater Flurry, Barge, and Fury abilities.	Various	150	<0.1%
+673	Wilderness: General	Crack 6 safes inside the Rogues' Castle.	Crack 6 safes inside the Rogues' Castle.	62 Thieving	150	<0.1%
+674	Wilderness: General	Defeat 5 Ripper Demons.	Defeat 5 ripper demons.	96 Slayer	150	<0.1%
+675	Wilderness: General	Defeat 10 Lava Strykewyrms in the Wilderness, south of the Lava Maze.	Defeat 10 lava strykewyrms in the Wilderness, south of the Lava Maze.	94 Slayer	150	<0.1%
+676	Wilderness: General	Equip Annihilation, Decimation, or Obliteration.	Equip Annihilation, Decimation, or Obliteration.	87 Attack, 87 Ranged, 87 Magic	150	<0.1%
+677	Wilderness: Daemonheim	Kill Blink in a solo Dungeoneering instance, without dying.	Kill Blink in a solo Dungeoneering instance without dying.	117 Dungeoneering	150	<0.1%
+679	Wilderness: General	Defeat every miniboss inside the Dragonkin Laboratory.	Defeat every miniboss inside the Dragonkin Laboratory.	95 Dungeoneering	150	<0.1%
+680	Wilderness: General	Defeat the Black Stone Dragon.	Defeat the black stone dragon once.	N/A	150	<0.1%
+681	Wilderness: General	Defeat the Black Stone Dragon. (25 times)	Defeat the black stone dragon 25 times.	N/A	150	<0.1%
+682	Wilderness: General	Complete the task set: Elite Wilderness.	Complete the Elite Wilderness achievements.	See Elite Wilderness achievements page	150	<0.1%
+683	Wilderness: General	Defeat 25 Hydrix dragons in the Wilderness.	Defeat 25 hydrix dragons in the Wilderness.	101 Slayer	150	<0.1%
+684	Wilderness: General	Defeat 10 Abyssal lords in the Wilderness.	Defeat 10 abyssal lords in the Wilderness.	115 Slayer	150	<0.1%
+685	Wilderness: Daemonheim	Mine 30 Primal ores.	Mine 30 primal ores.	99 Mining	150	<0.1%
+686	Wilderness: Daemonheim	Smelt 150 Primal bars.	Smelt 150 primal bars.	99 Smithing	150	<0.1%
+687	Wilderness: Daemonheim	Defeat Kal'Ger the Warmonger.	Defeat Kal'Ger the Warmonger.	90 Dungeoneering	150	<0.1%
+689	Wilderness: General	Defeat the Ambassador.	Defeat the Ambassador once.	N/A	150	<0.1%
+690	Wilderness: General	Defeat the Ambassador. (25 times)	Defeat the Ambassador 25 times.	N/A	150	<0.1%
+691	Wilderness: General	Equip a Spectral, Arcane, Elysian, or Divine spirit shield.	Equip a spectral, arcane, Elysian, or divine spirit shield.	75 Defence, 75 Prayer	150	<0.1%
+692	Wilderness: General	Defeat the Ambassador after allowing 4 unstable black holes to explode.	Defeat the Ambassador after allowing 4 unstable black holes to explode.	N/A	150	<0.1%
+688	Wilderness: General	Equip an Eldritch Crossbow.	Equip an eldritch crossbow.	92 Ranged	150	<0.1%

--- a/tasks.json
+++ b/tasks.json
@@ -1,6 +1,7 @@
 [
   {
     "id": 0,
+    "taskId": 462,
     "locality": "Anachronia",
     "task": "Complete the base camp tutorial on Anachronia.",
     "information": "Complete the Anachronia base camp tutorial.",
@@ -9,6 +10,7 @@
   },
   {
     "id": 1,
+    "taskId": 463,
     "locality": "Anachronia",
     "task": "Observe all the large dragonkin statues around Anachronia.",
     "information": "Observe all the large dragonkin statues around Anachronia.",
@@ -17,6 +19,7 @@
   },
   {
     "id": 2,
+    "taskId": 464,
     "locality": "Anachronia",
     "task": "Surge under the spine on Anachronia.",
     "information": "Complete Spinal Surgery.",
@@ -25,6 +28,7 @@
   },
   {
     "id": 3,
+    "taskId": 461,
     "locality": "Anachronia",
     "task": "Set sail for Anachronia.",
     "information": "Set sail for Anachronia on The Stormbreaker docked at Varrock Dig Site.",
@@ -33,6 +37,7 @@
   },
   {
     "id": 4,
+    "taskId": 465,
     "locality": "Anachronia",
     "task": "Complete the quest: Helping Laniakea (miniquest).",
     "information": "Complete the Helping Laniakea miniquest.",
@@ -41,6 +46,7 @@
   },
   {
     "id": 5,
+    "taskId": 466,
     "locality": "Anachronia",
     "task": "Complete the quest: Raksha, the Shadow Colossus.",
     "information": "Complete Raksha, the Shadow Colossus quest.",
@@ -49,6 +55,7 @@
   },
   {
     "id": 6,
+    "taskId": 467,
     "locality": "Anachronia",
     "task": "Obtain 100 potent herbs from Herby Werby.",
     "information": "Obtain 100 potent herbs from Herby Werby.",
@@ -57,1784 +64,7 @@
   },
   {
     "id": 7,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Complete a lap of the Burthorpe Agility course.",
-    "information": "Complete a lap of the Burthorpe Agility Course.",
-    "requirements": "1 Agility",
-    "points": 10
-  },
-  {
-    "id": 8,
-    "locality": "Asgarnia: Falador",
-    "task": "Kill a goblin raider boss in the Goblin Village.",
-    "information": "Kill 15 goblins in the Goblin Village to spawn a Goblin raider boss.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 9,
-    "locality": "Asgarnia: Falador",
-    "task": "Complete the quest: Witch's House.",
-    "information": "Complete Witch's House",
-    "requirements": "See quest page",
-    "points": 10
-  },
-  {
-    "id": 10,
-    "locality": "Asgarnia: Falador",
-    "task": "Sit down with Tiffy in Falador park.",
-    "information": "Sit on the bench with Sir Tiffy Cashien in Falador Park.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 11,
-    "locality": "Asgarnia: Falador",
-    "task": "Pray to Bandos's remains.",
-    "information": "Pray to Bandos's remains (just south-east of Goblin Village.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 12,
-    "locality": "Asgarnia: Falador",
-    "task": "Dance in the Falador party room.",
-    "information": "Dance in the Falador party room.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 13,
-    "locality": "Asgarnia: Port Sarim",
-    "task": "Give Thurgo a redberry pie.",
-    "information": "Give Thurgo a redberry pie.",
-    "requirements": "10 Cooking, Partial completion of The Knight's Sword",
-    "points": 10
-  },
-  {
-    "id": 14,
-    "locality": "Asgarnia: Taverley",
-    "task": "Build a God statue in Taverley.",
-    "information": "Build a God statue in Taverley.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 15,
-    "locality": "Desert: Menaphos",
-    "task": "Enter Menaphos.",
-    "information": "Enter Menaphos.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 16,
-    "locality": "Desert: General",
-    "task": "Catch a whirligig at Het's Oasis.",
-    "information": "Catch a whirligig at Het's Oasis.",
-    "requirements": "1 Hunter",
-    "points": 10
-  },
-  {
-    "id": 17,
-    "locality": "Desert: General",
-    "task": "Search the Grand Gold Chest in room 1 of Pyramid Plunder in Sophanem.",
-    "information": "Search the grand gold chest in room 1 of Pyramid Plunder in Sophanem.",
-    "requirements": "21 Thieving, Partial completion of Icthlarin's Little Helper",
-    "points": 10
-  },
-  {
-    "id": 18,
-    "locality": "Desert: General",
-    "task": "Search the Grand Gold Chest in room 2 of Pyramid Plunder in Sophanem.",
-    "information": "Search the grand gold chest in room 2 of Pyramid Plunder in Sophanem.",
-    "requirements": "31 Thieving, Partial completion of Icthlarin's Little Helper",
-    "points": 10
-  },
-  {
-    "id": 19,
-    "locality": "Desert: General",
-    "task": "Search the Grand Gold Chest in room 3 of Pyramid Plunder in Sophanem.",
-    "information": "Search the grand gold chest in room 3 of Pyramid Plunder in Sophanem.",
-    "requirements": "41 Thieving, Partial completion of Icthlarin's Little Helper",
-    "points": 10
-  },
-  {
-    "id": 20,
-    "locality": "Desert: General",
-    "task": "Mine a gem rock at the Al Kharid mine.",
-    "information": "Mine a gem rock at the Al Kharid mine. A common gem rock can be mined with level 1 Mining.",
-    "requirements": "1 Mining",
-    "points": 10
-  },
-  {
-    "id": 21,
-    "locality": "Desert: General",
-    "task": "Kill a crocodile.",
-    "information": "Kill a crocodile.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 22,
-    "locality": "Desert: General",
-    "task": "Create a spirit kalphite pouch at the obelisk south west of Pollnivneach.",
-    "information": "Create a spirit kalphite pouch at the obelisk south west of Pollnivneach.",
-    "requirements": "25 Summoning, A pouch, 51 spirit shards, a blue charm, and a potato cactus",
-    "points": 10
-  },
-  {
-    "id": 23,
-    "locality": "Desert: Menaphos",
-    "task": "Squish 10 corrupted scarabs.",
-    "information": "Squish 10 corrupted scarabs.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 24,
-    "locality": "Desert: General",
-    "task": "Sell a pyramid top to Simon.",
-    "information": "Hand Simon Templeton a pyramid top.",
-    "requirements": "30 Agility",
-    "points": 10
-  },
-  {
-    "id": 25,
-    "locality": "Desert: General",
-    "task": "Use any of the magic carpets in the desert.",
-    "information": "Use any of the magic carpets in the desert.",
-    "requirements": "1,000",
-    "points": 10
-  },
-  {
-    "id": 26,
-    "locality": "Desert: General",
-    "task": "Harvest a rose at Het's Oasis.",
-    "information": "Harvest a rose at Het's Oasis.",
-    "requirements": "30 Farming",
-    "points": 10
-  },
-  {
-    "id": 27,
-    "locality": "Fremennik: Lunar Isles",
-    "task": "Switch to the Lunar Spellbook at the astral altar.",
-    "information": "Switch to the Lunar Spellbook at the astral altar.",
-    "requirements": "Completion of Lunar Diplomacy",
-    "points": 10
-  },
-  {
-    "id": 28,
-    "locality": "Fremennik: Mainland",
-    "task": "Defeat a Rock Crab in the Fremennik Province.",
-    "information": "Defeat a Rock Crab in the Fremennik Province.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 29,
-    "locality": "Fremennik: Mainland",
-    "task": "Defeat a Cockatrice in the Fremennik Province.",
-    "information": "Defeat a cockatrice in the Fremennik Province.",
-    "requirements": "25 Slayer, A mirror shield",
-    "points": 10
-  },
-  {
-    "id": 30,
-    "locality": "Fremennik: Mainland",
-    "task": "Defeat a Troll in the Fremennik Province.",
-    "information": "Defeat a troll in the Fremennik Province.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 31,
-    "locality": "Fremennik: Mainland",
-    "task": "Deposit an item with Peer the Seer.",
-    "information": "Deposit an item with Peer the Seer.",
-    "requirements": "Completion of the easy Fremennik achievements",
-    "points": 10
-  },
-  {
-    "id": 32,
-    "locality": "Fremennik: Mainland",
-    "task": "Use the Bank on Jatizso or Neitiznot.",
-    "information": "Use the Bank on Jatizso or Neitiznot.",
-    "requirements": "Partial completion of The Fremennik Isles",
-    "points": 10
-  },
-  {
-    "id": 33,
-    "locality": "Fremennik: Mainland",
-    "task": "Catch a Sapphire Glacialis.",
-    "information": "Catch a Sapphire Glacialis.",
-    "requirements": "25 Hunter, A butterfly net and jar",
-    "points": 10
-  },
-  {
-    "id": 34,
-    "locality": "Global",
-    "task": "Level up any of your skills for the first time.",
-    "information": "Level up any of your skills for the first time.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 35,
-    "locality": "Global",
-    "task": "Reach level 5 in any skill.",
-    "information": "Reach level 5 in any skill.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 36,
-    "locality": "Global",
-    "task": "Reach level 10 in any skill.",
-    "information": "Reach level 10 in any skill.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 37,
-    "locality": "Global",
-    "task": "Reach level 20 in any skill.",
-    "information": "Reach level 20 in any skill.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 38,
-    "locality": "Global",
-    "task": "Reach combat level 5.",
-    "information": "Reach combat level 5.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 39,
-    "locality": "Global",
-    "task": "Reach combat level 10.",
-    "information": "Reach combat level 10.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 40,
-    "locality": "Global",
-    "task": "Reach total level 50.",
-    "information": "Reach total level 50.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 41,
-    "locality": "Global",
-    "task": "Reach total level 100.",
-    "information": "Reach total level 100.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 42,
-    "locality": "Global",
-    "task": "Mine a copper ore.",
-    "information": "Mine copper ore from a copper rock.",
-    "requirements": "1 Mining",
-    "points": 10
-  },
-  {
-    "id": 43,
-    "locality": "Global",
-    "task": "Mine 10 copper ore.",
-    "information": "Mine 10 copper ore.",
-    "requirements": "1 Mining",
-    "points": 10
-  },
-  {
-    "id": 44,
-    "locality": "Global",
-    "task": "Mine a tin ore.",
-    "information": "Mine tin ore from a tin rock.",
-    "requirements": "1 Mining",
-    "points": 10
-  },
-  {
-    "id": 45,
-    "locality": "Global",
-    "task": "Mine 10 tin ore.",
-    "information": "Mine 10 tin ore.",
-    "requirements": "1 Mining",
-    "points": 10
-  },
-  {
-    "id": 46,
-    "locality": "Global",
-    "task": "Smelt a bronze bar.",
-    "information": "Smelt a bronze bar.",
-    "requirements": "1 Smithing",
-    "points": 10
-  },
-  {
-    "id": 47,
-    "locality": "Global",
-    "task": "Smelt 10 bronze bars.",
-    "information": "Smelt 10 bronze bars.",
-    "requirements": "1 Smithing",
-    "points": 10
-  },
-  {
-    "id": 48,
-    "locality": "Global",
-    "task": "Smith any bronze item.",
-    "information": "Smith any bronze item.",
-    "requirements": "1 Smithing",
-    "points": 10
-  },
-  {
-    "id": 49,
-    "locality": "Global",
-    "task": "Mine clay.",
-    "information": "Mine clay.",
-    "requirements": "1 Mining",
-    "points": 10
-  },
-  {
-    "id": 50,
-    "locality": "Global",
-    "task": "Make some soft clay.",
-    "information": "Make soft clay by using clay on a water source or with a container of water",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 51,
-    "locality": "Global",
-    "task": "Mine any ore 5 times.",
-    "information": "Mine any ore 5 times.",
-    "requirements": "1 Mining",
-    "points": 10
-  },
-  {
-    "id": 52,
-    "locality": "Global",
-    "task": "Chop any tree 5 times.",
-    "information": "Chop any tree 5 times.",
-    "requirements": "1 Woodcutting",
-    "points": 10
-  },
-  {
-    "id": 53,
-    "locality": "Global",
-    "task": "Chop a basic tree.",
-    "information": "Chop a basic tree.",
-    "requirements": "1 Woodcutting",
-    "points": 10
-  },
-  {
-    "id": 54,
-    "locality": "Global",
-    "task": "Chop 10 basic trees.",
-    "information": "Chop 10 basic trees.",
-    "requirements": "1 Woodcutting",
-    "points": 10
-  },
-  {
-    "id": 55,
-    "locality": "Global",
-    "task": "Chop an oak tree.",
-    "information": "Chop an oak tree.",
-    "requirements": "10 Woodcutting",
-    "points": 10
-  },
-  {
-    "id": 56,
-    "locality": "Global",
-    "task": "Burn any logs.",
-    "information": "Burn any logs.",
-    "requirements": "1 Firemaking",
-    "points": 10
-  },
-  {
-    "id": 57,
-    "locality": "Global",
-    "task": "Burn any logs 5 times.",
-    "information": "Burn any logs 5 times.",
-    "requirements": "1 Firemaking",
-    "points": 10
-  },
-  {
-    "id": 58,
-    "locality": "Global",
-    "task": "Catch a shrimp.",
-    "information": "Catch a raw shrimp.",
-    "requirements": "1 Fishing",
-    "points": 10
-  },
-  {
-    "id": 59,
-    "locality": "Global",
-    "task": "Catch 10 shrimp.",
-    "information": "Catch 10 raw shrimps.",
-    "requirements": "1 Fishing",
-    "points": 10
-  },
-  {
-    "id": 60,
-    "locality": "Global",
-    "task": "Catch an anchovy.",
-    "information": "Catch a raw anchovy.",
-    "requirements": "15 Fishing",
-    "points": 10
-  },
-  {
-    "id": 61,
-    "locality": "Global",
-    "task": "Catch a herring.",
-    "information": "Catch a raw herring.",
-    "requirements": "10 Fishing",
-    "points": 10
-  },
-  {
-    "id": 62,
-    "locality": "Global",
-    "task": "Cook shrimp, meat, or chicken.",
-    "information": "Cook raw shrimps, raw meat, or raw chicken.",
-    "requirements": "1 Cooking",
-    "points": 10
-  },
-  {
-    "id": 63,
-    "locality": "Global",
-    "task": "Cook 10 shrimp, meat, or chicken.",
-    "information": "Cook 10 raw shrimps, raw meat, or raw chicken.",
-    "requirements": "1 Cooking",
-    "points": 10
-  },
-  {
-    "id": 64,
-    "locality": "Global",
-    "task": "Burn any food.",
-    "information": "Burn any food.",
-    "requirements": "1 Cooking",
-    "points": 10
-  },
-  {
-    "id": 65,
-    "locality": "Global",
-    "task": "Catch any fish 5 times.",
-    "information": "Catch any fish 5 times.",
-    "requirements": "1 Fishing",
-    "points": 10
-  },
-  {
-    "id": 66,
-    "locality": "Global",
-    "task": "Bury any bones.",
-    "information": "Bury any bones.",
-    "requirements": "1 Prayer",
-    "points": 10
-  },
-  {
-    "id": 67,
-    "locality": "Global",
-    "task": "Bury any bones 10 times.",
-    "information": "Bury any bones 10 times.",
-    "requirements": "1 Prayer",
-    "points": 10
-  },
-  {
-    "id": 68,
-    "locality": "Global",
-    "task": "Activate the thick skin, rock skin, or steel skin Prayer.",
-    "information": "Activate the Thick Skin, Rock Skin, or Steel Skin prayer.",
-    "requirements": "1 Prayer",
-    "points": 10
-  },
-  {
-    "id": 69,
-    "locality": "Global",
-    "task": "Run out of Prayer points.",
-    "information": "Run out of Prayer points.",
-    "requirements": "1 Prayer",
-    "points": 10
-  },
-  {
-    "id": 70,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Harvest a memory from a pale wisp.",
-    "information": "Harvest a pale memory from a pale wisp.",
-    "requirements": "1 Divination",
-    "points": 10
-  },
-  {
-    "id": 71,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Harvest 10 memories from a pale wisp.",
-    "information": "Harvest 10 pale memories from a pale wisp.",
-    "requirements": "1 Divination",
-    "points": 10
-  },
-  {
-    "id": 72,
-    "locality": "Global",
-    "task": "Harvest any memory from a wisp 5 times.",
-    "information": "Harvest any memory from a wisp 5 times.",
-    "requirements": "1 Divination",
-    "points": 10
-  },
-  {
-    "id": 73,
-    "locality": "Global",
-    "task": "Pickpocket from a man or woman.",
-    "information": "Pickpocket from a man or woman.",
-    "requirements": "1 Thieving",
-    "points": 10
-  },
-  {
-    "id": 74,
-    "locality": "Global",
-    "task": "Pickpocket from a man or woman 10 times.",
-    "information": "Pickpocket from a man or woman 10 times.",
-    "requirements": "1 Thieving",
-    "points": 10
-  },
-  {
-    "id": 75,
-    "locality": "Global",
-    "task": "Steal from any stall.",
-    "information": "Steal from any stall.",
-    "requirements": "2 Thieving for Vegetable Stalls",
-    "points": 10
-  },
-  {
-    "id": 76,
-    "locality": "Global",
-    "task": "Steal from any stall 10 times.",
-    "information": "Steal from any stall 10 times.",
-    "requirements": "2 Thieving for Vegetable Stalls",
-    "points": 10
-  },
-  {
-    "id": 77,
-    "locality": "Global",
-    "task": "Pickpocket anyone 5 times.",
-    "information": "Pickpocket anyone 5 times.",
-    "requirements": "1 Thieving",
-    "points": 10
-  },
-  {
-    "id": 78,
-    "locality": "Global",
-    "task": "Rake any farming patch.",
-    "information": "Rake any farming patch.",
-    "requirements": "1 Farming",
-    "points": 10
-  },
-  {
-    "id": 79,
-    "locality": "Global",
-    "task": "Plant seeds in any farming patch.",
-    "information": "Plant seeds in any farming patch.",
-    "requirements": "1 Farming",
-    "points": 10
-  },
-  {
-    "id": 80,
-    "locality": "Global",
-    "task": "Plant seeds in any farming patch 10 times.",
-    "information": "Plant seeds in any farming patch 10 times.",
-    "requirements": "1 Farming",
-    "points": 10
-  },
-  {
-    "id": 81,
-    "locality": "Global",
-    "task": "Add any compostable item to a compost bin.",
-    "information": "Add any compostable item to a compost bin.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 82,
-    "locality": "Global",
-    "task": "Have a tool leprechaun note any produce.",
-    "information": "Have a tool leprechaun note any produce.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 83,
-    "locality": "Global",
-    "task": "Use the Home Teleport spell to return to Lumbridge.",
-    "information": "Use the Home Teleport spell to return to Lumbridge.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 84,
-    "locality": "Global",
-    "task": "Eat a cabbage.",
-    "information": "Eat a cabbage.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 85,
-    "locality": "Global",
-    "task": "Eat a baked potato.",
-    "information": "Eat a baked potato.",
-    "requirements": "7 Cooking",
-    "points": 10
-  },
-  {
-    "id": 86,
-    "locality": "Global",
-    "task": "Eat an onion.",
-    "information": "Eat an onion.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 87,
-    "locality": "Global",
-    "task": "Kill an imp.",
-    "information": "Kill an imp.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 88,
-    "locality": "Global",
-    "task": "Kill a chicken.",
-    "information": "Kill a chicken.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 89,
-    "locality": "Global",
-    "task": "Claim a free item from any store.",
-    "information": "Claim a free item from any store e.g. a tinderbox from Lumbridge General Store",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 90,
-    "locality": "Global",
-    "task": "Return a free item to any store.",
-    "information": "Return a free item to any store e.g. a tinderbox from Lumbridge General Store",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 91,
-    "locality": "Global",
-    "task": "Sell an item to any store.",
-    "information": "Sell an item to any store.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 92,
-    "locality": "Global",
-    "task": "Listen to any musician.",
-    "information": "Listen to any musician.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 93,
-    "locality": "Global",
-    "task": "Pick wheat from a field.",
-    "information": "Pick wheat from a field.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 94,
-    "locality": "Global",
-    "task": "Prospect any rock.",
-    "information": "Prospect any rock.",
-    "requirements": "1 Mining",
-    "points": 10
-  },
-  {
-    "id": 95,
-    "locality": "Global",
-    "task": "View the skillguide.",
-    "information": "View the skill guide.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 96,
-    "locality": "Global",
-    "task": "Create a Guthix Rest Potion.",
-    "information": "Create a Guthix rest potion.",
-    "requirements": "18 Herblore, Partial completion of One Small Favour",
-    "points": 10
-  },
-  {
-    "id": 97,
-    "locality": "Global",
-    "task": "Make 5 potions of any kind.",
-    "information": "Make 5 potions of any kind.",
-    "requirements": "1 Herblore",
-    "points": 10
-  },
-  {
-    "id": 98,
-    "locality": "Global",
-    "task": "Drink a Strength Potion.",
-    "information": "Drink a Strength Potion.",
-    "requirements": "Giving a limpwurt root and red spiders' eggs to the Apothecary",
-    "points": 10
-  },
-  {
-    "id": 99,
-    "locality": "Global",
-    "task": "Make an Attack Potion.",
-    "information": "Make an Attack potion.",
-    "requirements": "1 Herblore, A clean guam and an eye of newt",
-    "points": 10
-  }
-,
-  {
-    "id": 100,
-    "locality": "Global",
-    "task": "Make a Necromancy Potion.",
-    "information": "Make a Necromancy potion.",
-    "requirements": "11 Herblore, A clean marrentill and cadava berries",
-    "points": 10
-  },
-  {
-    "id": 101,
-    "locality": "Global",
-    "task": "Clean 5 Grimy Guam.",
-    "information": "Clean 5 grimy guam.",
-    "requirements": "1 Herblore, 5 grimy guam",
-    "points": 10
-  },
-  {
-    "id": 102,
-    "locality": "Global",
-    "task": "Clean 15 Grimy Tarromin.",
-    "information": "Clean 15 grimy tarromin.",
-    "requirements": "5 Herblore, 15 grimy tarromin",
-    "points": 10
-  },
-  {
-    "id": 103,
-    "locality": "Global",
-    "task": "Clean 5 of any herb.",
-    "information": "Clean 5 of any herb.",
-    "requirements": "1 Herblore, 5 of any grimy herb",
-    "points": 10
-  },
-  {
-    "id": 104,
-    "locality": "Global",
-    "task": "Clean 10 of any herb",
-    "information": "Clean 10 of any herb",
-    "requirements": "1 Herblore, 10 of any grimy herb",
-    "points": 10
-  },
-  {
-    "id": 105,
-    "locality": "Global",
-    "task": "Fletch an Oak Shortbow (unstrung).",
-    "information": "Fletch an unstrung oak shortbow.",
-    "requirements": "20 Fletching, Oak logs",
-    "points": 10
-  },
-  {
-    "id": 106,
-    "locality": "Global",
-    "task": "Fletch some arrow shafts.",
-    "information": "Fletch some arrow shafts.",
-    "requirements": "1 Fletching, Logs of any kind",
-    "points": 10
-  },
-  {
-    "id": 107,
-    "locality": "Global",
-    "task": "Fletch 50 Bronze bolts.",
-    "information": "Fletch 50 bronze bolts.",
-    "requirements": "9 Fletching, A bronze bar and 50 feathers",
-    "points": 10
-  },
-  {
-    "id": 108,
-    "locality": "Global",
-    "task": "Complete 10 laps of any Agility course.",
-    "information": "Complete 10 laps of any Agility course.",
-    "requirements": "1 Agility",
-    "points": 10
-  },
-  {
-    "id": 109,
-    "locality": "Global",
-    "task": "Smith 10 of any metal weapon or armour piece.",
-    "information": "Smith 10 of any metal weapon or armour piece.",
-    "requirements": "1 Smithing, 10 of any metal bar",
-    "points": 10
-  },
-  {
-    "id": 110,
-    "locality": "Global",
-    "task": "Open 30 Sedimentary Geodes.",
-    "information": "Open 30 sedimentary geodes. These are found randomly while mining.",
-    "requirements": "1 Mining",
-    "points": 10
-  },
-  {
-    "id": 111,
-    "locality": "Global",
-    "task": "Maintain nearly maximum stamina when mining for 60 seconds.",
-    "information": "Maintain nearly maximum stamina when mining for 60 seconds.",
-    "requirements": "1 Mining",
-    "points": 10
-  },
-  {
-    "id": 112,
-    "locality": "Global",
-    "task": "Harvest a Grimy Marrentill.",
-    "information": "Harvest a grimy marrentill.",
-    "requirements": "9 Farming, Marrentill seed",
-    "points": 10
-  },
-  {
-    "id": 113,
-    "locality": "Global",
-    "task": "Harvest 10 Grimy Tarromin.",
-    "information": "Harvest 10 grimy tarromin.",
-    "requirements": "19 Farming, Tarromin seeds",
-    "points": 10
-  },
-  {
-    "id": 114,
-    "locality": "Global",
-    "task": "Cook 5 fish.",
-    "information": "Cook 5 fish.",
-    "requirements": "1 Cooking, 5 of any raw fish",
-    "points": 10
-  },
-  {
-    "id": 115,
-    "locality": "Global",
-    "task": "Make some Bread.",
-    "information": "Make some bread. Bread dough can be created by using a pot of flour with water, it must be cooked at a range.",
-    "requirements": "1 Cooking, Bread dough",
-    "points": 10
-  },
-  {
-    "id": 116,
-    "locality": "Global",
-    "task": "Make some flour.",
-    "information": "Make a pot of flour by grinding wheat at a windmill and collecting the flour in an empty pot.",
-    "requirements": "Wheat and an empty pot",
-    "points": 10
-  },
-  {
-    "id": 117,
-    "locality": "Global",
-    "task": "Offer 5 bones of any kind to an altar.",
-    "information": "Offer 5 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel",
-    "requirements": "1 Prayer",
-    "points": 10
-  },
-  {
-    "id": 118,
-    "locality": "Global",
-    "task": "Offer 25 bones of any kind to an altar.",
-    "information": "Offer 25 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel",
-    "requirements": "1 Prayer",
-    "points": 10
-  },
-  {
-    "id": 119,
-    "locality": "Global",
-    "task": "Scatter some Ashes.",
-    "information": "Scatter some ashes.",
-    "requirements": "1 Prayer, Any demonic ashes",
-    "points": 10
-  },
-  {
-    "id": 120,
-    "locality": "Global",
-    "task": "Scatter 25 ashes of any kind.",
-    "information": "Scatter 25 ashes of any kind.",
-    "requirements": "1 Prayer, 25 of any demonic ashes",
-    "points": 10
-  },
-  {
-    "id": 121,
-    "locality": "Global",
-    "task": "Restore 50 Prayer Points at an Altar at once.",
-    "information": "Restore 50 Prayer Points at an Altar at once.",
-    "requirements": "5 Prayer",
-    "points": 10
-  },
-  {
-    "id": 122,
-    "locality": "Global",
-    "task": "Activate Superhuman or Ultimate Strength and Improved or Incredible Reflexes prayers at the same time.",
-    "information": "Activate Superhuman or Ultimate Strength and Improved or Incredible Reflexes prayers at the same time.",
-    "requirements": "16 Prayer",
-    "points": 10
-  },
-  {
-    "id": 123,
-    "locality": "Global",
-    "task": "Catch a Baby Impling.",
-    "information": "Catch a baby impling.",
-    "requirements": "17 Hunter",
-    "points": 10
-  },
-  {
-    "id": 124,
-    "locality": "Global",
-    "task": "Catch 10 Implings of any kind.",
-    "information": "Catch 10 implings of any kind.",
-    "requirements": "17 Hunter",
-    "points": 10
-  },
-  {
-    "id": 125,
-    "locality": "Global",
-    "task": "Catch 5 Hunter creatures.",
-    "information": "Catch 5 Hunter creatures.",
-    "requirements": "1 Hunter",
-    "points": 10
-  },
-  {
-    "id": 126,
-    "locality": "Global",
-    "task": "Complete 5 Slayer tasks.",
-    "information": "Complete 5 Slayer assignments.",
-    "requirements": "1 Slayer",
-    "points": 10
-  },
-  {
-    "id": 127,
-    "locality": "Global",
-    "task": "Pick 5 Flax.",
-    "information": "Pick 5 flax from flax fields.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 128,
-    "locality": "Global",
-    "task": "Spin 5 bowstring.",
-    "information": "Spin 5 bowstrings by using flax on a spinning wheel.",
-    "requirements": "1 Fletching, 5 flax",
-    "points": 10
-  },
-  {
-    "id": 129,
-    "locality": "Global",
-    "task": "Surge a distance of one tile.",
-    "information": "Surge a distance of one tile.",
-    "requirements": "5 Agility",
-    "points": 10
-  },
-  {
-    "id": 130,
-    "locality": "Global",
-    "task": "Spin a Ball of Wool.",
-    "information": "Spin a ball of wool by using wool at a spinning wheel.",
-    "requirements": "1 Fletching, Wool",
-    "points": 10
-  },
-  {
-    "id": 131,
-    "locality": "Global",
-    "task": "Equip a full set of Iron armour without any upgrades.",
-    "information": "Equip an iron full helm, iron platebody, iron platelegs / iron plateskirt, iron gauntlets, iron armoured boots, and an iron kiteshield. Substitutes for pieces (e.g. med helm instead of full helm, chainbody instead of platebody, square shield instead of kite shield) will work. Iron armour can be bought at Horvik's Armour Shop.",
-    "requirements": "10 Defence",
-    "points": 10
-  },
-  {
-    "id": 132,
-    "locality": "Global",
-    "task": "Equip a full set of Green Dragonhide armour.",
-    "information": "Equip a full set of green dragonhide armour.",
-    "requirements": "40 Defence",
-    "points": 10
-  },
-  {
-    "id": 133,
-    "locality": "Global",
-    "task": "Equip a full set of Imphide robes.",
-    "information": "Equip a full set of imphide robes.",
-    "requirements": "10 Defence",
-    "points": 10
-  },
-  {
-    "id": 134,
-    "locality": "Global",
-    "task": "Equip a full set of Spider silk robes.",
-    "information": "Equip a full set of spider silk robes.",
-    "requirements": "20 Defence",
-    "points": 10
-  },
-  {
-    "id": 135,
-    "locality": "Global",
-    "task": "Store the items required for an emote clue in a Treasure Trail hidey-hole.",
-    "information": "Store the items required for an emote clue in a Treasure Trail hidey-hole.",
-    "requirements": "27 Construction, 4 planks and 10 of any nails for an easy hidey-hole",
-    "points": 10
-  },
-  {
-    "id": 136,
-    "locality": "Global",
-    "task": "Complete an Easy clue scroll.",
-    "information": "Complete an easy clue scroll.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 137,
-    "locality": "Global",
-    "task": "Collect 10 unique items for the General clue rewards collection log.",
-    "information": "Collect 10 unique items for the general clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 138,
-    "locality": "Kandarin: Gnomes",
-    "task": "Complete the Gnome Stronghold Agility Course.",
-    "information": "Complete the Gnome Stronghold Agility Course.",
-    "requirements": "1 Agility",
-    "points": 10
-  },
-  {
-    "id": 139,
-    "locality": "Kandarin: Feldip Hills",
-    "task": "Catch a Crimson Swift in the Feldip Hills.",
-    "information": "Catch a crimson swift in the Feldip Hills.",
-    "requirements": "1 Hunter, A bird snare",
-    "points": 10
-  },
-  {
-    "id": 140,
-    "locality": "Kandarin: Ardougne",
-    "task": "Defeat a Tortoise with riders in Kandarin.",
-    "information": "Defeat a tortoise with riders in Kandarin.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 141,
-    "locality": "Kandarin: Seers Village",
-    "task": "Complete the quest: You Are It.",
-    "information": "Complete You Are It.",
-    "requirements": "See quest page",
-    "points": 10
-  },
-  {
-    "id": 142,
-    "locality": "Kandarin: Gnomes",
-    "task": "Let Brimstail teleport you to the Rune Essence mine.",
-    "information": "Let Brimstail teleport you to the Rune Essence mine.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 143,
-    "locality": "Kandarin: Feldip Hills",
-    "task": "Equip a Marksman hat.",
-    "information": "Equip a marksman hat.",
-    "requirements": "125 chompy bird kills",
-    "points": 10
-  },
-  {
-    "id": 144,
-    "locality": "Global",
-    "task": "Obtain a Naragi engram from Orla Fairweather.",
-    "information": "Obtain a Naragi engram from Orla Fairweather. The engram is given to the player during the tutorial for Memorial to Guthix",
-    "requirements": "1 Divination",
-    "points": 10
-  },
-  {
-    "id": 145,
-    "locality": "Kandarin: Ardougne",
-    "task": "Learn how many beans make five (complete the Player Owned Farm tutorial).",
-    "information": "Complete the player-owned farm tutorial at Manor Farm.",
-    "requirements": "17 Farming, 20 Construction",
-    "points": 10
-  },
-  {
-    "id": 146,
-    "locality": "Global",
-    "task": "Catch a Wild Kebbit.",
-    "information": "Catch a wild kebbit.",
-    "requirements": "23 Hunter, Logs of any kind",
-    "points": 10
-  },
-  {
-    "id": 147,
-    "locality": "Kandarin: Ardougne",
-    "task": "Teleport to the Wilderness using the lever in Ardougne.",
-    "information": "Pull the lever in Ardougne.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 148,
-    "locality": "Kandarin: Yanille",
-    "task": "Use a ring of duelling to teleport to Castle Wars.",
-    "information": "Teleport to Castle Wars with a ring of duelling.",
-    "requirements": "27 Magic, 27 Crafting, Materials to make a ring of duelling",
-    "points": 10
-  },
-  {
-    "id": 149,
-    "locality": "Kandarin: Gnomes",
-    "task": "Make a Pineapple Punch cocktail.",
-    "information": "Make a pineapple punch cocktail.",
-    "requirements": "8 Cooking, See pineapple punch for ingredients",
-    "points": 10
-  },
-  {
-    "id": 150,
-    "locality": "Karamja",
-    "task": "Collect 5 seaweed from anywhere on Karamja.",
-    "information": "Collect 5 seaweed from anywhere on Karamja.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 151,
-    "locality": "Karamja",
-    "task": "Fill up Luthas' crate near the Musa Point plantation with bananas and receive 30 coins for your work.",
-    "information": "Fill up Luthas' crate near the Banana plantation with bananas and talk to him to receive 30 coins for your work.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 152,
-    "locality": "Karamja",
-    "task": "Claim a ticket from Brimhaven Agility Arena.",
-    "information": "Claim a ticket from Brimhaven Agility Arena.",
-    "requirements": "1 Agility",
-    "points": 10
-  },
-  {
-    "id": 153,
-    "locality": "Karamja",
-    "task": "Kill a snake.",
-    "information": "Kill a snake.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 154,
-    "locality": "Karamja",
-    "task": "Catch a Karambwanji.",
-    "information": "Catch a raw karambwanji.",
-    "requirements": "5 Fishing",
-    "points": 10
-  },
-  {
-    "id": 155,
-    "locality": "Karamja",
-    "task": "Be assigned a Slayer task in Shilo Village.",
-    "information": "Be assigned a Slayer task in Shilo Village.",
-    "requirements": "100 Combat, 50 Slayer, Completion of Shilo Village",
-    "points": 10
-  },
-  {
-    "id": 156,
-    "locality": "Karamja",
-    "task": "Defeat a Greater Demon on Karamja.",
-    "information": "Defeat a greater demon on Karamja.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 157,
-    "locality": "Karamja",
-    "task": "Pick a pineapple on Karamja.",
-    "information": "Pick a pineapple on Karamja from the pineapple plants near the lodestone.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 158,
-    "locality": "Karamja",
-    "task": "Enter the Brimhaven Dungeon.",
-    "information": "Enter the Brimhaven Dungeon.",
-    "requirements": "875 coins",
-    "points": 10
-  },
-  {
-    "id": 159,
-    "locality": "Karamja",
-    "task": "Cross the spiky pit using the stepping stones within Brimhaven Dungeon.",
-    "information": "Cross the spiky pit using the stepping stones within Brimhaven Dungeon.",
-    "requirements": "12 Agility",
-    "points": 10
-  },
-  {
-    "id": 160,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Progress through the Leagues tutorial to unlock your first relic.",
-    "information": "Progress through the Leagues tutorial to unlock your first relic.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 161,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Climb to the top of the Wizards' Tower.",
-    "information": "Climb to the top of the Wizards' Tower.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 162,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Have Ned make you some rope from balls of wool.",
-    "information": "Have Ned make you some rope from 4 balls of wool.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 163,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Siphon from a fire essling in the Runespan.",
-    "information": "Siphon from a fire essling in the Runespan.",
-    "requirements": "14 Runecrafting",
-    "points": 10
-  },
-  {
-    "id": 164,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Convert at least one pale memory into energy.",
-    "information": "Convert at least one pale memory into energy.",
-    "requirements": "1 Divination",
-    "points": 10
-  },
-  {
-    "id": 165,
-    "locality": "Misthalin: Edgeville",
-    "task": "Kill a mugger near the Edgeville lodestone.",
-    "information": "Kill a mugger near the Edgeville lodestone.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 166,
-    "locality": "Misthalin: Edgeville",
-    "task": "Mine some coal in the centre of Barbarian village.",
-    "information": "Mine some coal in the centre of Barbarian Village.",
-    "requirements": "20 Mining",
-    "points": 10
-  },
-  {
-    "id": 167,
-    "locality": "Misthalin: Fort Forinthry",
-    "task": "Use the bank in the workshop at Fort Forinthry.",
-    "information": "Use the bank in the workshop at Fort Forinthry.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 168,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Kill a giant rat in Lumbridge Swamp.",
-    "information": "Kill a giant rat in Lumbridge Swamp.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 169,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Kill a goblin in Lumbridge.",
-    "information": "Kill a goblin in Lumbridge.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 170,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Kill a giant spider in Lumbridge or Lumbridge Swamp.",
-    "information": "Kill a giant spider in Lumbridge or Lumbridge Swamp.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 171,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Milk a cow.",
-    "information": "Milk a cow.",
-    "requirements": "A bucket",
-    "points": 10
-  },
-  {
-    "id": 172,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Talk to Hans and find out how old you are.",
-    "information": "Talk to Hans and find out how old you are.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 173,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Complete the quest: The Blood Pact.",
-    "information": "Complete The Blood Pact.",
-    "requirements": "See quest page",
-    "points": 10
-  },
-  {
-    "id": 174,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Catch some shrimp in the fishing spot to the east of Lumbridge Swamp.",
-    "information": "Catch some shrimp in the fishing spot to the east of Lumbridge Swamp.",
-    "requirements": "1 Fishing",
-    "points": 10
-  },
-  {
-    "id": 175,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Smelt a steel bar in the furnace in Lumbridge.",
-    "information": "Smelt a steel bar in the furnace in Lumbridge.",
-    "requirements": "20 Smithing",
-    "points": 10
-  },
-  {
-    "id": 176,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Cook some rat meat on a fire in Lumbridge Swamp.",
-    "information": "Cook some rat meat on a campfire in Lumbridge Swamp.",
-    "requirements": "1 Cooking",
-    "points": 10
-  },
-  {
-    "id": 177,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Mine iron ore from the mining site south-west of Lumbridge Swamp.",
-    "information": "Mine iron ore from the mining site south-west of Lumbridge Swamp.",
-    "requirements": "10 Mining",
-    "points": 10
-  },
-  {
-    "id": 178,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Craft a water rune at the Water Altar.",
-    "information": "Craft a water rune at the Water altar.",
-    "requirements": "5 Runecrafting",
-    "points": 10
-  },
-  {
-    "id": 179,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Complete a task from Jacquelyn, the Lumbridge Slayer master.",
-    "information": "Complete a task from Jacquelyn, the Lumbridge Slayer master.",
-    "requirements": "1 Slayer",
-    "points": 10
-  },
-  {
-    "id": 180,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Fill a Charmed Sack with corruption at the Nexus in Lumbridge Swamp.",
-    "information": "Fill a charmed sack with corruption at the Nexus in Lumbridge Swamp.",
-    "requirements": "1 Prayer",
-    "points": 10
-  },
-  {
-    "id": 181,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Complete the quest: Necromancy!.[sic]",
-    "information": "Complete Necromancy!",
-    "requirements": "See quest page",
-    "points": 10
-  },
-  {
-    "id": 182,
-    "locality": "Misthalin: City of Um",
-    "task": "Upgrade a piece of Death Skull or Deathwarden equipment to tier 20.",
-    "information": "Upgrade a piece of death skull or deathwarden equipment to tier 20.",
-    "requirements": "20 Necromancy, 15 Smithing (death skull) OR 15 Crafting (Deathwarden), Completion of Kili Row",
-    "points": 10
-  },
-  {
-    "id": 183,
-    "locality": "Misthalin: City of Um",
-    "task": "Craft some spirit or bone runes.",
-    "information": "Craft some spirit or bone runes.",
-    "requirements": "1 Runecrafting, Partial completion of Rune Mythos",
-    "points": 10
-  },
-  {
-    "id": 184,
-    "locality": "Misthalin: City of Um",
-    "task": "Complete a Lesser Necroplasm ritual.",
-    "information": "Complete a Lesser Necroplasm ritual.",
-    "requirements": "5 Necromancy",
-    "points": 10
-  },
-  {
-    "id": 185,
-    "locality": "Misthalin: City of Um",
-    "task": "Conjure a skeleton at the City of Um ritual site.",
-    "information": "Conjure a Skeleton Warrior at the Um ritual site.",
-    "requirements": "2 Necromancy, Conjure Skeleton Warrior unlocked at the Well of Souls",
-    "points": 10
-  },
-  {
-    "id": 186,
-    "locality": "Misthalin: City of Um",
-    "task": "Conjure a zombie at the City of Um ritual site.",
-    "information": "Conjure a Putrid Zombie at the Um ritual site.",
-    "requirements": "40 Necromancy, Conjure Putrid Zombie unlocked at the Well of Souls",
-    "points": 10
-  },
-  {
-    "id": 187,
-    "locality": "Misthalin: City of Um",
-    "task": "Conjure a ghost  at the City of Um ritual site.[sic]",
-    "information": "Conjure a Vengeful Ghost at the Um ritual site.",
-    "requirements": "40 Necromancy, Conjure Vengeful Ghost unlocked at the Well of Souls",
-    "points": 10
-  },
-  {
-    "id": 188,
-    "locality": "Misthalin: Varrock",
-    "task": "Kill a dark wizard.",
-    "information": "Kill a dark wizard.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 189,
-    "locality": "Misthalin: Varrock",
-    "task": "Enter the Earth Altar using an earth tiara or talisman.",
-    "information": "Enter the earth altar using an earth tiara or talisman.",
-    "requirements": "1 Runecrafting",
-    "points": 10
-  },
-  {
-    "id": 190,
-    "locality": "Misthalin: Varrock",
-    "task": "Have Elsie tell you a story.",
-    "information": "Have Elsie tell you a story, she is found upstairs in the church in Varrock. You must give her a cup of tea",
-    "requirements": "A cup of tea",
-    "points": 10
-  },
-  {
-    "id": 191,
-    "locality": "Misthalin: Varrock",
-    "task": "Give a bone to one of Varrock's stray dogs (or to your pet stray dog if you have one).",
-    "information": "Use some bones on one of Varrock's stray dogs (or to your pet stray dog if you have one).",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 192,
-    "locality": "Misthalin: Varrock",
-    "task": "Claim a free clue scroll from Zaida at the Grand Exchange.",
-    "information": "Claim a free clue scroll from Zaida at the Grand Exchange.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 193,
-    "locality": "Misthalin: Fort Forinthry",
-    "task": "Give Bill a beer in Fort Forinthry.",
-    "information": "Give Bill a beer in Fort Forinthry.",
-    "requirements": "A beer, partial completion of New Foundations",
-    "points": 10
-  },
-  {
-    "id": 194,
-    "locality": "Misthalin: Varrock",
-    "task": "Complete the Archaeology tutorial.",
-    "information": "Complete the Archaeology tutorial.",
-    "requirements": "1 Archaeology",
-    "points": 10
-  },
-  {
-    "id": 195,
-    "locality": "Misthalin: Fort Forinthry",
-    "task": "Make a plank yourself on the sawmill in Fort Forinthry.",
-    "information": "Make a plank yourself on the sawmill in Fort Forinthry.",
-    "requirements": "1 Construction, Partial completion of New Foundations",
-    "points": 10
-  },
-  {
-    "id": 196,
-    "locality": "Misthalin: Varrock",
-    "task": "Mine some iron ore in the mining spot south-west of Varrock.",
-    "information": "Mine some iron ore in the mining spot south-west of Varrock.",
-    "requirements": "10 Mining",
-    "points": 10
-  },
-  {
-    "id": 197,
-    "locality": "Misthalin: Varrock",
-    "task": "Steal from the Varrock tea stall.",
-    "information": "Steal from the Varrock tea stall.",
-    "requirements": "5 Thieving",
-    "points": 10
-  },
-  {
-    "id": 198,
-    "locality": "Misthalin: Varrock",
-    "task": "Pan in the river at the Digsite.",
-    "information": "This can only be completed after the point during The Dig Site quest where the panning guide teaches you how to pan for gold. You can then use the panning point. If you complete the quest without completing this achievement the task will be completed by attempting to pan with a panning tray in your inventory.",
-    "requirements": "Partial completion of The Dig Site",
-    "points": 10
-  },
-  {
-    "id": 199,
-    "locality": "Morytania",
-    "task": "Take an easy companion through an easy route of Temple Trekking.",
-    "information": "Complete an Easy Temple Trek.",
-    "requirements": "Completion of In Aid of the Myreque",
-    "points": 10
-  }
-,
-  {
-    "id": 200,
-    "locality": "Morytania",
-    "task": "Craft your own snelm in Morytania.",
-    "information": "Craft a snelm.",
-    "requirements": "15 Crafting, Any blamish shell",
-    "points": 10
-  },
-  {
-    "id": 201,
-    "locality": "Morytania",
-    "task": "Defeat a Werewolf in Morytania.",
-    "information": "Defeat a Werewolf in Morytania.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 202,
-    "locality": "Morytania",
-    "task": "Pass through the Holy barrier.",
-    "information": "Pass through the Holy barrier.",
-    "requirements": "Defeat a Ghoul (Paterdomus)",
-    "points": 10
-  },
-  {
-    "id": 203,
-    "locality": "Morytania",
-    "task": "Enter through the western gate of Port Phasmatys.",
-    "information": "Pass through the western gate of Port Phasmatys.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 204,
-    "locality": "Morytania",
-    "task": "Activate the lodestone in Canifis.",
-    "information": "Activate the Canifis lodestone.",
-    "requirements": "Access to Morytania",
-    "points": 10
-  },
-  {
-    "id": 205,
-    "locality": "Morytania",
-    "task": "Kill anything on the ground floor of the Slayer Tower.",
-    "information": "Kill anything on the ground floor of the Slayer Tower.",
-    "requirements": "1 Slayer, Access to Morytania",
-    "points": 10
-  },
-  {
-    "id": 206,
-    "locality": "Morytania",
-    "task": "Using either a Silver Sickle or the Ivandis Flail, grow some fungus in the swamp using Bloom.",
-    "information": "Cast Bloom using a blessed sickle or the Ivandis flail in Mort Myre Swamp.",
-    "requirements": "18 Crafting, Completion of Nature Spirit",
-    "points": 10
-  },
-  {
-    "id": 207,
-    "locality": "Morytania",
-    "task": "Defeat 5 Feral Vampyres in the Haunted Woods.",
-    "information": "Defeat 5 feral vampyres in the Haunted Woods.",
-    "requirements": "Access to Morytania",
-    "points": 10
-  },
-  {
-    "id": 208,
-    "locality": "Morytania",
-    "task": "Use an ectophial to return to Port Phasmatys.",
-    "information": "Use an ectophial to return to Port Phasmatys.",
-    "requirements": "Completion of Ghosts Ahoy",
-    "points": 10
-  },
-  {
-    "id": 209,
-    "locality": "Morytania",
-    "task": "Visit Dragontooth Island by boat.",
-    "information": "Visit Dragontooth Island by boat.",
-    "requirements": "Ghostspeak amulet",
-    "points": 10
-  },
-  {
-    "id": 210,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Cook a Rabbit in Tirannwn.",
-    "information": "Cook a raw rabbit in Tirannwn.",
-    "requirements": "1 Cooking",
-    "points": 10
-  },
-  {
-    "id": 211,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Attempt to pass a leaf trap.",
-    "information": "Attempt to pass a leaf trap.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 212,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Use the Bank in Lletya.",
-    "information": "Use the bank in Lletya.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 213,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Charter a ship from Port Tyras.",
-    "information": "Charter a ship from Port Tyras.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 214,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Climb the Tower of Voices.",
-    "information": "Climb the Tower of Voices.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 215,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Burn some logs using the everlasting bonfire in the Tower of Voices.",
-    "information": "Burn some logs using the everlasting bonfire in the Tower of Voices.",
-    "requirements": "1 Firemaking",
-    "points": 10
-  },
-  {
-    "id": 216,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Activate the lodestone in Prifddinas.",
-    "information": "Activate the Prifddinas lodestone.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 217,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Activate the lodestone in Tirannwn.",
-    "information": "Activate the Tirannwn lodestone.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 218,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Restore your prayer using the altar in Lletya.",
-    "information": "Restore your prayer using the altar in Lletya.",
-    "requirements": "1 Prayer",
-    "points": 10
-  },
-  {
-    "id": 219,
-    "locality": "Wilderness: General",
-    "task": "Use the bank at the Mage Arena.",
-    "information": "Use the Mage Arena bank.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 220,
-    "locality": "Wilderness: General",
-    "task": "Defeat the Chaos Elemental.",
-    "information": "Defeat the Chaos Elemental once.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 221,
-    "locality": "Wilderness: General",
-    "task": "Defeat the Chaos Elemental. (100 times)",
-    "information": "Defeat the Chaos Elemental 100 times.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 222,
-    "locality": "Wilderness: General",
-    "task": "Reach a score of 10 using the strange switches in the Wilderness.",
-    "information": "Reach a score of 10 using the strange switches in the Wilderness.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 223,
-    "locality": "Wilderness: General",
-    "task": "Jump over the Wilderness wall.",
-    "information": "Jump over the Wilderness wall.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 224,
-    "locality": "Wilderness: General",
-    "task": "Activate the lodestone near the Wilderness Crater.",
-    "information": "Activate the Wilderness Crater lodestone.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 225,
-    "locality": "Wilderness: Daemonheim",
-    "task": "Complete a Frozen floor in Daemonheim.",
-    "information": "Complete a Frozen floor in Daemonheim.",
-    "requirements": "1 Dungeoneering",
-    "points": 10
-  },
-  {
-    "id": 226,
-    "locality": "Wilderness: Daemonheim",
-    "task": "Make use of either an autoheater, gem bag, herbicide, bonecrusher or charming imp.",
-    "information": "Make use of either an autoheater, gem bag, herbicide, bonecrusher or charming imp.",
-    "requirements": "The gem bag is the cheapest reward at 2000 dungeoneering token, and upgrading it is required for a later task.",
-    "points": 10
-  },
-  {
-    "id": 227,
-    "locality": "Wilderness: General",
-    "task": "Enter the chaos tunnels from an entrance in the Wilderness.",
-    "information": "Enter the Chaos Tunnels from an entrance in the Wilderness.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 228,
-    "locality": "Wilderness: General",
-    "task": "Defeat a Black Unicorn in the Wilderness.",
-    "information": "Defeat a black unicorn in the Wilderness.",
-    "requirements": "N/A",
-    "points": 10
-  },
-  {
-    "id": 229,
+    "taskId": 468,
     "locality": "Anachronia",
     "task": "Build your Player Lodge on Anachronia.",
     "information": "Build your Player Lodge on Anachronia.",
@@ -1842,23 +72,26 @@
     "points": 30
   },
   {
-    "id": 230,
+    "id": 8,
+    "taskId": 469,
     "locality": "Anachronia",
     "task": "Purchase the herb bag and the herb bag upgrade from the Herby Werby reward shop.",
     "information": "Purchase the herb bag and the herb bag upgrade from the Herby Werby reward shop.",
-    "requirements": "1 Herblore, Requires 4 weeks worth of potent herbs",
+    "requirements": "1 Herblore",
     "points": 30
   },
   {
-    "id": 231,
+    "id": 9,
+    "taskId": 470,
     "locality": "Anachronia",
     "task": "Give Snoop some clean Dwarf weed.",
     "information": "Give Snoop some clean dwarf weed.",
-    "requirements": "70 Herblore if cleaning the herb yourself",
+    "requirements": "70 Herblore",
     "points": 30
   },
   {
-    "id": 232,
+    "id": 10,
+    "taskId": 471,
     "locality": "Anachronia",
     "task": "Harvest produce from 5 animals on Anachronia farm.",
     "information": "Harvest produce from 5 animals on Anachronia farm.",
@@ -1866,7 +99,8 @@
     "points": 30
   },
   {
-    "id": 233,
+    "id": 11,
+    "taskId": 473,
     "locality": "Anachronia",
     "task": "Complete the beginner sections of the Anachronia agility course.",
     "information": "Complete the beginner sections of the Anachronia agility course.",
@@ -1874,7 +108,8 @@
     "points": 30
   },
   {
-    "id": 234,
+    "id": 12,
+    "taskId": 474,
     "locality": "Anachronia",
     "task": "Complete the novice sections of the Anachronia agility course.",
     "information": "Complete the novice sections of the Anachronia agility course.",
@@ -1882,31 +117,467 @@
     "points": 30
   },
   {
-    "id": 235,
+    "id": 13,
+    "taskId": 472,
+    "locality": "Anachronia",
+    "task": "Harvest produce from 25 animals on Anachronia farm.",
+    "information": "Harvest produce from 25 animals on Anachronia farm.",
+    "requirements": "42 Farming, 45 Construction",
+    "points": 80
+  },
+  {
+    "id": 14,
+    "taskId": 475,
+    "locality": "Anachronia",
+    "task": "Complete the ritual to activate a totem on Anachronia.",
+    "information": "Complete the ritual to activate a totem on Anachronia.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 15,
+    "taskId": 476,
+    "locality": "Anachronia",
+    "task": "Complete the Anachronia agility course in under 7 minutes.",
+    "information": "Complete the Anachronia agility course in under 7 minutes.",
+    "requirements": "85 Agility",
+    "points": 80
+  },
+  {
+    "id": 16,
+    "taskId": 477,
+    "locality": "Anachronia",
+    "task": "Complete all frog breeds.",
+    "information": "Complete all frog breeds.",
+    "requirements": "42 Farming, 45 Construction",
+    "points": 80
+  },
+  {
+    "id": 17,
+    "taskId": 478,
+    "locality": "Anachronia",
+    "task": "Purchase the Quick Traps upgrade from Irwinsson's Hunter Mark shop.",
+    "information": "Purchase the quick traps upgrade from the Hunter Mark Shop.",
+    "requirements": "50 hunter marks",
+    "points": 80
+  },
+  {
+    "id": 18,
+    "taskId": 479,
+    "locality": "Anachronia",
+    "task": "Complete the quest: Osseous Rex.",
+    "information": "Complete the Osseous Rex quest.",
+    "requirements": "See quest page",
+    "points": 80
+  },
+  {
+    "id": 19,
+    "taskId": 480,
+    "locality": "Anachronia",
+    "task": "Clear an Overgrown idol on Anachronia.",
+    "information": "Clear an overgrown idol on Anachronia.",
+    "requirements": "81 Woodcutting",
+    "points": 80
+  },
+  {
+    "id": 20,
+    "taskId": 481,
+    "locality": "Anachronia",
+    "task": "Defeat any of the Rex Matriarchs.",
+    "information": "Defeat any of the Rex Matriarchs once.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 21,
+    "taskId": 482,
+    "locality": "Anachronia",
+    "task": "Defeat any of the Rex Matriarchs. (100 times)",
+    "information": "Defeat any of the Rex Matriarchs 100 times.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 22,
+    "taskId": 483,
+    "locality": "Anachronia",
+    "task": "Complete the quest: Desperate Times.",
+    "information": "Complete the Desperate Times quest.",
+    "requirements": "See quest page",
+    "points": 80
+  },
+  {
+    "id": 23,
+    "taskId": 484,
+    "locality": "Anachronia",
+    "task": "Find all the hidden Zygomites on Anachronia.",
+    "information": "Find all of the ancient zygomites on Anachronia. See the page for a route.",
+    "requirements": "85 Agility",
+    "points": 80
+  },
+  {
+    "id": 24,
+    "taskId": 485,
+    "locality": "Anachronia",
+    "task": "Equip Laniakea's spear.",
+    "information": "Equip Laniakea's spear.",
+    "requirements": "82 Attack",
+    "points": 80
+  },
+  {
+    "id": 25,
+    "taskId": 486,
+    "locality": "Anachronia",
+    "task": "Harvest an Arbuck herb.",
+    "information": "Harvest an arbuck herb.",
+    "requirements": "77 Farming",
+    "points": 80
+  },
+  {
+    "id": 26,
+    "taskId": 487,
+    "locality": "Anachronia",
+    "task": "Complete the advanced sections of the Anachronia agility course.",
+    "information": "Complete the advanced sections of the Anachronia agility course.",
+    "requirements": "70 Agility",
+    "points": 80
+  },
+  {
+    "id": 27,
+    "taskId": 488,
+    "locality": "Anachronia",
+    "task": "Equip a Dragon Mattock.",
+    "information": "Equip a dragon mattock.",
+    "requirements": "60 Archaeology",
+    "points": 80
+  },
+  {
+    "id": 28,
+    "taskId": 490,
+    "locality": "Anachronia",
+    "task": "Take down each dinosaur in Big Game Hunter.",
+    "information": "Take down each dinosaur in Big Game Hunter.",
+    "requirements": "96 Hunter, 76 Slayer",
+    "points": 80
+  },
+  {
+    "id": 29,
+    "taskId": 492,
+    "locality": "Anachronia",
+    "task": "Get caught by each of the big game creatures once.",
+    "information": "Get caught by each of the Big Game Hunter creatures once.",
+    "requirements": "96 Hunter, 76 Slayer",
+    "points": 80
+  },
+  {
+    "id": 30,
+    "taskId": 493,
+    "locality": "Anachronia",
+    "task": "Complete a big game encounter without using movement abilities.",
+    "information": "Complete a Big Game Hunter encounter without using movement abilities.",
+    "requirements": "75 Hunter, 55 Slayer",
+    "points": 80
+  },
+  {
+    "id": 31,
+    "taskId": 500,
+    "locality": "Anachronia",
+    "task": "Defeat Raksha, the Shadow Colossus.",
+    "information": "Defeat Raksha, the Shadow Colossus once.",
+    "requirements": "Completion of Raksha, the Shadow Colossus",
+    "points": 80
+  },
+  {
+    "id": 32,
+    "taskId": 489,
+    "locality": "Anachronia",
+    "task": "Discover all the totem pieces on Anachronia.",
+    "information": "Discover all the totem pieces on Anachronia.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 33,
+    "taskId": 491,
+    "locality": "Anachronia",
+    "task": "Unlock the double Surge or double Escape ability upgrade.",
+    "information": "Unlock the double Surge or double Escape ability upgrade.",
+    "requirements": "85 Agility",
+    "points": 150
+  },
+  {
+    "id": 34,
+    "taskId": 494,
+    "locality": "Anachronia",
+    "task": "Harvest a Dragonfruit plant in the cactus patch in the north of Anachronia.",
+    "information": "Harvest a dragonfruit cactus in the cactus patch in the north of Anachronia.",
+    "requirements": "81 Farming",
+    "points": 150
+  },
+  {
+    "id": 35,
+    "taskId": 495,
+    "locality": "Anachronia",
+    "task": "Kill 50 Dinosaurs.",
+    "information": "Kill 50 dinosaurs.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 36,
+    "taskId": 496,
+    "locality": "Anachronia",
+    "task": "Kill 50 Vile Blooms.",
+    "information": "Kill 50 vile blooms.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 37,
+    "taskId": 497,
+    "locality": "Anachronia",
+    "task": "Solve the Archaeology mystery: Teleport Node On.",
+    "information": "Activate all Orthen teleportation devices on Anachronia.",
+    "requirements": "90 Archaeology",
+    "points": 150
+  },
+  {
+    "id": 38,
+    "taskId": 498,
+    "locality": "Anachronia",
+    "task": "Use Potterington Blend #102 Fertiliser or dinosaur 'propellant' on Prehistoric Potterington.",
+    "information": "Use Potterington blend 102 fertiliser or dinosaur 'propellant' on Prehistoric Potterington.",
+    "requirements": "102 Farming",
+    "points": 150
+  },
+  {
+    "id": 39,
+    "taskId": 499,
+    "locality": "Anachronia",
+    "task": "Find an unchecked egg in the pile of dinosaur eggs south of Anachronia dinosaur farm.",
+    "information": "Find a dinosaur egg in the pile of dinosaur eggs on Anachronia Farm.",
+    "requirements": "42 Farming, 45 Construction",
+    "points": 150
+  },
+  {
+    "id": 40,
+    "taskId": 501,
+    "locality": "Anachronia",
+    "task": "Defeat Raksha, the Shadow Colossus. (100 times)",
+    "information": "Defeat Raksha, the Shadow Colossus 100 times.",
+    "requirements": "Completion of Raksha, the Shadow Colossus",
+    "points": 150
+  },
+  {
+    "id": 41,
+    "taskId": 502,
+    "locality": "Anachronia",
+    "task": "Complete the quest: Desperate Measures.",
+    "information": "Complete the Desperate Measures quest.",
+    "requirements": "See quest page",
+    "points": 150
+  },
+  {
+    "id": 42,
+    "taskId": 503,
+    "locality": "Anachronia",
+    "task": "Equip a Terrasaur maul.",
+    "information": "Equip a terrasaur maul.",
+    "requirements": "90 Attack",
+    "points": 150
+  },
+  {
+    "id": 43,
+    "taskId": 505,
+    "locality": "Anachronia",
+    "task": "Complete a big game encounter without stepping into the creature's vision ring.",
+    "information": "Complete a Big Game Hunter encounter without stepping into the creature's vision ring.",
+    "requirements": "75 Hunter, 55 Slayer",
+    "points": 150
+  },
+  {
+    "id": 44,
+    "taskId": 508,
+    "locality": "Anachronia",
+    "task": "Craft 500 Time Runes.",
+    "information": "Craft 500 time runes.",
+    "requirements": "102 Runecrafting",
+    "points": 150
+  },
+  {
+    "id": 45,
+    "taskId": 509,
+    "locality": "Anachronia",
+    "task": "Solve the Archaeology mystery: Fragmented Memories.",
+    "information": "Complete the Fragmented Memories Archaeology mystery.",
+    "requirements": "99 Archaeology",
+    "points": 150
+  },
+  {
+    "id": 46,
+    "taskId": 512,
+    "locality": "Anachronia",
+    "task": "Fletch any type of Elder God arrow.",
+    "information": "Fletch any type of Elder God arrow.",
+    "requirements": "95 Fletching",
+    "points": 150
+  },
+  {
+    "id": 47,
+    "taskId": 513,
+    "locality": "Anachronia",
+    "task": "Cast the Crumble Undead spell.",
+    "information": "Cast the Crumble Undead spell.",
+    "requirements": "39 Magic",
+    "points": 150
+  },
+  {
+    "id": 48,
+    "taskId": 504,
+    "locality": "Anachronia",
+    "task": "Fully upgrade the Town Hall in the base camp on Anachronia.",
+    "information": "Fully upgrade the town hall in the base camp on Anachronia.",
+    "requirements": "90 Construction",
+    "points": 150
+  },
+  {
+    "id": 49,
+    "taskId": 506,
+    "locality": "Anachronia",
+    "task": "Complete a big game encounter with 3 creatures active.",
+    "information": "Complete a Big Game Hunter encounter with 3 creatures active.",
+    "requirements": "75 Hunter, 55 Slayer",
+    "points": 150
+  },
+  {
+    "id": 50,
+    "taskId": 507,
+    "locality": "Anachronia",
+    "task": "Breed a shiny dinosaur.",
+    "information": "Breed a shiny dinosaur.",
+    "requirements": "42 Farming, 45 Construction",
+    "points": 150
+  },
+  {
+    "id": 51,
+    "taskId": 510,
+    "locality": "Anachronia",
+    "task": "Equip Skeka's hypnowand.",
+    "information": "Equip Skeka's hypnowand.",
+    "requirements": "99 Archaeology",
+    "points": 150
+  },
+  {
+    "id": 52,
+    "taskId": 511,
+    "locality": "Anachronia",
+    "task": "Complete the quest: Extinction.",
+    "information": "Complete the Extinction quest.",
+    "requirements": "See quest page",
+    "points": 150
+  },
+  {
+    "id": 53,
+    "taskId": 217,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Complete a lap of the Burthorpe Agility course.",
+    "information": "Complete a lap of the Burthorpe Agility Course.",
+    "requirements": "1 Agility",
+    "points": 10
+  },
+  {
+    "id": 54,
+    "taskId": 221,
+    "locality": "Asgarnia: Falador",
+    "task": "Kill a goblin raider boss in the Goblin Village.",
+    "information": "Kill 15 goblins in the Goblin Village to spawn a Goblin raider boss.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 55,
+    "taskId": 222,
+    "locality": "Asgarnia: Falador",
+    "task": "Complete the quest: Witch's House.",
+    "information": "Complete Witch's House",
+    "requirements": "See quest page",
+    "points": 10
+  },
+  {
+    "id": 56,
+    "taskId": 223,
+    "locality": "Asgarnia: Falador",
+    "task": "Sit down with Tiffy in Falador park.",
+    "information": "Sit on the bench with Sir Tiffy Cashien in Falador Park.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 57,
+    "taskId": 224,
+    "locality": "Asgarnia: Falador",
+    "task": "Pray to Bandos's remains.",
+    "information": "Pray to Bandos's remains (just south-east of Goblin Village.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 58,
+    "taskId": 225,
+    "locality": "Asgarnia: Falador",
+    "task": "Dance in the Falador party room.",
+    "information": "Dance in the Falador party room.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 59,
+    "taskId": 263,
+    "locality": "Asgarnia: Port Sarim",
+    "task": "Give Thurgo a redberry pie.",
+    "information": "Give Thurgo a redberry pie.",
+    "requirements": "10 Cooking",
+    "points": 10
+  },
+  {
+    "id": 60,
+    "taskId": 268,
+    "locality": "Asgarnia: Taverley",
+    "task": "Build a God statue in Taverley.",
+    "information": "Build a God statue in Taverley.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 61,
+    "taskId": 218,
     "locality": "Asgarnia: Burthorpe",
     "task": "Enter the Warriors Guild.",
     "information": "Enter the Warriors Guild.",
-    "requirements": "Combined Attack and Strength level of 130, or 99 Attack, or 99 Strength",
+    "requirements": "Combined Attack and Strength level of 130",
     "points": 30
   },
   {
-    "id": 236,
+    "id": 62,
+    "taskId": 219,
     "locality": "Asgarnia: Burthorpe",
     "task": "Equip a defender.",
     "information": "Equip a defender.",
-    "requirements": "Combined Attack and Strength level of 130, or 99 Attack, or 99 Strength",
+    "requirements": "Combined Attack and Strength level of 130",
     "points": 30
   },
   {
-    "id": 237,
+    "id": 63,
+    "taskId": 220,
     "locality": "Asgarnia: Burthorpe",
     "task": "Charge an Amulet of Glory in the Heroes' Guild.",
     "information": "Charge an amulet of glory in the Heroes' Guild.",
-    "requirements": "If not as a drop from revenant knights, 80 Crafting and 68 Magic to make it from scratch, or 83 Hunter to catch dragon implings Completion of Heroes' Quest",
+    "requirements": "80 Crafting, 68 Magic",
     "points": 30
   },
   {
-    "id": 238,
+    "id": 64,
+    "taskId": 226,
     "locality": "Asgarnia: Falador",
     "task": "Enter the Crafting Guild.",
     "information": "Enter the Crafting Guild.",
@@ -1914,23 +585,26 @@
     "points": 30
   },
   {
-    "id": 239,
+    "id": 65,
+    "taskId": 227,
     "locality": "Asgarnia: Falador",
     "task": "Complete the task set: Easy Falador.",
-    "information": "",
+    "information": "See Easy Falador achievements page",
     "requirements": "See Easy Falador achievements page",
     "points": 30
   },
   {
-    "id": 240,
+    "id": 66,
+    "taskId": 228,
     "locality": "Asgarnia: Falador",
     "task": "Complete the task set: Medium Falador.",
-    "information": "",
+    "information": "See Medium Falador achievements page",
     "requirements": "See Medium Falador achievements page",
     "points": 30
   },
   {
-    "id": 241,
+    "id": 67,
+    "taskId": 229,
     "locality": "Asgarnia: Falador",
     "task": "Defeat the Giant Mole.",
     "information": "Kill the giant mole.",
@@ -1938,7 +612,8 @@
     "points": 30
   },
   {
-    "id": 242,
+    "id": 68,
+    "taskId": 230,
     "locality": "Asgarnia: Falador",
     "task": "Defeat the Giant Mole. (50 times)",
     "information": "Kill the giant mole 50 times.",
@@ -1946,15 +621,17 @@
     "points": 30
   },
   {
-    "id": 243,
+    "id": 69,
+    "taskId": 231,
     "locality": "Asgarnia: Falador",
     "task": "Steal some Wine of Zamorak from the Captured Temple, south of Goblin Village.",
     "information": "Steal some wine of Zamorak from the Captured Temple, south of Goblin Village.",
-    "requirements": "33 Magic for Telekinetic Grab",
+    "requirements": "33 Magic",
     "points": 30
   },
   {
-    "id": 244,
+    "id": 70,
+    "taskId": 232,
     "locality": "Asgarnia: Falador",
     "task": "Set up a dwarf cannon.",
     "information": "Set up a dwarf multicannon.",
@@ -1962,7 +639,8 @@
     "points": 30
   },
   {
-    "id": 245,
+    "id": 71,
+    "taskId": 233,
     "locality": "Asgarnia: Falador",
     "task": "Complete a ceremonial sword at the Artisans' Workshop.",
     "information": "Complete a ceremonial sword at the Artisans' Workshop.",
@@ -1970,7 +648,8 @@
     "points": 30
   },
   {
-    "id": 246,
+    "id": 72,
+    "taskId": 234,
     "locality": "Asgarnia: Falador",
     "task": "Mine some orichalcite in the Mining Guild.",
     "information": "Mine some orichalcite ore in the Mining Guild.",
@@ -1978,23 +657,26 @@
     "points": 30
   },
   {
-    "id": 247,
+    "id": 73,
+    "taskId": 235,
     "locality": "Asgarnia: Burthorpe",
     "task": "Harvest a herb from the troll stronghold herb patch.",
     "information": "Harvest a herb from the troll stronghold herb patch.",
-    "requirements": "9 Farming to plant the lowest Herb seed. Completion of My Arm's Big Adventure",
+    "requirements": "9 Farming",
     "points": 30
   },
   {
-    "id": 248,
+    "id": 74,
+    "taskId": 269,
     "locality": "Asgarnia: Taverley",
     "task": "Kill a blue dragon in Taverley dungeon.",
     "information": "Kill a blue dragon in Taverley dungeon.",
-    "requirements": "Dusty key or 70 Agility",
+    "requirements": "70 Agility",
     "points": 30
   },
   {
-    "id": 249,
+    "id": 75,
+    "taskId": 270,
     "locality": "Asgarnia: Taverley",
     "task": "Open the crystal chest in Taverley.",
     "information": "Open the crystal chest in Taverley.",
@@ -2002,7 +684,395 @@
     "points": 30
   },
   {
-    "id": 250,
+    "id": 76,
+    "taskId": 236,
+    "locality": "Asgarnia: Falador",
+    "task": "Reach 100% respect at the Artisans' Workshop.",
+    "information": "Reach 100% respect at the Artisans' Workshop.",
+    "requirements": "1 Smithing",
+    "points": 80
+  },
+  {
+    "id": 77,
+    "taskId": 237,
+    "locality": "Asgarnia: Falador",
+    "task": "Complete the task set: Hard Falador.",
+    "information": "Complete the Hard Falador achievements.",
+    "requirements": "See Hard Falador achievements page",
+    "points": 80
+  },
+  {
+    "id": 78,
+    "taskId": 246,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Defeat any God Wars Dungeon boss 100 times.",
+    "information": "Defeat any God Wars Dungeon boss 100 times.",
+    "requirements": "Partial completion of Troll Stronghold",
+    "points": 80
+  },
+  {
+    "id": 79,
+    "taskId": 247,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Defeat any God Wars Dungeon boss 250 times.",
+    "information": "Defeat any God Wars Dungeon boss 250 times.",
+    "requirements": "Partial completion of Troll Stronghold",
+    "points": 80
+  },
+  {
+    "id": 80,
+    "taskId": 248,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Defeat Commander Zilyana.",
+    "information": "Defeat Commander Zilyana",
+    "requirements": "70 Agility",
+    "points": 80
+  },
+  {
+    "id": 81,
+    "taskId": 249,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Defeat General Graardor.",
+    "information": "Defeat General Graardor",
+    "requirements": "70 Strength",
+    "points": 80
+  },
+  {
+    "id": 82,
+    "taskId": 250,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Defeat K'ril Tsutsaroth.",
+    "information": "Defeat K'ril Tsutsaroth",
+    "requirements": "70 Constitution",
+    "points": 80
+  },
+  {
+    "id": 83,
+    "taskId": 251,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Defeat Kree'arra.",
+    "information": "Defeat Kree'arra",
+    "requirements": "70 Ranged",
+    "points": 80
+  },
+  {
+    "id": 84,
+    "taskId": 252,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Defeat Nex.",
+    "information": "Defeat Nex",
+    "requirements": "70 Agility, 70 Strength, 70 Constitution, 70 Ranged",
+    "points": 80
+  },
+  {
+    "id": 85,
+    "taskId": 253,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Defeat Kree'arra. (100 times)",
+    "information": "Defeat Kree'arra 100 times.",
+    "requirements": "70 Ranged",
+    "points": 80
+  },
+  {
+    "id": 86,
+    "taskId": 254,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Assemble any godsword from the God Wars Dungeon.",
+    "information": "Assemble any godsword from the God Wars Dungeon.",
+    "requirements": "80 Smithing",
+    "points": 80
+  },
+  {
+    "id": 87,
+    "taskId": 264,
+    "locality": "Asgarnia: Port Sarim",
+    "task": "Defeat the Queen Black Dragon.",
+    "information": "Defeat the Queen Black Dragon.",
+    "requirements": "60 Summoning",
+    "points": 80
+  },
+  {
+    "id": 88,
+    "taskId": 265,
+    "locality": "Asgarnia: Port Sarim",
+    "task": "Defeat the Queen Black Dragon. (100 times)",
+    "information": "Defeat the Queen Black Dragon 100 times.",
+    "requirements": "60 Summoning",
+    "points": 80
+  },
+  {
+    "id": 89,
+    "taskId": 266,
+    "locality": "Asgarnia: Port Sarim",
+    "task": "Bury some frost dragon bones.",
+    "information": "Bury some frost dragon bones.",
+    "requirements": "85 Dungeoneering",
+    "points": 80
+  },
+  {
+    "id": 90,
+    "taskId": 238,
+    "locality": "Asgarnia: Falador",
+    "task": "Complete the task set: Elite Falador.",
+    "information": "Complete the Elite Falador achievements.",
+    "requirements": "See Elite Falador achievements page",
+    "points": 150
+  },
+  {
+    "id": 91,
+    "taskId": 239,
+    "locality": "Asgarnia: Falador",
+    "task": "Complete the Invention tutorial.",
+    "information": "Complete the Invention tutorial.",
+    "requirements": "80 Divination, 80 Smithing, 80 Crafting",
+    "points": 150
+  },
+  {
+    "id": 92,
+    "taskId": 240,
+    "locality": "Asgarnia: Falador",
+    "task": "Defeat Vorago, if you think you're hard enough.",
+    "information": "Defeat Vorago.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 93,
+    "taskId": 241,
+    "locality": "Asgarnia: Falador",
+    "task": "Defeat Vorago, if you think you're hard enough. (50 times)",
+    "information": "Defeat Vorago 50 times.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 94,
+    "taskId": 242,
+    "locality": "Asgarnia: Falador",
+    "task": "Equip a seismic wand or seismic singularity.",
+    "information": "Equip a seismic wand or singularity.",
+    "requirements": "90 Magic",
+    "points": 150
+  },
+  {
+    "id": 95,
+    "taskId": 243,
+    "locality": "Asgarnia: Falador",
+    "task": "Harvest some starbloom flowers from the flower patch south of Falador.",
+    "information": "Harvest some starbloom flowers from the flower patch south of Falador.",
+    "requirements": "84 Farming",
+    "points": 150
+  },
+  {
+    "id": 96,
+    "taskId": 244,
+    "locality": "Asgarnia: Falador",
+    "task": "Unlock the Royale Cannon from the Artisans' Workshop reward shop.",
+    "information": "Unlock the royale dwarf multicannon from the Artisans' Workshop Reward Shop.",
+    "requirements": "100% respect",
+    "points": 150
+  },
+  {
+    "id": 97,
+    "taskId": 245,
+    "locality": "Asgarnia: Falador",
+    "task": "Equip a piece of masterwork melee armour.",
+    "information": "Equip a piece of masterwork melee armour.",
+    "requirements": "99 Smithing",
+    "points": 150
+  },
+  {
+    "id": 98,
+    "taskId": 255,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Equip a full set of Bandos armour.",
+    "information": "Equip a full set of Bandos armour.",
+    "requirements": "70 Defence",
+    "points": 150
+  },
+  {
+    "id": 99,
+    "taskId": 256,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Equip a full set of Armadyl armour.",
+    "information": "Equip a full set of Armadyl armour.",
+    "requirements": "70 Defence",
+    "points": 150
+  },
+  {
+    "id": 100,
+    "taskId": 257,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Equip a full set of subjugation armour.",
+    "information": "Equip a full set of subjugation armour.",
+    "requirements": "70 Defence",
+    "points": 150
+  },
+  {
+    "id": 101,
+    "taskId": 258,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Equip a piece of Torva, Pernix or Virtus armour.",
+    "information": "Equip a piece of Torva, Pernix or Virtus armour.",
+    "requirements": "80 Defence",
+    "points": 150
+  },
+  {
+    "id": 102,
+    "taskId": 259,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Defeat Nex, the Angel of Death.",
+    "information": "Kill Nex: Angel of Death.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 103,
+    "taskId": 260,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Defeat Nex, the Angel of Death. (50 times)",
+    "information": "Kill Nex: Angel of Death 50 times.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 104,
+    "taskId": 267,
+    "locality": "Asgarnia: Port Sarim",
+    "task": "Kill a living wyvern.",
+    "information": "Kill a wyvern.",
+    "requirements": "96 Slayer",
+    "points": 150
+  },
+  {
+    "id": 105,
+    "taskId": 261,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Complete all of the Combat Achievements for God Wars Dungeon bosses, including Nex.",
+    "information": "Complete all of the Combat Achievements for God Wars Dungeon bosses, including Nex.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 106,
+    "taskId": 262,
+    "locality": "Asgarnia: Burthorpe",
+    "task": "Unlock all the prayers from the Praesul Codex.",
+    "information": "Unlock all the prayers from the Praesul codex.",
+    "requirements": "99 Prayer",
+    "points": 150
+  },
+  {
+    "id": 107,
+    "taskId": 271,
+    "locality": "Desert: Menaphos",
+    "task": "Enter Menaphos.",
+    "information": "Enter Menaphos.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 108,
+    "taskId": 272,
+    "locality": "Desert: General",
+    "task": "Catch a whirligig at Het's Oasis.",
+    "information": "Catch a whirligig at Het's Oasis.",
+    "requirements": "1 Hunter",
+    "points": 10
+  },
+  {
+    "id": 109,
+    "taskId": 274,
+    "locality": "Desert: General",
+    "task": "Search the Grand Gold Chest in room 1 of Pyramid Plunder in Sophanem.",
+    "information": "Search the grand gold chest in room 1 of Pyramid Plunder in Sophanem.",
+    "requirements": "21 Thieving",
+    "points": 10
+  },
+  {
+    "id": 110,
+    "taskId": 275,
+    "locality": "Desert: General",
+    "task": "Search the Grand Gold Chest in room 2 of Pyramid Plunder in Sophanem.",
+    "information": "Search the grand gold chest in room 2 of Pyramid Plunder in Sophanem.",
+    "requirements": "31 Thieving",
+    "points": 10
+  },
+  {
+    "id": 111,
+    "taskId": 276,
+    "locality": "Desert: General",
+    "task": "Search the Grand Gold Chest in room 3 of Pyramid Plunder in Sophanem.",
+    "information": "Search the grand gold chest in room 3 of Pyramid Plunder in Sophanem.",
+    "requirements": "41 Thieving",
+    "points": 10
+  },
+  {
+    "id": 112,
+    "taskId": 277,
+    "locality": "Desert: General",
+    "task": "Mine a gem rock at the Al Kharid mine.",
+    "information": "Mine a gem rock at the Al Kharid mine. A common gem rock can be mined with level 1 Mining.",
+    "requirements": "1 Mining",
+    "points": 10
+  },
+  {
+    "id": 113,
+    "taskId": 279,
+    "locality": "Desert: General",
+    "task": "Kill a crocodile.",
+    "information": "Kill a crocodile.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 114,
+    "taskId": 280,
+    "locality": "Desert: General",
+    "task": "Create a spirit kalphite pouch at the obelisk south west of Pollnivneach.",
+    "information": "Create a spirit kalphite pouch at the obelisk south west of Pollnivneach.",
+    "requirements": "25 Summoning",
+    "points": 10
+  },
+  {
+    "id": 115,
+    "taskId": 281,
+    "locality": "Desert: Menaphos",
+    "task": "Squish 10 corrupted scarabs.",
+    "information": "Squish 10 corrupted scarabs.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 116,
+    "taskId": 282,
+    "locality": "Desert: General",
+    "task": "Sell a pyramid top to Simon.",
+    "information": "Hand Simon Templeton a pyramid top.",
+    "requirements": "30 Agility",
+    "points": 10
+  },
+  {
+    "id": 117,
+    "taskId": 283,
+    "locality": "Desert: General",
+    "task": "Use any of the magic carpets in the desert.",
+    "information": "Use any of the magic carpets in the desert.",
+    "requirements": "1,000 gp",
+    "points": 10
+  },
+  {
+    "id": 118,
+    "taskId": 284,
+    "locality": "Desert: General",
+    "task": "Harvest a rose at Het's Oasis.",
+    "information": "Harvest a rose at Het's Oasis.",
+    "requirements": "30 Farming",
+    "points": 10
+  },
+  {
+    "id": 119,
+    "taskId": 273,
     "locality": "Desert: General",
     "task": "Clear the Fort debris at the Kharid-et Dig Site.",
     "information": "Clear the fort debris at the Kharid-et Dig Site.",
@@ -2010,7 +1080,8 @@
     "points": 30
   },
   {
-    "id": 251,
+    "id": 120,
+    "taskId": 278,
     "locality": "Desert: General",
     "task": "Complete the quest: One Piercing Note.",
     "information": "Complete One Piercing Note.",
@@ -2018,7 +1089,8 @@
     "points": 30
   },
   {
-    "id": 252,
+    "id": 121,
+    "taskId": 285,
     "locality": "Desert: General",
     "task": "Complete a lap of the Het's Oasis agility course.",
     "information": "Complete a lap of the Het's Oasis agility course.",
@@ -2026,7 +1098,8 @@
     "points": 30
   },
   {
-    "id": 253,
+    "id": 122,
+    "taskId": 286,
     "locality": "Desert: General",
     "task": "Defeat the Kalphite Queen.",
     "information": "Defeat the Kalphite Queen.",
@@ -2034,7 +1107,8 @@
     "points": 30
   },
   {
-    "id": 254,
+    "id": 123,
+    "taskId": 287,
     "locality": "Desert: General",
     "task": "Defeat the Kalphite Queen. (100 times)",
     "information": "Defeat the Kalphite Queen 100 times.",
@@ -2042,7 +1116,8 @@
     "points": 30
   },
   {
-    "id": 255,
+    "id": 124,
+    "taskId": 288,
     "locality": "Desert: General",
     "task": "Defeat 100 bosses in the Dominion Tower.",
     "information": "Defeat 100 bosses in the Dominion Tower.",
@@ -2050,7 +1125,8 @@
     "points": 30
   },
   {
-    "id": 256,
+    "id": 125,
+    "taskId": 289,
     "locality": "Desert: General",
     "task": "Complete the task set: Easy Desert.",
     "information": "Easy desert tasks.",
@@ -2058,7 +1134,8 @@
     "points": 30
   },
   {
-    "id": 257,
+    "id": 126,
+    "taskId": 290,
     "locality": "Desert: General",
     "task": "Complete the task set: Medium Desert.",
     "information": "Medium desert tasks.",
@@ -2066,7 +1143,8 @@
     "points": 30
   },
   {
-    "id": 258,
+    "id": 127,
+    "taskId": 291,
     "locality": "Desert: Menaphos",
     "task": "Steal from the lamp stall in Menaphos.",
     "information": "Steal from the lamp stall in Menaphos.",
@@ -2074,7 +1152,8 @@
     "points": 30
   },
   {
-    "id": 259,
+    "id": 128,
+    "taskId": 292,
     "locality": "Desert: General",
     "task": "Buy some runes from Ali Morrisane.",
     "information": "Buy some runes from Ali Morrisane.",
@@ -2082,7 +1161,8 @@
     "points": 30
   },
   {
-    "id": 260,
+    "id": 129,
+    "taskId": 293,
     "locality": "Desert: Menaphos",
     "task": "Catch a catfish.",
     "information": "Catch a raw catfish.",
@@ -2090,15 +1170,17 @@
     "points": 30
   },
   {
-    "id": 261,
+    "id": 130,
+    "taskId": 294,
     "locality": "Desert: General",
     "task": "Restore a Pontifex signet ring.",
     "information": "Restore a pontifex signet ring.",
-    "requirements": "58 Archaeology, A cut dragonstone, which may require 55 Crafting",
+    "requirements": "58 Archaeology",
     "points": 30
   },
   {
-    "id": 262,
+    "id": 131,
+    "taskId": 295,
     "locality": "Desert: General",
     "task": "Search the Grand Gold Chest in room 4 of Pyramid Plunder in Sophanem.",
     "information": "Search the Grand Gold Chest in room 4 of Pyramid Plunder in Sophanem.",
@@ -2106,7 +1188,8 @@
     "points": 30
   },
   {
-    "id": 263,
+    "id": 132,
+    "taskId": 296,
     "locality": "Desert: General",
     "task": "Search the Grand Gold Chest in room 5 of Pyramid Plunder in Sophanem.",
     "information": "Search the Grand Gold Chest in room 5 of Pyramid Plunder in Sophanem.",
@@ -2114,7 +1197,8 @@
     "points": 30
   },
   {
-    "id": 264,
+    "id": 133,
+    "taskId": 297,
     "locality": "Desert: General",
     "task": "Search the Grand Gold Chest in room 6 of Pyramid Plunder in Sophanem.",
     "information": "Search the Grand Gold Chest in room 6 of Pyramid Plunder in Sophanem.",
@@ -2122,7 +1206,8 @@
     "points": 30
   },
   {
-    "id": 265,
+    "id": 134,
+    "taskId": 298,
     "locality": "Desert: General",
     "task": "Complete the quest: Smoking Kills.",
     "information": "Complete Smoking Kills.",
@@ -2130,7 +1215,8 @@
     "points": 30
   },
   {
-    "id": 266,
+    "id": 135,
+    "taskId": 299,
     "locality": "Desert: General",
     "task": "Complete the quest: Desert Treasure.",
     "information": "Complete Desert Treasure.",
@@ -2138,7 +1224,8 @@
     "points": 30
   },
   {
-    "id": 267,
+    "id": 136,
+    "taskId": 300,
     "locality": "Desert: General",
     "task": "Fully repair the statue of Het.",
     "information": "Repair the statue of Het at Het's Oasis.",
@@ -2146,7 +1233,431 @@
     "points": 30
   },
   {
-    "id": 268,
+    "id": 137,
+    "taskId": 301,
+    "locality": "Desert: General",
+    "task": "Defeat the Kalphite King.",
+    "information": "Defeat the Kalphite King.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 138,
+    "taskId": 302,
+    "locality": "Desert: General",
+    "task": "Defeat the Kalphite King. (100 times)",
+    "information": "Defeat the Kalphite King 100 times.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 139,
+    "taskId": 303,
+    "locality": "Desert: General",
+    "task": "Equip a drygore weapon.",
+    "information": "Equip a drygore weapon.",
+    "requirements": "90 Attack",
+    "points": 80
+  },
+  {
+    "id": 140,
+    "taskId": 304,
+    "locality": "Desert: General",
+    "task": "Become an honorary druid at the Garden of Kharid.",
+    "information": "Purchase the Druid/Druidess title for 50,000 Crux Eqal favour",
+    "requirements": "50 Farming",
+    "points": 80
+  },
+  {
+    "id": 141,
+    "taskId": 305,
+    "locality": "Desert: General",
+    "task": "Deploy a dreadnip.",
+    "information": "Deploy a dreadnip.",
+    "requirements": "450 Dominion Tower kills",
+    "points": 80
+  },
+  {
+    "id": 142,
+    "taskId": 306,
+    "locality": "Desert: General",
+    "task": "Complete the task set: Hard Desert.",
+    "information": "Complete the Hard Desert achievements.",
+    "requirements": "See Hard Desert achievements page",
+    "points": 80
+  },
+  {
+    "id": 143,
+    "taskId": 307,
+    "locality": "Desert: General",
+    "task": "Defeat Avaryss and Nymora.",
+    "information": "Defeat the Twin Furies.",
+    "requirements": "80 Ranged",
+    "points": 80
+  },
+  {
+    "id": 144,
+    "taskId": 308,
+    "locality": "Desert: General",
+    "task": "Defeat Gregorovic.",
+    "information": "Defeat Gregorovic.",
+    "requirements": "80 Prayer",
+    "points": 80
+  },
+  {
+    "id": 145,
+    "taskId": 309,
+    "locality": "Desert: General",
+    "task": "Defeat Vindicta and Gorvek.",
+    "information": "Defeat Vindicta.",
+    "requirements": "80 Attack",
+    "points": 80
+  },
+  {
+    "id": 146,
+    "taskId": 310,
+    "locality": "Desert: General",
+    "task": "Defeat Helwyr.",
+    "information": "Defeat Helwyr.",
+    "requirements": "80 Magic",
+    "points": 80
+  },
+  {
+    "id": 147,
+    "taskId": 311,
+    "locality": "Desert: General",
+    "task": "Defeat Avaryss and Nymora. (100 times)",
+    "information": "Defeat the Twin Furies 100 times.",
+    "requirements": "80 Ranged",
+    "points": 80
+  },
+  {
+    "id": 148,
+    "taskId": 312,
+    "locality": "Desert: General",
+    "task": "Defeat Gregorovic. (100 times)",
+    "information": "Defeat Gregorovic 100 times.",
+    "requirements": "80 Prayer",
+    "points": 80
+  },
+  {
+    "id": 149,
+    "taskId": 313,
+    "locality": "Desert: General",
+    "task": "Defeat Vindicta and Gorvek. (100 times)",
+    "information": "Defeat Vindicta 100 times.",
+    "requirements": "80 Attack",
+    "points": 80
+  },
+  {
+    "id": 150,
+    "taskId": 314,
+    "locality": "Desert: General",
+    "task": "Defeat Helwyr. (100 times)",
+    "information": "Defeat Helwyr 100 times.",
+    "requirements": "80 Magic",
+    "points": 80
+  },
+  {
+    "id": 151,
+    "taskId": 315,
+    "locality": "Desert: General",
+    "task": "Equip a Dragon Rider lance.",
+    "information": "Equip a Dragon Rider lance.",
+    "requirements": "85 Attack",
+    "points": 80
+  },
+  {
+    "id": 152,
+    "taskId": 316,
+    "locality": "Desert: General",
+    "task": "Equip a wand or orb of the Cywir elders.",
+    "information": "Equip a wand or orb of the Cywir elders.",
+    "requirements": "85 Magic",
+    "points": 80
+  },
+  {
+    "id": 153,
+    "taskId": 317,
+    "locality": "Desert: General",
+    "task": "Equip a shadow glaive.",
+    "information": "Equip a shadow glaive.",
+    "requirements": "85 Ranged",
+    "points": 80
+  },
+  {
+    "id": 154,
+    "taskId": 318,
+    "locality": "Desert: General",
+    "task": "Equip a blade of Nymora or Avaryss.",
+    "information": "Equip a blade of Nymora or Avaryss.",
+    "requirements": "85 Attack",
+    "points": 80
+  },
+  {
+    "id": 155,
+    "taskId": 319,
+    "locality": "Desert: Menaphos",
+    "task": "Slay a combination of 500 corrupted or devourer creatures.",
+    "information": "Slay a combination of 500 corrupted creatures or soul devourers.",
+    "requirements": "88 Slayer",
+    "points": 80
+  },
+  {
+    "id": 156,
+    "taskId": 320,
+    "locality": "Desert: General",
+    "task": "Defeat the Magister.",
+    "information": "Defeat the Magister.",
+    "requirements": "115 Slayer",
+    "points": 80
+  },
+  {
+    "id": 157,
+    "taskId": 321,
+    "locality": "Desert: General",
+    "task": "Defeat the Magister. (50 times)",
+    "information": "Defeat the Magister 50 times.",
+    "requirements": "115 Slayer",
+    "points": 80
+  },
+  {
+    "id": 158,
+    "taskId": 322,
+    "locality": "Desert: Menaphos",
+    "task": "Find an Off-hand khopesh of the Kharidian in Shifting Tombs.",
+    "information": "Find an off-hand khopesh of the Kharidian in Shifting Tombs.",
+    "requirements": "50 Dungeoneering, 50 Agility, 50 Thieving, or 50 Construction",
+    "points": 80
+  },
+  {
+    "id": 159,
+    "taskId": 323,
+    "locality": "Desert: General",
+    "task": "Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.",
+    "information": "Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.",
+    "requirements": "81 Thieving",
+    "points": 80
+  },
+  {
+    "id": 160,
+    "taskId": 324,
+    "locality": "Desert: General",
+    "task": "Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.",
+    "information": "Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.",
+    "requirements": "91 Thieving",
+    "points": 80
+  },
+  {
+    "id": 161,
+    "taskId": 325,
+    "locality": "Desert: Menaphos",
+    "task": "Complete the quest: Beneath Scabaras' Sands.",
+    "information": "Complete Beneath Scabaras' Sands.",
+    "requirements": "See quest page",
+    "points": 80
+  },
+  {
+    "id": 162,
+    "taskId": 326,
+    "locality": "Desert: General",
+    "task": "Kill a desert strykewyrm wearing a Full Slayer Helm and wielding an ancient staff.",
+    "information": "Kill a desert strykewyrm wearing a full Slayer helm and wielding an ancient staff.",
+    "requirements": "77 Slayer, 50 Magic, 20 Defence, 55 Crafting",
+    "points": 80
+  },
+  {
+    "id": 163,
+    "taskId": 328,
+    "locality": "Desert: General",
+    "task": "Defeat Telos, the Warden.",
+    "information": "Defeat Telos, the Warden.",
+    "requirements": "80 Attack, 80 Prayer, 80 Magic, 80 Ranged",
+    "points": 80
+  },
+  {
+    "id": 164,
+    "taskId": 327,
+    "locality": "Desert: General",
+    "task": "Complete the task set: Elite Desert.",
+    "information": "Complete the Elite Desert achievements.",
+    "requirements": "See Elite Desert achievements page",
+    "points": 150
+  },
+  {
+    "id": 165,
+    "taskId": 329,
+    "locality": "Desert: General",
+    "task": "Defeat Telos, the Warden at 100% enrage.",
+    "information": "Defeat Telos, the Warden at 100% enrage.",
+    "requirements": "80 Attack, 80 Prayer, 80 Magic, 80 Ranged",
+    "points": 150
+  },
+  {
+    "id": 166,
+    "taskId": 330,
+    "locality": "Desert: General",
+    "task": "Defeat Telos, the Warden at 500% enrage.",
+    "information": "Defeat Telos, the Warden at 500% enrage.",
+    "requirements": "80 Attack, 80 Prayer, 80 Magic, 80 Ranged",
+    "points": 150
+  },
+  {
+    "id": 167,
+    "taskId": 331,
+    "locality": "Desert: Menaphos",
+    "task": "Craft some Soul runes.",
+    "information": "Craft some soul runes.",
+    "requirements": "90 Runecrafting",
+    "points": 150
+  },
+  {
+    "id": 168,
+    "taskId": 332,
+    "locality": "Desert: General",
+    "task": "Defeat a Camel Warrior.",
+    "information": "Defeat a camel warrior.",
+    "requirements": "96 Slayer",
+    "points": 150
+  },
+  {
+    "id": 169,
+    "taskId": 333,
+    "locality": "Desert: General",
+    "task": "Escape Kharid-et by boat.",
+    "information": "Complete the Aquatic Escape achievement.",
+    "requirements": "93 Archaeology",
+    "points": 150
+  },
+  {
+    "id": 170,
+    "taskId": 334,
+    "locality": "Desert: General",
+    "task": "Defeat the Kalphite King solo.",
+    "information": "Kill the Kalphite King solo.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 171,
+    "taskId": 335,
+    "locality": "Desert: General",
+    "task": "Cast Ice Barrage in the desert.",
+    "information": "Cast Ice Barrage in the desert.",
+    "requirements": "94 Magic",
+    "points": 150
+  },
+  {
+    "id": 172,
+    "taskId": 337,
+    "locality": "Desert: General",
+    "task": "Craft a Zaros godsword, Seren godbow or staff of Sliske.",
+    "information": "Craft a Zaros godsword, Seren godbow or staff of Sliske.",
+    "requirements": "92 Smithing",
+    "points": 150
+  },
+  {
+    "id": 173,
+    "taskId": 1112,
+    "locality": "Desert: Menaphos",
+    "task": "Defeat Amascut, the Devourer.",
+    "information": "Defeat Amascut, the Devourer.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 174,
+    "taskId": 336,
+    "locality": "Desert: General",
+    "task": "Defeat Telos, the Warden at 1,000% enrage.",
+    "information": "Defeat Telos, the Warden at 1000% enrage.",
+    "requirements": "80 Attack, 80 Prayer, 80 Magic, 80 Ranged",
+    "points": 150
+  },
+  {
+    "id": 175,
+    "taskId": 338,
+    "locality": "Desert: General",
+    "task": "Complete all of the Combat Achievements for the Heart of Gielinor bosses (excluding Telos).",
+    "information": "Complete all of the Combat Achievements for the Heart of Gielinor bosses (excluding Telos).",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 176,
+    "taskId": 1113,
+    "locality": "Desert: Menaphos",
+    "task": "Defeat Amascut, the Devourer. (100 times)",
+    "information": "Defeat Amascut, the Devourer 100 times.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 177,
+    "taskId": 339,
+    "locality": "Fremennik: Lunar Isles",
+    "task": "Switch to the Lunar Spellbook at the astral altar.",
+    "information": "Switch to the Lunar Spellbook at the astral altar.",
+    "requirements": "Completion of Lunar Diplomacy",
+    "points": 10
+  },
+  {
+    "id": 178,
+    "taskId": 340,
+    "locality": "Fremennik: Mainland",
+    "task": "Defeat a Rock Crab in the Fremennik Province.",
+    "information": "Defeat a Rock Crab in the Fremennik Province.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 179,
+    "taskId": 341,
+    "locality": "Fremennik: Mainland",
+    "task": "Defeat a Cockatrice in the Fremennik Province.",
+    "information": "Defeat a cockatrice in the Fremennik Province.",
+    "requirements": "25 Slayer",
+    "points": 10
+  },
+  {
+    "id": 180,
+    "taskId": 342,
+    "locality": "Fremennik: Mainland",
+    "task": "Defeat a Troll in the Fremennik Province.",
+    "information": "Defeat a troll in the Fremennik Province.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 181,
+    "taskId": 343,
+    "locality": "Fremennik: Mainland",
+    "task": "Deposit an item with Peer the Seer.",
+    "information": "Deposit an item with Peer the Seer.",
+    "requirements": "Completion of the easy Fremennik achievements",
+    "points": 10
+  },
+  {
+    "id": 182,
+    "taskId": 344,
+    "locality": "Fremennik: Mainland",
+    "task": "Use the Bank on Jatizso or Neitiznot.",
+    "information": "Use the Bank on Jatizso or Neitiznot.",
+    "requirements": "Partial completion of The Fremennik Isles",
+    "points": 10
+  },
+  {
+    "id": 183,
+    "taskId": 346,
+    "locality": "Fremennik: Mainland",
+    "task": "Catch a Sapphire Glacialis.",
+    "information": "Catch a Sapphire Glacialis.",
+    "requirements": "25 Hunter",
+    "points": 10
+  },
+  {
+    "id": 184,
+    "taskId": 347,
     "locality": "Fremennik: Lunar Isles",
     "task": "Cast Moonclan Teleport.",
     "information": "Cast Moonclan Teleport.",
@@ -2154,47 +1665,53 @@
     "points": 30
   },
   {
-    "id": 269,
+    "id": 185,
+    "taskId": 348,
     "locality": "Fremennik: Mainland",
     "task": "Move Your House to Rellekka.",
     "information": "Move your player-owned house's location to Rellekka by speaking to an estate agent.",
-    "requirements": "30 Construction, 10,000",
+    "requirements": "30 Construction",
     "points": 30
   },
   {
-    "id": 270,
+    "id": 186,
+    "taskId": 349,
     "locality": "Fremennik: Lunar Isles",
     "task": "Craft 50 Astral Runes.",
     "information": "Craft 50 astral runes.",
-    "requirements": "40 Runecrafting, Completion of Lunar Diplomacy",
+    "requirements": "40 Runecrafting",
     "points": 30
   },
   {
-    "id": 271,
+    "id": 187,
+    "taskId": 350,
     "locality": "Fremennik: Mainland",
     "task": "Complete the Penguin Agility Course.",
     "information": "Complete the Penguin Agility Course.",
-    "requirements": "30 Agility, Completion of Cold War",
+    "requirements": "30 Agility",
     "points": 30
   },
   {
-    "id": 272,
+    "id": 188,
+    "taskId": 351,
     "locality": "Fremennik: Mainland",
     "task": "Catch a Snowy Knight.",
     "information": "Catch a Snowy Knight.",
-    "requirements": "35 Hunter, A butterfly net and jar",
+    "requirements": "35 Hunter",
     "points": 30
   },
   {
-    "id": 273,
+    "id": 189,
+    "taskId": 352,
     "locality": "Fremennik: Mainland",
     "task": "Defeat a Kurask in the Fremennik Province.",
     "information": "Defeat a Kurask in the Fremennik Province.",
-    "requirements": "70 Slayer, Leaf-bladed spear or other special weapon",
+    "requirements": "70 Slayer",
     "points": 30
   },
   {
-    "id": 274,
+    "id": 190,
+    "taskId": 353,
     "locality": "Fremennik: Mainland",
     "task": "Defeat a Dagannoth in the Fremennik Province.",
     "information": "Defeat a dagannoth in the Fremennik Province.",
@@ -2202,15 +1719,17 @@
     "points": 30
   },
   {
-    "id": 275,
+    "id": 191,
+    "taskId": 354,
     "locality": "Fremennik: Mainland",
     "task": "Equip a Helm of Neitiznot.",
     "information": "Equip a Helm of Neitiznot.",
-    "requirements": "55 Defence, Completion of The Fremennik Isles",
+    "requirements": "55 Defence",
     "points": 30
   },
   {
-    "id": 276,
+    "id": 192,
+    "taskId": 355,
     "locality": "Fremennik: Mainland",
     "task": "Defeat a Jelly in the Fremennik Province.",
     "information": "Defeat a jelly in the Fremennik Province.",
@@ -2218,7 +1737,8 @@
     "points": 30
   },
   {
-    "id": 277,
+    "id": 193,
+    "taskId": 356,
     "locality": "Fremennik: Mainland",
     "task": "Complete the quest: Throne of Miscellania.",
     "information": "Complete Throne of Miscellania.",
@@ -2226,7 +1746,8 @@
     "points": 30
   },
   {
-    "id": 278,
+    "id": 194,
+    "taskId": 357,
     "locality": "Fremennik: Mainland",
     "task": "Complete the quest: Royal Trouble.",
     "information": "Complete Royal Trouble.",
@@ -2234,23 +1755,26 @@
     "points": 30
   },
   {
-    "id": 279,
+    "id": 195,
+    "taskId": 358,
     "locality": "Fremennik: Mainland",
     "task": "Equip a Granite Shield.",
     "information": "Equip a granite shield.",
-    "requirements": "55 Defence, 55 Strength, Either completion of Eadgar's Ruse or partial completion of The Fremennik Isles",
+    "requirements": "55 Defence, 55 Strength",
     "points": 30
   },
   {
-    "id": 280,
+    "id": 196,
+    "taskId": 359,
     "locality": "Fremennik: Mainland",
     "task": "Equip a full set of Graahk, Larupia or Kyatt hunter gear.",
     "information": "Equip a full set of graahk, larupia or kyatt hunter gear.",
-    "requirements": "31 Hunter to hunt spined larupia",
+    "requirements": "31 Hunter",
     "points": 30
   },
   {
-    "id": 281,
+    "id": 197,
+    "taskId": 360,
     "locality": "Fremennik: Mainland",
     "task": "Defeat any of the Dagannoth Kings.",
     "information": "Defeat any of the Dagannoth Kings 1 time.",
@@ -2258,7 +1782,8 @@
     "points": 30
   },
   {
-    "id": 282,
+    "id": 198,
+    "taskId": 361,
     "locality": "Fremennik: Mainland",
     "task": "Defeat any of the Dagannoth Kings.",
     "information": "Defeat any of the Dagannoth Kings 100 times.",
@@ -2266,15 +1791,17 @@
     "points": 30
   },
   {
-    "id": 283,
+    "id": 199,
+    "taskId": 362,
     "locality": "Fremennik: Mainland",
     "task": "Complete the task set: Easy Fremennik.",
-    "information": "",
-    "requirements": "N/A",
+    "information": "Complete the Easy Fremennik achievements.",
+    "requirements": "See Easy Fremennik achievements page",
     "points": 30
   },
   {
-    "id": 284,
+    "id": 200,
+    "taskId": 363,
     "locality": "Fremennik: Mainland",
     "task": "Ride a mine cart into Keldagrim.",
     "information": "Ride a mine cart into Keldagrim.",
@@ -2282,7 +1809,8 @@
     "points": 30
   },
   {
-    "id": 285,
+    "id": 201,
+    "taskId": 364,
     "locality": "Fremennik: Mainland",
     "task": "Travel to the Mammoth Iceberg.",
     "information": "Travel to the Mammoth Iceberg.",
@@ -2290,15 +1818,17 @@
     "points": 30
   },
   {
-    "id": 286,
+    "id": 202,
+    "taskId": 365,
     "locality": "Fremennik: Mainland",
     "task": "Steal from the fish stall in Rellekka.",
     "information": "Steal from the fish stall in Rellekka.",
-    "requirements": "42 Thieving, Completion of The Fremennik Trials",
+    "requirements": "42 Thieving",
     "points": 30
   },
   {
-    "id": 287,
+    "id": 203,
+    "taskId": 366,
     "locality": "Fremennik: Mainland",
     "task": "Harvest 100 sparkling energy from Sparkling Wisps.",
     "information": "Harvest 100 sparkling energy from sparkling wisps.",
@@ -2306,7 +1836,8 @@
     "points": 30
   },
   {
-    "id": 288,
+    "id": 204,
+    "taskId": 367,
     "locality": "Fremennik: Mainland",
     "task": "Climb to the top of the lighthouse.",
     "information": "Climb to the top of the lighthouse.",
@@ -2314,15 +1845,17 @@
     "points": 30
   },
   {
-    "id": 289,
+    "id": 205,
+    "taskId": 368,
     "locality": "Fremennik: Mainland",
     "task": "Chop 10 Artic[sic] Pine trees.",
     "information": "Chop 10 arctic pine trees.",
-    "requirements": "54 Woodcutting, Partial completion of The Fremennik Isles",
+    "requirements": "54 Woodcutting",
     "points": 30
   },
   {
-    "id": 290,
+    "id": 206,
+    "taskId": 369,
     "locality": "Fremennik: Mainland",
     "task": "Kill 25 Yaks.",
     "information": "Kill 25 yaks.",
@@ -2330,7 +1863,8 @@
     "points": 30
   },
   {
-    "id": 291,
+    "id": 207,
+    "taskId": 370,
     "locality": "Fremennik: Mainland",
     "task": "Interact with a pet rock.",
     "information": "Interact with a pet rock.",
@@ -2338,7 +1872,8 @@
     "points": 30
   },
   {
-    "id": 292,
+    "id": 208,
+    "taskId": 383,
     "locality": "Fremennik: Mainland",
     "task": "Complete the task set: Medium Fremennik.",
     "information": "Complete the Medium Fremennik achievements.",
@@ -2346,7 +1881,1223 @@
     "points": 30
   },
   {
+    "id": 209,
+    "taskId": 371,
+    "locality": "Fremennik: Lunar Isles",
+    "task": "Cast Fertile Soil.",
+    "information": "Cast Fertile Soil.",
+    "requirements": "83 Magic",
+    "points": 80
+  },
+  {
+    "id": 210,
+    "taskId": 372,
+    "locality": "Fremennik: Mainland",
+    "task": "Build a Gilded Altar.",
+    "information": "Build a gilded altar in your player-owned house's chapel.",
+    "requirements": "75 Construction",
+    "points": 80
+  },
+  {
+    "id": 211,
+    "taskId": 373,
+    "locality": "Fremennik: Mainland",
+    "task": "Trap a Sabre-Toothed Kyatt.",
+    "information": "Trap a sabre-toothed kyatt.",
+    "requirements": "55 Hunter",
+    "points": 80
+  },
+  {
+    "id": 212,
+    "taskId": 374,
+    "locality": "Fremennik: Mainland",
+    "task": "Defeat all the Dagannoth Kings without leaving a solo boss instance.",
+    "information": "Defeat all the Dagannoth Kings without leaving a solo boss instance.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 213,
+    "taskId": 375,
+    "locality": "Fremennik: Mainland",
+    "task": "Equip a Berserker, Warrior, Seers, or Archers Ring.",
+    "information": "Equip a Berserker, Warrior, Seers, or Archers Ring.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 214,
+    "taskId": 376,
+    "locality": "Fremennik: Mainland",
+    "task": "Use the Special Attack of a Dragon Axe.",
+    "information": "Use the special attack of a dragon hatchet.",
+    "requirements": "60 Attack",
+    "points": 80
+  },
+  {
+    "id": 215,
+    "taskId": 377,
+    "locality": "Fremennik: Mainland",
+    "task": "Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.",
+    "information": "Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.",
+    "requirements": "25 Defence",
+    "points": 80
+  },
+  {
+    "id": 216,
+    "taskId": 378,
+    "locality": "Fremennik: Mainland",
+    "task": "Equip a full set of Skeletal, Spined, or Rockshell armour.",
+    "information": "Equip a full skeletal, spined, or rock-shell armour set.",
+    "requirements": "50 Defence",
+    "points": 80
+  },
+  {
+    "id": 217,
+    "taskId": 379,
+    "locality": "Fremennik: Mainland",
+    "task": "Collect Miscellania Resources at Full Approval.",
+    "information": "Collect from Managing Miscellania with a 100% approval rating.",
+    "requirements": "Completion of Throne of Miscellania",
+    "points": 80
+  },
+  {
+    "id": 218,
+    "taskId": 380,
+    "locality": "Fremennik: Mainland",
+    "task": "Travel to the island of Ungael.",
+    "information": "Travel to the island of Ungael.",
+    "requirements": "Partial completion of Ancient Awakening",
+    "points": 80
+  },
+  {
+    "id": 219,
+    "taskId": 381,
+    "locality": "Fremennik: Mainland",
+    "task": "Adopt a baby yak.",
+    "information": "Obtain an unchecked/baby Fremennik yak.",
+    "requirements": "71 Farming",
+    "points": 80
+  },
+  {
+    "id": 220,
+    "taskId": 382,
+    "locality": "Fremennik: Mainland",
+    "task": "Catch 50 Azure Skillchompas.",
+    "information": "Catch 50 azure skillchompas.",
+    "requirements": "68 Hunter",
+    "points": 80
+  },
+  {
+    "id": 221,
+    "taskId": 384,
+    "locality": "Fremennik: Mainland",
+    "task": "Mine 10 Banite Ore north of Rellekka.",
+    "information": "Mine 10 Banite ore in the arctic (azure) habitat mine.",
+    "requirements": "80 Mining",
+    "points": 80
+  },
+  {
+    "id": 222,
+    "taskId": 385,
+    "locality": "Fremennik: Mainland",
+    "task": "Smith a piece of Bane equipment to +4 in Rellekka.",
+    "information": "Upgrade a piece of bane equipment to +4 in Rellekka.",
+    "requirements": "80 Smithing",
+    "points": 80
+  },
+  {
+    "id": 223,
+    "taskId": 386,
+    "locality": "Fremennik: Mainland",
+    "task": "Use a Crystal triskelion key to obtain some treasures.",
+    "information": "Use a crystal triskelion to obtain some treasures.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 224,
+    "taskId": 388,
+    "locality": "Fremennik: Mainland",
+    "task": "Create a Catherby Teleport Tablet.",
+    "information": "Create a Catherby teleport tablet.",
+    "requirements": "87 Magic, 67 Construction",
+    "points": 80
+  },
+  {
+    "id": 225,
+    "taskId": 392,
+    "locality": "Fremennik: Mainland",
+    "task": "Gather a seed from an Aquanite using Seedicide.",
+    "information": "Gather a seed from an aquanite using Seedicide.",
+    "requirements": "78 Slayer",
+    "points": 80
+  },
+  {
+    "id": 226,
+    "taskId": 393,
+    "locality": "Fremennik: Mainland",
+    "task": "Complete the task set: Hard Fremennik.",
+    "information": "Complete the Hard Fremennik achievements.",
+    "requirements": "See Hard Fremennik achievements page",
+    "points": 80
+  },
+  {
+    "id": 227,
+    "taskId": 387,
+    "locality": "Fremennik: Lunar Isles",
+    "task": "Cast Spellbook Swap from the Lunar spellbook.",
+    "information": "Cast Spellbook Swap from the lunar spellbook.",
+    "requirements": "96 Magic",
+    "points": 150
+  },
+  {
+    "id": 228,
+    "taskId": 389,
+    "locality": "Fremennik: Mainland",
+    "task": "Equip Every Dagannoth King Ring.",
+    "information": "Equip every Dagannoth King ring.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 229,
+    "taskId": 390,
+    "locality": "Fremennik: Mainland",
+    "task": "Equip a Completed God Book.",
+    "information": "Equip a completed god book.",
+    "requirements": "Completion of Horror from the Deep",
+    "points": 150
+  },
+  {
+    "id": 230,
+    "taskId": 391,
+    "locality": "Fremennik: Mainland",
+    "task": "Defeat 20 Acheron Mammoths.",
+    "information": "Defeat 20 acheron mammoths.",
+    "requirements": "96 Slayer",
+    "points": 150
+  },
+  {
+    "id": 231,
+    "taskId": 394,
+    "locality": "Fremennik: Mainland",
+    "task": "Cast the Paradox spell on any tree, rock, fishing spot, or box trap.",
+    "information": "Cast the Paradox spell on any tree, rock, fishing spot, or box trap.",
+    "requirements": "99 Necromancy",
+    "points": 150
+  },
+  {
+    "id": 232,
+    "taskId": 395,
+    "locality": "Fremennik: Mainland",
+    "task": "Build a Demonic Throne.",
+    "information": "Build a demonic throne.",
+    "requirements": "99 Construction",
+    "points": 150
+  },
+  {
+    "id": 233,
+    "taskId": 397,
+    "locality": "Fremennik: Lunar Isles",
+    "task": "Perform a Powerful Necroplasm ritual at the Ungael ritual site.",
+    "information": "Perform a powerful necroplasm ritual at the Ungael ritual site.",
+    "requirements": "90 Necromancy",
+    "points": 150
+  },
+  {
+    "id": 234,
+    "taskId": 398,
+    "locality": "Fremennik: Mainland",
+    "task": "Defeat the Abomination once after Hero's Welcome.",
+    "information": "Defeat the Abomination once after Hero's Welcome.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 235,
+    "taskId": 399,
+    "locality": "Fremennik: Mainland",
+    "task": "Summon a Pack Mammoth.",
+    "information": "Summon a pack mammoth.",
+    "requirements": "96 Summoning",
+    "points": 150
+  },
+  {
+    "id": 236,
+    "taskId": 400,
+    "locality": "Fremennik: Mainland",
+    "task": "Complete the task set: Elite Fremennik.",
+    "information": "Complete the Elite Fremennik achievements.",
+    "requirements": "See Elite Fremennik achievements page",
+    "points": 150
+  },
+  {
+    "id": 237,
+    "taskId": 401,
+    "locality": "Fremennik: Mainland",
+    "task": "Complete the Ungael combat activity on hard mode.",
+    "information": "Complete the Ungael combat activity on hard mode.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 238,
+    "taskId": 402,
+    "locality": "Fremennik: Mainland",
+    "task": "Use the Trap Telekinesis spell to catch Azure Skillchompas 25 times.",
+    "information": "Use the Trap Telekinesis spell to catch azure skillchompas 25 times.",
+    "requirements": "70 Magic",
+    "points": 150
+  },
+  {
+    "id": 239,
+    "taskId": 396,
+    "locality": "Fremennik: Mainland",
+    "task": "Equip every completed God Book.",
+    "information": "Equip every completed god book.",
+    "requirements": "Completion of Horror from the Deep",
+    "points": 150
+  },
+  {
+    "id": 240,
+    "taskId": 127,
+    "locality": "Global",
+    "task": "Level up any of your skills for the first time.",
+    "information": "Level up any of your skills for the first time.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 241,
+    "taskId": 128,
+    "locality": "Global",
+    "task": "Reach level 5 in any skill.",
+    "information": "Reach level 5 in any skill.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 242,
+    "taskId": 129,
+    "locality": "Global",
+    "task": "Reach level 10 in any skill.",
+    "information": "Reach level 10 in any skill.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 243,
+    "taskId": 130,
+    "locality": "Global",
+    "task": "Reach level 20 in any skill.",
+    "information": "Reach level 20 in any skill.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 244,
+    "taskId": 136,
+    "locality": "Global",
+    "task": "Reach combat level 5.",
+    "information": "Reach combat level 5.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 245,
+    "taskId": 137,
+    "locality": "Global",
+    "task": "Reach combat level 10.",
+    "information": "Reach combat level 10.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 246,
+    "taskId": 141,
+    "locality": "Global",
+    "task": "Reach total level 50.",
+    "information": "Reach total level 50.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 247,
+    "taskId": 142,
+    "locality": "Global",
+    "task": "Reach total level 100.",
+    "information": "Reach total level 100.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 248,
+    "taskId": 147,
+    "locality": "Global",
+    "task": "Mine a copper ore.",
+    "information": "Mine copper ore from a copper rock.",
+    "requirements": "1 Mining",
+    "points": 10
+  },
+  {
+    "id": 249,
+    "taskId": 148,
+    "locality": "Global",
+    "task": "Mine 10 copper ore.",
+    "information": "Mine 10 copper ore.",
+    "requirements": "1 Mining",
+    "points": 10
+  },
+  {
+    "id": 250,
+    "taskId": 149,
+    "locality": "Global",
+    "task": "Mine a tin ore.",
+    "information": "Mine tin ore from a tin rock.",
+    "requirements": "1 Mining",
+    "points": 10
+  },
+  {
+    "id": 251,
+    "taskId": 150,
+    "locality": "Global",
+    "task": "Mine 10 tin ore.",
+    "information": "Mine 10 tin ore.",
+    "requirements": "1 Mining",
+    "points": 10
+  },
+  {
+    "id": 252,
+    "taskId": 151,
+    "locality": "Global",
+    "task": "Smelt a bronze bar.",
+    "information": "Smelt a bronze bar.",
+    "requirements": "1 Smithing",
+    "points": 10
+  },
+  {
+    "id": 253,
+    "taskId": 152,
+    "locality": "Global",
+    "task": "Smelt 10 bronze bars.",
+    "information": "Smelt 10 bronze bars.",
+    "requirements": "1 Smithing",
+    "points": 10
+  },
+  {
+    "id": 254,
+    "taskId": 153,
+    "locality": "Global",
+    "task": "Smith any bronze item.",
+    "information": "Smith any bronze item.",
+    "requirements": "1 Smithing",
+    "points": 10
+  },
+  {
+    "id": 255,
+    "taskId": 154,
+    "locality": "Global",
+    "task": "Mine clay.",
+    "information": "Mine clay.",
+    "requirements": "1 Mining",
+    "points": 10
+  },
+  {
+    "id": 256,
+    "taskId": 155,
+    "locality": "Global",
+    "task": "Make some soft clay.",
+    "information": "Make soft clay by using clay on a water source or with a container of water",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 257,
+    "taskId": 156,
+    "locality": "Global",
+    "task": "Mine any ore 5 times.",
+    "information": "Mine any ore 5 times.",
+    "requirements": "1 Mining",
+    "points": 10
+  },
+  {
+    "id": 258,
+    "taskId": 159,
+    "locality": "Global",
+    "task": "Chop any tree 5 times.",
+    "information": "Chop any tree 5 times.",
+    "requirements": "1 Woodcutting",
+    "points": 10
+  },
+  {
+    "id": 259,
+    "taskId": 162,
+    "locality": "Global",
+    "task": "Chop a basic tree.",
+    "information": "Chop a basic tree.",
+    "requirements": "1 Woodcutting",
+    "points": 10
+  },
+  {
+    "id": 260,
+    "taskId": 163,
+    "locality": "Global",
+    "task": "Chop 10 basic trees.",
+    "information": "Chop 10 basic trees.",
+    "requirements": "1 Woodcutting",
+    "points": 10
+  },
+  {
+    "id": 261,
+    "taskId": 164,
+    "locality": "Global",
+    "task": "Chop an oak tree.",
+    "information": "Chop an oak tree.",
+    "requirements": "10 Woodcutting",
+    "points": 10
+  },
+  {
+    "id": 262,
+    "taskId": 166,
+    "locality": "Global",
+    "task": "Burn any logs.",
+    "information": "Burn any logs.",
+    "requirements": "1 Firemaking",
+    "points": 10
+  },
+  {
+    "id": 263,
+    "taskId": 167,
+    "locality": "Global",
+    "task": "Burn any logs 5 times.",
+    "information": "Burn any logs 5 times.",
+    "requirements": "1 Firemaking",
+    "points": 10
+  },
+  {
+    "id": 264,
+    "taskId": 170,
+    "locality": "Global",
+    "task": "Catch a shrimp.",
+    "information": "Catch a raw shrimp.",
+    "requirements": "1 Fishing",
+    "points": 10
+  },
+  {
+    "id": 265,
+    "taskId": 171,
+    "locality": "Global",
+    "task": "Catch 10 shrimp.",
+    "information": "Catch 10 raw shrimps.",
+    "requirements": "1 Fishing",
+    "points": 10
+  },
+  {
+    "id": 266,
+    "taskId": 172,
+    "locality": "Global",
+    "task": "Catch an anchovy.",
+    "information": "Catch a raw anchovy.",
+    "requirements": "15 Fishing",
+    "points": 10
+  },
+  {
+    "id": 267,
+    "taskId": 173,
+    "locality": "Global",
+    "task": "Catch a herring.",
+    "information": "Catch a raw herring.",
+    "requirements": "10 Fishing",
+    "points": 10
+  },
+  {
+    "id": 268,
+    "taskId": 174,
+    "locality": "Global",
+    "task": "Cook shrimp, meat, or chicken.",
+    "information": "Cook raw shrimps, raw meat, or raw chicken.",
+    "requirements": "1 Cooking",
+    "points": 10
+  },
+  {
+    "id": 269,
+    "taskId": 175,
+    "locality": "Global",
+    "task": "Cook 10 shrimp, meat, or chicken.",
+    "information": "Cook 10 raw shrimps, raw meat, or raw chicken.",
+    "requirements": "1 Cooking",
+    "points": 10
+  },
+  {
+    "id": 270,
+    "taskId": 176,
+    "locality": "Global",
+    "task": "Burn any food.",
+    "information": "Burn any food.",
+    "requirements": "1 Cooking",
+    "points": 10
+  },
+  {
+    "id": 271,
+    "taskId": 177,
+    "locality": "Global",
+    "task": "Catch any fish 5 times.",
+    "information": "Catch any fish 5 times.",
+    "requirements": "1 Fishing",
+    "points": 10
+  },
+  {
+    "id": 272,
+    "taskId": 180,
+    "locality": "Global",
+    "task": "Bury any bones.",
+    "information": "Bury any bones.",
+    "requirements": "1 Prayer",
+    "points": 10
+  },
+  {
+    "id": 273,
+    "taskId": 181,
+    "locality": "Global",
+    "task": "Bury any bones 10 times.",
+    "information": "Bury any bones 10 times.",
+    "requirements": "1 Prayer",
+    "points": 10
+  },
+  {
+    "id": 274,
+    "taskId": 182,
+    "locality": "Global",
+    "task": "Activate the thick skin, rock skin, or steel skin Prayer.",
+    "information": "Activate the Thick Skin, Rock Skin, or Steel Skin prayer.",
+    "requirements": "1 Prayer",
+    "points": 10
+  },
+  {
+    "id": 275,
+    "taskId": 183,
+    "locality": "Global",
+    "task": "Run out of Prayer points.",
+    "information": "Run out of Prayer points.",
+    "requirements": "1 Prayer",
+    "points": 10
+  },
+  {
+    "id": 276,
+    "taskId": 186,
+    "locality": "Global",
+    "task": "Harvest any memory from a wisp 5 times.",
+    "information": "Harvest any memory from a wisp 5 times.",
+    "requirements": "1 Divination",
+    "points": 10
+  },
+  {
+    "id": 277,
+    "taskId": 189,
+    "locality": "Global",
+    "task": "Pickpocket from a man or woman.",
+    "information": "Pickpocket from a man or woman.",
+    "requirements": "1 Thieving",
+    "points": 10
+  },
+  {
+    "id": 278,
+    "taskId": 190,
+    "locality": "Global",
+    "task": "Pickpocket from a man or woman 10 times.",
+    "information": "Pickpocket from a man or woman 10 times.",
+    "requirements": "1 Thieving",
+    "points": 10
+  },
+  {
+    "id": 279,
+    "taskId": 191,
+    "locality": "Global",
+    "task": "Steal from any stall.",
+    "information": "Steal from any stall.",
+    "requirements": "2 Thieving",
+    "points": 10
+  },
+  {
+    "id": 280,
+    "taskId": 192,
+    "locality": "Global",
+    "task": "Steal from any stall 10 times.",
+    "information": "Steal from any stall 10 times.",
+    "requirements": "2 Thieving",
+    "points": 10
+  },
+  {
+    "id": 281,
+    "taskId": 193,
+    "locality": "Global",
+    "task": "Pickpocket anyone 5 times.",
+    "information": "Pickpocket anyone 5 times.",
+    "requirements": "1 Thieving",
+    "points": 10
+  },
+  {
+    "id": 282,
+    "taskId": 196,
+    "locality": "Global",
+    "task": "Rake any farming patch.",
+    "information": "Rake any farming patch.",
+    "requirements": "1 Farming",
+    "points": 10
+  },
+  {
+    "id": 283,
+    "taskId": 197,
+    "locality": "Global",
+    "task": "Plant seeds in any farming patch.",
+    "information": "Plant seeds in any farming patch.",
+    "requirements": "1 Farming",
+    "points": 10
+  },
+  {
+    "id": 284,
+    "taskId": 198,
+    "locality": "Global",
+    "task": "Plant seeds in any farming patch 10 times.",
+    "information": "Plant seeds in any farming patch 10 times.",
+    "requirements": "1 Farming",
+    "points": 10
+  },
+  {
+    "id": 285,
+    "taskId": 200,
+    "locality": "Global",
+    "task": "Add any compostable item to a compost bin.",
+    "information": "Add any compostable item to a compost bin.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 286,
+    "taskId": 201,
+    "locality": "Global",
+    "task": "Have a tool leprechaun note any produce.",
+    "information": "Have a tool leprechaun note any produce.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 287,
+    "taskId": 204,
+    "locality": "Global",
+    "task": "Use the Home Teleport spell to return to Lumbridge.",
+    "information": "Use the Home Teleport spell to return to Lumbridge.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 288,
+    "taskId": 205,
+    "locality": "Global",
+    "task": "Eat a cabbage.",
+    "information": "Eat a cabbage.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 289,
+    "taskId": 206,
+    "locality": "Global",
+    "task": "Eat a baked potato.",
+    "information": "Eat a baked potato.",
+    "requirements": "7 Cooking",
+    "points": 10
+  },
+  {
+    "id": 290,
+    "taskId": 207,
+    "locality": "Global",
+    "task": "Eat an onion.",
+    "information": "Eat an onion.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 291,
+    "taskId": 208,
+    "locality": "Global",
+    "task": "Kill an imp.",
+    "information": "Kill an imp.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 292,
+    "taskId": 209,
+    "locality": "Global",
+    "task": "Kill a chicken.",
+    "information": "Kill a chicken.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
     "id": 293,
+    "taskId": 210,
+    "locality": "Global",
+    "task": "Claim a free item from any store.",
+    "information": "Claim a free item from any store e.g. a tinderbox from Lumbridge General Store",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 294,
+    "taskId": 211,
+    "locality": "Global",
+    "task": "Return a free item to any store.",
+    "information": "Return a free item to any store e.g. a tinderbox from Lumbridge General Store",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 295,
+    "taskId": 212,
+    "locality": "Global",
+    "task": "Sell an item to any store.",
+    "information": "Sell an item to any store.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 296,
+    "taskId": 213,
+    "locality": "Global",
+    "task": "Listen to any musician.",
+    "information": "Listen to any musician.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 297,
+    "taskId": 214,
+    "locality": "Global",
+    "task": "Pick wheat from a field.",
+    "information": "Pick wheat from a field.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 298,
+    "taskId": 215,
+    "locality": "Global",
+    "task": "Prospect any rock.",
+    "information": "Prospect any rock.",
+    "requirements": "1 Mining",
+    "points": 10
+  },
+  {
+    "id": 299,
+    "taskId": 216,
+    "locality": "Global",
+    "task": "View the skillguide.",
+    "information": "View the skill guide.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 300,
+    "taskId": 345,
+    "locality": "Global",
+    "task": "Create a Guthix Rest Potion.",
+    "information": "Create a Guthix rest potion.",
+    "requirements": "18 Herblore",
+    "points": 10
+  },
+  {
+    "id": 301,
+    "taskId": 770,
+    "locality": "Global",
+    "task": "Make 5 potions of any kind.",
+    "information": "Make 5 potions of any kind.",
+    "requirements": "1 Herblore",
+    "points": 10
+  },
+  {
+    "id": 302,
+    "taskId": 773,
+    "locality": "Global",
+    "task": "Drink a Strength Potion.",
+    "information": "Drink a Strength Potion.",
+    "requirements": "Giving a limpwurt root and red spiders' eggs to the Apothecary",
+    "points": 10
+  },
+  {
+    "id": 303,
+    "taskId": 774,
+    "locality": "Global",
+    "task": "Make an Attack Potion.",
+    "information": "Make an Attack potion.",
+    "requirements": "1 Herblore",
+    "points": 10
+  },
+  {
+    "id": 304,
+    "taskId": 775,
+    "locality": "Global",
+    "task": "Make a Necromancy Potion.",
+    "information": "Make a Necromancy potion.",
+    "requirements": "11 Herblore",
+    "points": 10
+  },
+  {
+    "id": 305,
+    "taskId": 776,
+    "locality": "Global",
+    "task": "Clean 5 Grimy Guam.",
+    "information": "Clean 5 grimy guam.",
+    "requirements": "1 Herblore",
+    "points": 10
+  },
+  {
+    "id": 306,
+    "taskId": 777,
+    "locality": "Global",
+    "task": "Clean 15 Grimy Tarromin.",
+    "information": "Clean 15 grimy tarromin.",
+    "requirements": "5 Herblore",
+    "points": 10
+  },
+  {
+    "id": 307,
+    "taskId": 778,
+    "locality": "Global",
+    "task": "Clean 5 of any herb.",
+    "information": "Clean 5 of any herb.",
+    "requirements": "1 Herblore",
+    "points": 10
+  },
+  {
+    "id": 308,
+    "taskId": 779,
+    "locality": "Global",
+    "task": "Clean 10 of any herb",
+    "information": "Clean 10 of any herb",
+    "requirements": "1 Herblore",
+    "points": 10
+  },
+  {
+    "id": 309,
+    "taskId": 782,
+    "locality": "Global",
+    "task": "Fletch an Oak Shortbow (unstrung).",
+    "information": "Fletch an unstrung oak shortbow.",
+    "requirements": "20 Fletching",
+    "points": 10
+  },
+  {
+    "id": 310,
+    "taskId": 783,
+    "locality": "Global",
+    "task": "Fletch some arrow shafts.",
+    "information": "Fletch some arrow shafts.",
+    "requirements": "1 Fletching",
+    "points": 10
+  },
+  {
+    "id": 311,
+    "taskId": 785,
+    "locality": "Global",
+    "task": "Fletch 50 Bronze bolts.",
+    "information": "Fletch 50 bronze bolts.",
+    "requirements": "9 Fletching",
+    "points": 10
+  },
+  {
+    "id": 312,
+    "taskId": 786,
+    "locality": "Global",
+    "task": "Complete 10 laps of any Agility course.",
+    "information": "Complete 10 laps of any Agility course.",
+    "requirements": "1 Agility",
+    "points": 10
+  },
+  {
+    "id": 313,
+    "taskId": 790,
+    "locality": "Global",
+    "task": "Smith 10 of any metal weapon or armour piece.",
+    "information": "Smith 10 of any metal weapon or armour piece.",
+    "requirements": "1 Smithing",
+    "points": 10
+  },
+  {
+    "id": 314,
+    "taskId": 794,
+    "locality": "Global",
+    "task": "Open 30 Sedimentary Geodes.",
+    "information": "Open 30 sedimentary geodes. These are found randomly while mining.",
+    "requirements": "1 Mining",
+    "points": 10
+  },
+  {
+    "id": 315,
+    "taskId": 795,
+    "locality": "Global",
+    "task": "Maintain nearly maximum stamina when mining for 60 seconds.",
+    "information": "Maintain nearly maximum stamina when mining for 60 seconds.",
+    "requirements": "1 Mining",
+    "points": 10
+  },
+  {
+    "id": 316,
+    "taskId": 796,
+    "locality": "Global",
+    "task": "Harvest a Grimy Marrentill.",
+    "information": "Harvest a grimy marrentill.",
+    "requirements": "9 Farming",
+    "points": 10
+  },
+  {
+    "id": 317,
+    "taskId": 797,
+    "locality": "Global",
+    "task": "Harvest 10 Grimy Tarromin.",
+    "information": "Harvest 10 grimy tarromin.",
+    "requirements": "19 Farming",
+    "points": 10
+  },
+  {
+    "id": 318,
+    "taskId": 798,
+    "locality": "Global",
+    "task": "Cook 5 fish.",
+    "information": "Cook 5 fish.",
+    "requirements": "1 Cooking",
+    "points": 10
+  },
+  {
+    "id": 319,
+    "taskId": 801,
+    "locality": "Global",
+    "task": "Make some Bread.",
+    "information": "Make some bread. Bread dough can be created by using a pot of flour with water, it must be cooked at a range.",
+    "requirements": "1 Cooking",
+    "points": 10
+  },
+  {
+    "id": 320,
+    "taskId": 802,
+    "locality": "Global",
+    "task": "Make some flour.",
+    "information": "Make a pot of flour by grinding wheat at a windmill and collecting the flour in an empty pot.",
+    "requirements": "Wheat and an empty pot",
+    "points": 10
+  },
+  {
+    "id": 321,
+    "taskId": 803,
+    "locality": "Global",
+    "task": "Offer 5 bones of any kind to an altar.",
+    "information": "Offer 5 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel",
+    "requirements": "1 Prayer",
+    "points": 10
+  },
+  {
+    "id": 322,
+    "taskId": 804,
+    "locality": "Global",
+    "task": "Offer 25 bones of any kind to an altar.",
+    "information": "Offer 25 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel",
+    "requirements": "1 Prayer",
+    "points": 10
+  },
+  {
+    "id": 323,
+    "taskId": 806,
+    "locality": "Global",
+    "task": "Scatter some Ashes.",
+    "information": "Scatter some ashes.",
+    "requirements": "1 Prayer",
+    "points": 10
+  },
+  {
+    "id": 324,
+    "taskId": 807,
+    "locality": "Global",
+    "task": "Scatter 25 ashes of any kind.",
+    "information": "Scatter 25 ashes of any kind.",
+    "requirements": "1 Prayer",
+    "points": 10
+  },
+  {
+    "id": 325,
+    "taskId": 809,
+    "locality": "Global",
+    "task": "Restore 50 Prayer Points at an Altar at once.",
+    "information": "Restore 50 Prayer Points at an Altar at once.",
+    "requirements": "5 Prayer",
+    "points": 10
+  },
+  {
+    "id": 326,
+    "taskId": 811,
+    "locality": "Global",
+    "task": "Activate Superhuman or Ultimate Strength and Improved or Incredible Reflexes prayers at the same time.",
+    "information": "Activate Superhuman or Ultimate Strength and Improved or Incredible Reflexes prayers at the same time.",
+    "requirements": "16 Prayer",
+    "points": 10
+  },
+  {
+    "id": 327,
+    "taskId": 812,
+    "locality": "Global",
+    "task": "Catch a Baby Impling.",
+    "information": "Catch a baby impling.",
+    "requirements": "17 Hunter",
+    "points": 10
+  },
+  {
+    "id": 328,
+    "taskId": 813,
+    "locality": "Global",
+    "task": "Catch 10 Implings of any kind.",
+    "information": "Catch 10 implings of any kind.",
+    "requirements": "17 Hunter",
+    "points": 10
+  },
+  {
+    "id": 329,
+    "taskId": 816,
+    "locality": "Global",
+    "task": "Catch 5 Hunter creatures.",
+    "information": "Catch 5 Hunter creatures.",
+    "requirements": "1 Hunter",
+    "points": 10
+  },
+  {
+    "id": 330,
+    "taskId": 819,
+    "locality": "Global",
+    "task": "Complete 5 Slayer tasks.",
+    "information": "Complete 5 Slayer assignments.",
+    "requirements": "1 Slayer",
+    "points": 10
+  },
+  {
+    "id": 331,
+    "taskId": 823,
+    "locality": "Global",
+    "task": "Pick 5 Flax.",
+    "information": "Pick 5 flax from flax fields.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 332,
+    "taskId": 824,
+    "locality": "Global",
+    "task": "Spin 5 bowstring.",
+    "information": "Spin 5 bowstrings by using flax on a spinning wheel.",
+    "requirements": "1 Fletching",
+    "points": 10
+  },
+  {
+    "id": 333,
+    "taskId": 825,
+    "locality": "Global",
+    "task": "Surge a distance of one tile.",
+    "information": "Surge a distance of one tile.",
+    "requirements": "5 Agility",
+    "points": 10
+  },
+  {
+    "id": 334,
+    "taskId": 826,
+    "locality": "Global",
+    "task": "Spin a Ball of Wool.",
+    "information": "Spin a ball of wool by using wool at a spinning wheel.",
+    "requirements": "1 Fletching",
+    "points": 10
+  },
+  {
+    "id": 335,
+    "taskId": 827,
+    "locality": "Global",
+    "task": "Equip a full set of Iron armour without any upgrades.",
+    "information": "Equip an iron full helm, iron platebody, iron platelegs / iron plateskirt, iron gauntlets, iron armoured boots, and an iron kiteshield. Substitutes for pieces (e.g. med helm instead of full helm, chainbody instead of platebody, square shield instead of kite shield) will work. Iron armour can be bought at Horvik's Armour Shop.",
+    "requirements": "10 Defence",
+    "points": 10
+  },
+  {
+    "id": 336,
+    "taskId": 828,
+    "locality": "Global",
+    "task": "Equip a full set of Green Dragonhide armour.",
+    "information": "Equip a full set of green dragonhide armour.",
+    "requirements": "40 Defence",
+    "points": 10
+  },
+  {
+    "id": 337,
+    "taskId": 829,
+    "locality": "Global",
+    "task": "Equip a full set of Imphide robes.",
+    "information": "Equip a full set of imphide robes.",
+    "requirements": "10 Defence",
+    "points": 10
+  },
+  {
+    "id": 338,
+    "taskId": 830,
+    "locality": "Global",
+    "task": "Equip a full set of Spider silk robes.",
+    "information": "Equip a full set of spider silk robes.",
+    "requirements": "20 Defence",
+    "points": 10
+  },
+  {
+    "id": 339,
+    "taskId": 831,
+    "locality": "Global",
+    "task": "Store the items required for an emote clue in a Treasure Trail hidey-hole.",
+    "information": "Store the items required for an emote clue in a Treasure Trail hidey-hole.",
+    "requirements": "27 Construction",
+    "points": 10
+  },
+  {
+    "id": 340,
+    "taskId": 832,
+    "locality": "Global",
+    "task": "Complete an Easy clue scroll.",
+    "information": "Complete an easy clue scroll.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 341,
+    "taskId": 836,
+    "locality": "Global",
+    "task": "Collect 10 unique items for the General clue rewards collection log.",
+    "information": "Collect 10 unique items for the general clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 342,
+    "taskId": 409,
+    "locality": "Global",
+    "task": "Obtain a Naragi engram from Orla Fairweather.",
+    "information": "Obtain a Naragi engram from Orla Fairweather. The engram is given to the player during the tutorial for Memorial to Guthix",
+    "requirements": "1 Divination",
+    "points": 10
+  },
+  {
+    "id": 343,
+    "taskId": 411,
+    "locality": "Global",
+    "task": "Catch a Wild Kebbit.",
+    "information": "Catch a wild kebbit.",
+    "requirements": "23 Hunter",
+    "points": 10
+  },
+  {
+    "id": 344,
+    "taskId": 131,
     "locality": "Global",
     "task": "Reach level 50 in any skill.",
     "information": "Reach level 50 in any skill.",
@@ -2354,7 +3105,8 @@
     "points": 30
   },
   {
-    "id": 294,
+    "id": 345,
+    "taskId": 132,
     "locality": "Global",
     "task": "Reach at least level 5 in all non-elite skills.",
     "information": "Reach at least level 5 in all non-elite skills.",
@@ -2362,7 +3114,8 @@
     "points": 30
   },
   {
-    "id": 295,
+    "id": 346,
+    "taskId": 133,
     "locality": "Global",
     "task": "Reach at least level 10 in all non-elite skills.",
     "information": "Reach at least level 10 in all non-elite skills.",
@@ -2370,7 +3123,8 @@
     "points": 30
   },
   {
-    "id": 296,
+    "id": 347,
+    "taskId": 134,
     "locality": "Global",
     "task": "Reach at least level 20 in all non-elite skills.",
     "information": "Reach at least level 20 in all non-elite skills.",
@@ -2378,7 +3132,8 @@
     "points": 30
   },
   {
-    "id": 297,
+    "id": 348,
+    "taskId": 138,
     "locality": "Global",
     "task": "Reach combat level 50.",
     "information": "Reach combat level 50.",
@@ -2386,7 +3141,8 @@
     "points": 30
   },
   {
-    "id": 298,
+    "id": 349,
+    "taskId": 143,
     "locality": "Global",
     "task": "Reach total level 500.",
     "information": "Reach total level 500. This task is currently bugged and may complete before you have reached 500 total levels",
@@ -2394,16 +3150,17 @@
     "points": 30
   },
   {
-    "id": 299,
+    "id": 350,
+    "taskId": 157,
     "locality": "Global",
     "task": "Mine any ore 200 times.",
     "information": "Mine any ore 200 times.",
     "requirements": "1 Mining",
     "points": 30
-  }
-,
+  },
   {
-    "id": 300,
+    "id": 351,
+    "taskId": 160,
     "locality": "Global",
     "task": "Chop any tree 200 times.",
     "information": "Chop any tree 200 times.",
@@ -2411,7 +3168,8 @@
     "points": 30
   },
   {
-    "id": 301,
+    "id": 352,
+    "taskId": 165,
     "locality": "Global",
     "task": "Chop a willow tree.",
     "information": "Chop a willow tree.",
@@ -2419,7 +3177,8 @@
     "points": 30
   },
   {
-    "id": 302,
+    "id": 353,
+    "taskId": 168,
     "locality": "Global",
     "task": "Burn any logs 200 times.",
     "information": "Burn any logs 200 times.",
@@ -2427,7 +3186,8 @@
     "points": 30
   },
   {
-    "id": 303,
+    "id": 354,
+    "taskId": 178,
     "locality": "Global",
     "task": "Catch any fish 200 times.",
     "information": "Catch any fish 200 times.",
@@ -2435,7 +3195,8 @@
     "points": 30
   },
   {
-    "id": 304,
+    "id": 355,
+    "taskId": 187,
     "locality": "Global",
     "task": "Harvest any memory from a wisp 200 times.",
     "information": "Harvest any memory from a wisp 200 times.",
@@ -2443,7 +3204,8 @@
     "points": 30
   },
   {
-    "id": 305,
+    "id": 356,
+    "taskId": 194,
     "locality": "Global",
     "task": "Pickpocket anyone 200 times.",
     "information": "Pickpocket anyone 200 times.",
@@ -2451,7 +3213,8 @@
     "points": 30
   },
   {
-    "id": 306,
+    "id": 357,
+    "taskId": 199,
     "locality": "Global",
     "task": "Plant seeds in any farming patch 100 times.",
     "information": "Plant seeds in any farming patch 100 times.",
@@ -2459,7 +3222,8 @@
     "points": 30
   },
   {
-    "id": 307,
+    "id": 358,
+    "taskId": 202,
     "locality": "Global",
     "task": "Unlock all of the Free to Play Lodestones.",
     "information": "Unlock all of the Free to Play Lodestones.",
@@ -2467,7 +3231,8 @@
     "points": 30
   },
   {
-    "id": 308,
+    "id": 359,
+    "taskId": 771,
     "locality": "Global",
     "task": "Make 200 potions of any kind.",
     "information": "Make 200 potions of any kind.",
@@ -2475,7 +3240,8 @@
     "points": 30
   },
   {
-    "id": 309,
+    "id": 360,
+    "taskId": 780,
     "locality": "Global",
     "task": "Clean 200 of any herb.",
     "information": "Clean 200 of any herb.",
@@ -2483,7 +3249,8 @@
     "points": 30
   },
   {
-    "id": 310,
+    "id": 361,
+    "taskId": 784,
     "locality": "Global",
     "task": "Fletch 1,000 arrow shafts.",
     "information": "Fletch 1,000 Arrow Shafts.",
@@ -2491,7 +3258,8 @@
     "points": 30
   },
   {
-    "id": 311,
+    "id": 362,
+    "taskId": 787,
     "locality": "Global",
     "task": "Complete 25 laps of any Agility course.",
     "information": "Complete 25 laps of any Agility course.",
@@ -2499,7 +3267,8 @@
     "points": 30
   },
   {
-    "id": 312,
+    "id": 363,
+    "taskId": 791,
     "locality": "Global",
     "task": "Smith 25 of any metal weapon or armour piece.",
     "information": "Smith 25 of any metal weapon or armour piece.",
@@ -2507,7 +3276,8 @@
     "points": 30
   },
   {
-    "id": 313,
+    "id": 364,
+    "taskId": 799,
     "locality": "Global",
     "task": "Cook 200 fish.",
     "information": "Cook 200 fish.",
@@ -2515,7 +3285,8 @@
     "points": 30
   },
   {
-    "id": 314,
+    "id": 365,
+    "taskId": 805,
     "locality": "Global",
     "task": "Offer 100 bones of any kind to an altar.",
     "information": "Offer 100 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel",
@@ -2523,7 +3294,8 @@
     "points": 30
   },
   {
-    "id": 315,
+    "id": 366,
+    "taskId": 808,
     "locality": "Global",
     "task": "Scatter 100 ashes of any kind.",
     "information": "Scatter 100 ashes of any kind.",
@@ -2531,7 +3303,8 @@
     "points": 30
   },
   {
-    "id": 316,
+    "id": 367,
+    "taskId": 810,
     "locality": "Global",
     "task": "Restore 500 Prayer Points at an Altar at once.",
     "information": "Restore 500 Prayer Points at an Altar at once.",
@@ -2539,7 +3312,8 @@
     "points": 30
   },
   {
-    "id": 317,
+    "id": 368,
+    "taskId": 814,
     "locality": "Global",
     "task": "Catch 25 Implings of any kind.",
     "information": "Catch 25 implings of any kind.",
@@ -2547,7 +3321,8 @@
     "points": 30
   },
   {
-    "id": 318,
+    "id": 369,
+    "taskId": 815,
     "locality": "Global",
     "task": "Catch 35 Implings of any kind.",
     "information": "Catch 35 Implings of any kind.",
@@ -2555,7 +3330,8 @@
     "points": 30
   },
   {
-    "id": 319,
+    "id": 370,
+    "taskId": 817,
     "locality": "Global",
     "task": "Catch 200 Hunter creatures.",
     "information": "Catch 200 Hunter creatures.",
@@ -2563,7 +3339,8 @@
     "points": 30
   },
   {
-    "id": 320,
+    "id": 371,
+    "taskId": 833,
     "locality": "Global",
     "task": "Complete 25 Easy clue scrolls.",
     "information": "Complete 25 easy clue scrolls.",
@@ -2571,7 +3348,8 @@
     "points": 30
   },
   {
-    "id": 321,
+    "id": 372,
+    "taskId": 834,
     "locality": "Global",
     "task": "Complete 75 Easy clue scrolls.",
     "information": "Complete 75 easy clue scrolls.",
@@ -2579,7 +3357,8 @@
     "points": 30
   },
   {
-    "id": 322,
+    "id": 373,
+    "taskId": 837,
     "locality": "Global",
     "task": "Collect 25 unique items for the General clue rewards collection log.",
     "information": "Collect 25 unique items for the general clue rewards collection log.",
@@ -2587,7 +3366,8 @@
     "points": 30
   },
   {
-    "id": 323,
+    "id": 374,
+    "taskId": 839,
     "locality": "Global",
     "task": "Make 30 Prayer Potions.",
     "information": "Make 30 prayer potions.",
@@ -2595,15 +3375,17 @@
     "points": 30
   },
   {
-    "id": 324,
+    "id": 375,
+    "taskId": 840,
     "locality": "Global",
     "task": "Make a 4-dose Potion.",
     "information": "Make a 4-dose potion.",
-    "requirements": "1 Herblore, A botanist's amulet, Morytania legs 4, Underworld Grimoire 1, or a varanusaur pen with a farm totem at the Anachronia Dinosaur Farm",
+    "requirements": "1 Herblore",
     "points": 30
   },
   {
-    "id": 325,
+    "id": 376,
+    "taskId": 841,
     "locality": "Global",
     "task": "Make 20 Super Attack Potions.",
     "information": "Make 20 super attack potions.",
@@ -2611,7 +3393,8 @@
     "points": 30
   },
   {
-    "id": 326,
+    "id": 377,
+    "taskId": 842,
     "locality": "Global",
     "task": "Clean 50 Grimy Ranarr.",
     "information": "Clean 50 grimy ranarr.",
@@ -2619,7 +3402,8 @@
     "points": 30
   },
   {
-    "id": 327,
+    "id": 378,
+    "taskId": 843,
     "locality": "Global",
     "task": "Clean 50 Grimy Avantoe.",
     "information": "Clean 50 grimy avantoe.",
@@ -2627,7 +3411,8 @@
     "points": 30
   },
   {
-    "id": 328,
+    "id": 379,
+    "taskId": 844,
     "locality": "Global",
     "task": "Harvest 5 Grimy Ranarr.",
     "information": "Harvest 5 grimy ranarr.",
@@ -2635,7 +3420,8 @@
     "points": 30
   },
   {
-    "id": 329,
+    "id": 380,
+    "taskId": 845,
     "locality": "Global",
     "task": "Equip an Iron Crossbow.",
     "information": "Equip an iron crossbow.",
@@ -2643,7 +3429,8 @@
     "points": 30
   },
   {
-    "id": 330,
+    "id": 381,
+    "taskId": 846,
     "locality": "Global",
     "task": "Equip a Maple shieldbow.",
     "information": "Equip a maple shieldbow.",
@@ -2651,7 +3438,8 @@
     "points": 30
   },
   {
-    "id": 331,
+    "id": 382,
+    "taskId": 847,
     "locality": "Global",
     "task": "Fletch 50 Maple shieldbow (unstrung).",
     "information": "Fletch 50 unstrung maple shieldbows.",
@@ -2659,7 +3447,8 @@
     "points": 30
   },
   {
-    "id": 332,
+    "id": 383,
+    "taskId": 848,
     "locality": "Global",
     "task": "Fletch 400 Steel arrows.",
     "information": "Fletch 400 steel arrows.",
@@ -2667,7 +3456,8 @@
     "points": 30
   },
   {
-    "id": 333,
+    "id": 384,
+    "taskId": 849,
     "locality": "Global",
     "task": "Fletch 100 Iron bolts.",
     "information": "Fletch 100 iron bolts.",
@@ -2675,7 +3465,8 @@
     "points": 30
   },
   {
-    "id": 334,
+    "id": 385,
+    "taskId": 850,
     "locality": "Global",
     "task": "Mine some Ore With a Rune Pickaxe.",
     "information": "Mine some ore with a rune pickaxe.",
@@ -2683,7 +3474,8 @@
     "points": 30
   },
   {
-    "id": 335,
+    "id": 386,
+    "taskId": 851,
     "locality": "Global",
     "task": "Mine 20 Mithril Ore.",
     "information": "Mine 20 mithril ore.",
@@ -2691,7 +3483,8 @@
     "points": 30
   },
   {
-    "id": 336,
+    "id": 387,
+    "taskId": 852,
     "locality": "Global",
     "task": "Mine 30 Adamant Ore.",
     "information": "Mine 30 adamantite ore.",
@@ -2699,7 +3492,8 @@
     "points": 30
   },
   {
-    "id": 337,
+    "id": 388,
+    "taskId": 853,
     "locality": "Global",
     "task": "Mine 40 Runite Ore.",
     "information": "Mine 40 runite ore.",
@@ -2707,7 +3501,8 @@
     "points": 30
   },
   {
-    "id": 338,
+    "id": 389,
+    "taskId": 854,
     "locality": "Global",
     "task": "Open 20 Igenous[sic] Geodes.",
     "information": "Open 20 igneous geodes. These are found randomly while mining from rocks which require at least level 60 Mining",
@@ -2715,7 +3510,8 @@
     "points": 30
   },
   {
-    "id": 339,
+    "id": 390,
+    "taskId": 855,
     "locality": "Global",
     "task": "Check a grown Fruit Tree.",
     "information": "Check a tree grown in a fruit tree patch.",
@@ -2723,7 +3519,8 @@
     "points": 30
   },
   {
-    "id": 340,
+    "id": 391,
+    "taskId": 856,
     "locality": "Global",
     "task": "Catch 100 Lobsters.",
     "information": "Catch 100 lobsters.",
@@ -2731,7 +3528,8 @@
     "points": 30
   },
   {
-    "id": 341,
+    "id": 392,
+    "taskId": 857,
     "locality": "Global",
     "task": "Catch 50 Swordfish.",
     "information": "Catch 50 swordfish.",
@@ -2739,7 +3537,8 @@
     "points": 30
   },
   {
-    "id": 342,
+    "id": 393,
+    "taskId": 858,
     "locality": "Global",
     "task": "Catch 50 Salmon.",
     "information": "Catch 50 salmon.",
@@ -2747,7 +3546,8 @@
     "points": 30
   },
   {
-    "id": 343,
+    "id": 394,
+    "taskId": 859,
     "locality": "Global",
     "task": "Catch 10 Pike.",
     "information": "Catch 10 pike.",
@@ -2755,15 +3555,17 @@
     "points": 30
   },
   {
-    "id": 344,
+    "id": 395,
+    "taskId": 860,
     "locality": "Global",
     "task": "Make a Pineapple pizza.",
     "information": "Make a pineapple pizza by adding pineapple chunks or a pineapple ring to a plain pizza.",
-    "requirements": "65 Cooking, Plain pizza and pineapple",
+    "requirements": "65 Cooking",
     "points": 30
   },
   {
-    "id": 345,
+    "id": 396,
+    "taskId": 861,
     "locality": "Global",
     "task": "Make a Stew.",
     "information": "Make a stew: add a raw potato to a bowl of water, then add either cooked meat or chicken, and cook the stew at a range.",
@@ -2771,15 +3573,17 @@
     "points": 30
   },
   {
-    "id": 346,
+    "id": 397,
+    "taskId": 862,
     "locality": "Global",
     "task": "Make a Chocolate Cake.",
     "information": "Make a chocolate cake by adding a chocolate bar to a cooked cake.",
-    "requirements": "50 Cooking, Cake and chocolate bar",
+    "requirements": "50 Cooking",
     "points": 30
   },
   {
-    "id": 347,
+    "id": 398,
+    "taskId": 863,
     "locality": "Global",
     "task": "Bury some Baby Dragon bones.",
     "information": "Bury some baby dragon bones.",
@@ -2787,7 +3591,8 @@
     "points": 30
   },
   {
-    "id": 348,
+    "id": 399,
+    "taskId": 864,
     "locality": "Global",
     "task": "Bury 5 Dragon bones.",
     "information": "Bury 5 dragon bones.",
@@ -2795,7 +3600,8 @@
     "points": 30
   },
   {
-    "id": 349,
+    "id": 400,
+    "taskId": 865,
     "locality": "Global",
     "task": "Activate Protect from Melee prayer.",
     "information": "Activate the Protect from Melee prayer.",
@@ -2803,7 +3609,8 @@
     "points": 30
   },
   {
-    "id": 350,
+    "id": 401,
+    "taskId": 866,
     "locality": "Global",
     "task": "Catch a Gourmet Impling.",
     "information": "Catch a gourmet impling.",
@@ -2811,31 +3618,35 @@
     "points": 30
   },
   {
-    "id": 351,
+    "id": 402,
+    "taskId": 867,
     "locality": "Global",
     "task": "Light a Bullseye Lantern.",
     "information": "Light a bullseye lantern.",
-    "requirements": "49 Firemaking, Either 36 Thieving and completion of Death to the Dorgeshuun; or 50 Quest points and the Lorehound pet unlocked; or 20 Smithing and 49 Crafting to create from scratch",
+    "requirements": "49 Firemaking",
     "points": 30
   },
   {
-    "id": 352,
+    "id": 403,
+    "taskId": 868,
     "locality": "Global",
     "task": "Teleport using Law runes.",
     "information": "Teleport using law runes. The lowest level teleport spell is South Feldip Hills Teleport which also requires one air and one water rune",
-    "requirements": "10 Magic, A law rune",
+    "requirements": "10 Magic",
     "points": 30
   },
   {
-    "id": 353,
+    "id": 404,
+    "taskId": 869,
     "locality": "Global",
     "task": "Craft some Combination runes.",
     "information": "Craft some combination runes: mist runes have the lowest level requirement. They can made by using a pure essence and 1 water rune and a water talisman at the air altar or 1 air rune and an air talisman at the water altar",
-    "requirements": "6 Runecrafting, A pure essence",
+    "requirements": "6 Runecrafting",
     "points": 30
   },
   {
-    "id": 354,
+    "id": 405,
+    "taskId": 870,
     "locality": "Global",
     "task": "Craft 100 runes.",
     "information": "Craft 100 runes.",
@@ -2843,7 +3654,8 @@
     "points": 30
   },
   {
-    "id": 355,
+    "id": 406,
+    "taskId": 871,
     "locality": "Global",
     "task": "Craft 1,000 runes.",
     "information": "Craft 1,000 runes.",
@@ -2851,7 +3663,8 @@
     "points": 30
   },
   {
-    "id": 356,
+    "id": 407,
+    "taskId": 874,
     "locality": "Global",
     "task": "Equip a full set of Steel armour.",
     "information": "Equip a full set of steel armour (helm, body, legs, boots, and gauntlets).",
@@ -2859,7 +3672,8 @@
     "points": 30
   },
   {
-    "id": 357,
+    "id": 408,
+    "taskId": 875,
     "locality": "Global",
     "task": "Equip a full set of Mithril armour.",
     "information": "Equip a full set of mithril armour (full helm, platebody, legs, boots, and gauntlets).",
@@ -2867,7 +3681,8 @@
     "points": 30
   },
   {
-    "id": 358,
+    "id": 409,
+    "taskId": 876,
     "locality": "Global",
     "task": "Equip a full set of Adamant armour.",
     "information": "Equip a full set of adamant armour (full helm, platebody, legs, boots, and gauntlets).",
@@ -2875,7 +3690,8 @@
     "points": 30
   },
   {
-    "id": 359,
+    "id": 410,
+    "taskId": 877,
     "locality": "Global",
     "task": "Equip a full set of Rune armour.",
     "information": "Equip a full set of rune armour (full helm, platebody, legs, boots, and gauntlets).",
@@ -2883,7 +3699,8 @@
     "points": 30
   },
   {
-    "id": 360,
+    "id": 411,
+    "taskId": 878,
     "locality": "Global",
     "task": "Equip a full set of Blue Dragonhide armour.",
     "information": "Equip a full set of blue dragonhide armour.",
@@ -2891,7 +3708,8 @@
     "points": 30
   },
   {
-    "id": 361,
+    "id": 412,
+    "taskId": 879,
     "locality": "Global",
     "task": "Equip a full set of Red Dragonhide armour.",
     "information": "Equip a full set of red Dragonhide armour.",
@@ -2899,7 +3717,8 @@
     "points": 30
   },
   {
-    "id": 362,
+    "id": 413,
+    "taskId": 880,
     "locality": "Global",
     "task": "Equip a full set of Batwing robes.",
     "information": "Equip a full set of batwing robes.",
@@ -2907,7 +3726,8 @@
     "points": 30
   },
   {
-    "id": 363,
+    "id": 414,
+    "taskId": 881,
     "locality": "Global",
     "task": "Equip a full set of Mystic robes.",
     "information": "Equip a full set of mystic robes.",
@@ -2915,7 +3735,8 @@
     "points": 30
   },
   {
-    "id": 364,
+    "id": 415,
+    "taskId": 882,
     "locality": "Global",
     "task": "Create a Mithril Grapple.",
     "information": "Create a mithril grapple.",
@@ -2923,7 +3744,8 @@
     "points": 30
   },
   {
-    "id": 365,
+    "id": 416,
+    "taskId": 883,
     "locality": "Global",
     "task": "Burn 25 Willow logs.",
     "information": "Burn 25 willow logs.",
@@ -2931,7 +3753,8 @@
     "points": 30
   },
   {
-    "id": 366,
+    "id": 417,
+    "taskId": 884,
     "locality": "Global",
     "task": "Burn 50 Maple logs.",
     "information": "Burn 50 maple logs.",
@@ -2939,7 +3762,8 @@
     "points": 30
   },
   {
-    "id": 367,
+    "id": 418,
+    "taskId": 885,
     "locality": "Global",
     "task": "Equip any elemental battlestaff.",
     "information": "Equip any elemental battlestaff.",
@@ -2947,7 +3771,8 @@
     "points": 30
   },
   {
-    "id": 368,
+    "id": 419,
+    "taskId": 886,
     "locality": "Global",
     "task": "Equip a mystic staff.",
     "information": "Equip a mystic staff.",
@@ -2955,7 +3780,8 @@
     "points": 30
   },
   {
-    "id": 369,
+    "id": 420,
+    "taskId": 887,
     "locality": "Global",
     "task": "Obtain 50 Quest Points.",
     "information": "Obtain 50 quest points.",
@@ -2963,7 +3789,8 @@
     "points": 30
   },
   {
-    "id": 370,
+    "id": 421,
+    "taskId": 891,
     "locality": "Global",
     "task": "Complete 100 clues of any tier.",
     "information": "Complete 100 clues of any tier.",
@@ -2971,7 +3798,8 @@
     "points": 30
   },
   {
-    "id": 371,
+    "id": 422,
+    "taskId": 892,
     "locality": "Global",
     "task": "Complete a Medium clue scroll.",
     "information": "Complete a medium clue scroll.",
@@ -2979,7 +3807,8 @@
     "points": 30
   },
   {
-    "id": 372,
+    "id": 423,
+    "taskId": 893,
     "locality": "Global",
     "task": "Complete 25 Medium clue scrolls.",
     "information": "Complete 25 medium clue scrolls.",
@@ -2987,7 +3816,8 @@
     "points": 30
   },
   {
-    "id": 373,
+    "id": 424,
+    "taskId": 894,
     "locality": "Global",
     "task": "Complete 75 Medium clue scrolls.",
     "information": "Complete 75 medium clue scrolls.",
@@ -2995,7 +3825,8 @@
     "points": 30
   },
   {
-    "id": 374,
+    "id": 425,
+    "taskId": 896,
     "locality": "Global",
     "task": "Complete a Hard clue scroll.",
     "information": "Complete a hard clue scroll.",
@@ -3003,7 +3834,8 @@
     "points": 30
   },
   {
-    "id": 375,
+    "id": 426,
+    "taskId": 897,
     "locality": "Global",
     "task": "Complete 25 Hard clue scrolls.",
     "information": "Complete 25 hard clue scrolls.",
@@ -3011,7 +3843,8 @@
     "points": 30
   },
   {
-    "id": 376,
+    "id": 427,
+    "taskId": 900,
     "locality": "Global",
     "task": "Collect 5 unique items for the Easy clue rewards collection log.",
     "information": "Collect 5 unique items for the easy clue rewards collection log.",
@@ -3019,7 +3852,8 @@
     "points": 30
   },
   {
-    "id": 377,
+    "id": 428,
+    "taskId": 901,
     "locality": "Global",
     "task": "Collect 10 unique items for the Easy clue rewards collection log.",
     "information": "Collect 10 unique items for the easy clue rewards collection log.",
@@ -3027,7 +3861,8 @@
     "points": 30
   },
   {
-    "id": 378,
+    "id": 429,
+    "taskId": 904,
     "locality": "Global",
     "task": "Collect 5 unique items for the Medium clue rewards collection log.",
     "information": "Collect 5 unique items for the medium clue rewards collection log.",
@@ -3035,7 +3870,8 @@
     "points": 30
   },
   {
-    "id": 379,
+    "id": 430,
+    "taskId": 905,
     "locality": "Global",
     "task": "Collect 10 unique items for the Medium clue rewards collection log.",
     "information": "Collect 10 unique items for the Medium clue rewards collection log.",
@@ -3043,7 +3879,8 @@
     "points": 30
   },
   {
-    "id": 380,
+    "id": 431,
+    "taskId": 908,
     "locality": "Global",
     "task": "Collect 5 unique items for the Hard clue rewards collection log.",
     "information": "Collect 5 unique items for the hard clue rewards collection log.",
@@ -3051,7 +3888,8 @@
     "points": 30
   },
   {
-    "id": 381,
+    "id": 432,
+    "taskId": 912,
     "locality": "Global",
     "task": "Equip any 2 pieces of an Elegant outfit.",
     "information": "Equip any 2 pieces of an elegant outfit.",
@@ -3059,7 +3897,8 @@
     "points": 30
   },
   {
-    "id": 382,
+    "id": 433,
+    "taskId": 913,
     "locality": "Global",
     "task": "Equip a composite bow of any kind.",
     "information": "Equip a composite bow of any kind.",
@@ -3067,15 +3906,17 @@
     "points": 30
   },
   {
-    "id": 383,
+    "id": 434,
+    "taskId": 943,
     "locality": "Global",
     "task": "Perform a Special Attack.",
     "information": "Perform a special attack.",
-    "requirements": "5 Attack or 5 Ranged or 5 Magic (claimed from Gudrik in Port Sarim)",
+    "requirements": "5 Attack or 5 Ranged or 5 Magic",
     "points": 30
   },
   {
-    "id": 384,
+    "id": 435,
+    "taskId": 1098,
     "locality": "Global",
     "task": "Reach level 30 in any skill.",
     "information": "Reach level 30 in any skill.",
@@ -3083,7 +3924,8 @@
     "points": 30
   },
   {
-    "id": 385,
+    "id": 436,
+    "taskId": 1099,
     "locality": "Global",
     "task": "Reach level 40 in any skill.",
     "information": "Reach level 40 in any skill.",
@@ -3091,7 +3933,8 @@
     "points": 30
   },
   {
-    "id": 386,
+    "id": 437,
+    "taskId": 1100,
     "locality": "Global",
     "task": "Reach level 60 in any skill.",
     "information": "Reach level 60 in any skill.",
@@ -3099,7 +3942,8 @@
     "points": 30
   },
   {
-    "id": 387,
+    "id": 438,
+    "taskId": 1105,
     "locality": "Global",
     "task": "Reach at least level 30 in all non-elite skills.",
     "information": "Reach at least level 30 in all non-elite skills.",
@@ -3107,31 +3951,8 @@
     "points": 30
   },
   {
-    "id": 388,
-    "locality": "Kandarin: Ardougne",
-    "task": "Fletch 50 Maple shieldbow (unstrung) in Kandarin.",
-    "information": "Fletch 50 unstrung maple shieldbows in Kandarin.",
-    "requirements": "55 Fletching",
-    "points": 30
-  },
-  {
-    "id": 389,
-    "locality": "Kandarin: Ardougne",
-    "task": "Pickpocket a Knight of Ardougne 50 times.",
-    "information": "Pickpocket a knight of Ardougne 50 times.",
-    "requirements": "55 Thieving",
-    "points": 30
-  },
-  {
-    "id": 390,
-    "locality": "Kandarin: Ardougne",
-    "task": "Complete the Barbarian Outpost Agility Course.",
-    "information": "Complete the Barbarian Outpost Agility Course.",
-    "requirements": "35 Agility, Completion of Bar Crawl (miniquest)",
-    "points": 30
-  },
-  {
-    "id": 391,
+    "id": 439,
+    "taskId": 418,
     "locality": "Global",
     "task": "Equip a Spottier Cape.",
     "information": "Equip a spottier cape.",
@@ -3139,112 +3960,8 @@
     "points": 30
   },
   {
-    "id": 392,
-    "locality": "Kandarin: Ardougne",
-    "task": "Catch a red salamander from the Hunter area outside of Ourania Altar.",
-    "information": "Catch a red salamander.",
-    "requirements": "59 Hunter",
-    "points": 30
-  },
-  {
-    "id": 393,
-    "locality": "Kandarin: Ardougne",
-    "task": "Enter the Fishing Guild.",
-    "information": "Enter the Fishing Guild.",
-    "requirements": "68 Fishing",
-    "points": 30
-  },
-  {
-    "id": 394,
-    "locality": "Kandarin: Gnomes",
-    "task": "Check a grown Papaya Tree inside Tree Gnome Stronghold.",
-    "information": "Check a grown papaya tree inside Tree Gnome Stronghold.",
-    "requirements": "57 Farming",
-    "points": 30
-  },
-  {
-    "id": 395,
-    "locality": "Kandarin: Ardougne",
-    "task": "Kill a mithril dragon.",
-    "information": "Defeat a mithril dragon.",
-    "requirements": "N/A",
-    "points": 30
-  },
-  {
-    "id": 396,
-    "locality": "Kandarin: Yanille",
-    "task": "Enter the Magic Guild in Yanille.",
-    "information": "Enter the Wizards' Guild.",
-    "requirements": "66 Magic",
-    "points": 30
-  },
-  {
-    "id": 397,
-    "locality": "Kandarin: Ardougne",
-    "task": "Defeat a Fire Giant in Kandarin.",
-    "information": "Defeat a fire giant in Kandarin.",
-    "requirements": "N/A",
-    "points": 30
-  },
-  {
-    "id": 398,
-    "locality": "Kandarin: Seers Village",
-    "task": "Use the Chivalry Prayer.",
-    "information": "Use the Chivalry prayer.",
-    "requirements": "60 Prayer, 65 Defence, Completion of Knight Waves training ground",
-    "points": 30
-  },
-  {
-    "id": 399,
-    "locality": "Kandarin: Yanille",
-    "task": "Be on the winning side in a game of Castle Wars.",
-    "information": "Win a game of Castle Wars.",
-    "requirements": "N/A",
-    "points": 30
-  }
-,
-  {
-    "id": 400,
-    "locality": "Kandarin: Seers Village",
-    "task": "Complete the quest: Elemental Workshop II.",
-    "information": "Complete Elemental Workshop II.",
-    "requirements": "See quest page",
-    "points": 30
-  },
-  {
-    "id": 401,
-    "locality": "Kandarin: Feldip Hills",
-    "task": "Equip an Ogre Forester Hat.",
-    "information": "Equip an ogre forester hat.",
-    "requirements": "300 chompy bird kills",
-    "points": 30
-  },
-  {
-    "id": 402,
-    "locality": "Kandarin: Ardougne",
-    "task": "Complete the task set: Easy Ardougne.",
-    "information": "Complete the Easy Ardougne achievements.",
-    "requirements": "See Easy Ardougne achievements page",
-    "points": 30
-  },
-  {
-    "id": 403,
-    "locality": "Kandarin: Gnomes",
-    "task": "Create the listed gnome cocktails.",
-    "information": "Make one of each type of cocktail.",
-    "requirements": "37 Cooking",
-    "points": 30
-  },
-  {
-    "id": 404,
-    "locality": "Kandarin: Ardougne",
-    "task": "Earn a total amount of 10,000 beans.",
-    "information": "Earn a total of 10,000 beans from selling animals in player-owned farm.",
-    "requirements": "17 Farming",
-    "points": 30
-  },
-  {
-    "id": 405,
+    "id": 440,
+    "taskId": 432,
     "locality": "Global",
     "task": "Hunt 10 Spotted Kebbits with the help of a falcon.",
     "information": "Hunt 10 spotted kebbits with using falconry.",
@@ -3252,7 +3969,8 @@
     "points": 30
   },
   {
-    "id": 406,
+    "id": 441,
+    "taskId": 433,
     "locality": "Global",
     "task": "Complete the quest: The Needle Skips.",
     "information": "Complete The Needle Skips.",
@@ -3260,7 +3978,2402 @@
     "points": 30
   },
   {
-    "id": 407,
+    "id": 442,
+    "taskId": 443,
+    "locality": "Global",
+    "task": "Catch a Monkfish.",
+    "information": "Catch a raw monkfish.",
+    "requirements": "62 Fishing",
+    "points": 80
+  },
+  {
+    "id": 443,
+    "taskId": 444,
+    "locality": "Global",
+    "task": "Recover all data for one memory-storage bot in the Hall of Memories.",
+    "information": "Recover all data for memory-storage bot (Aagi) in the Hall of Memories.",
+    "requirements": "70 Divination",
+    "points": 80
+  },
+  {
+    "id": 444,
+    "taskId": 459,
+    "locality": "Global",
+    "task": "Mine 25 Platinum Ore south of Piscatoris Fishing Colony.",
+    "information": "Mine 25 platinum ores south of Piscatoris Fishing Colony.",
+    "requirements": "70 Mining",
+    "points": 80
+  },
+  {
+    "id": 445,
+    "taskId": 460,
+    "locality": "Global",
+    "task": "Chop 50 Eternal Magic logs.",
+    "information": "Chop 50 eternal magic logs.",
+    "requirements": "75 Woodcutting",
+    "points": 80
+  },
+  {
+    "id": 446,
+    "taskId": 135,
+    "locality": "Global",
+    "task": "Reach at least level 50 in all non-elite skills.",
+    "information": "Reach at least level 50 in all non-elite skills.",
+    "requirements": "All skills except Invention at level 50",
+    "points": 80
+  },
+  {
+    "id": 447,
+    "taskId": 139,
+    "locality": "Global",
+    "task": "Reach combat level 100.",
+    "information": "Reach combat level 100.",
+    "requirements": "100 Combat",
+    "points": 80
+  },
+  {
+    "id": 448,
+    "taskId": 144,
+    "locality": "Global",
+    "task": "Reach total level 1000.",
+    "information": "Reach total level 1000. This task is currently bugged and may complete before you have reached 1000 total levels",
+    "requirements": "1000 Skills Total level",
+    "points": 80
+  },
+  {
+    "id": 449,
+    "taskId": 158,
+    "locality": "Global",
+    "task": "Mine any ore 1000 times.",
+    "information": "Mine any ore 1000 times.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 450,
+    "taskId": 161,
+    "locality": "Global",
+    "task": "Chop any tree 1000 times.",
+    "information": "Chop any tree 1000 times.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 451,
+    "taskId": 169,
+    "locality": "Global",
+    "task": "Burn any logs 1000 times.",
+    "information": "Burn any logs 1000 times.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 452,
+    "taskId": 179,
+    "locality": "Global",
+    "task": "Catch any fish 1000 times.",
+    "information": "Catch any fish 1000 times.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 453,
+    "taskId": 188,
+    "locality": "Global",
+    "task": "Harvest any memory from a wisp 1000 times.",
+    "information": "Harvest any memory from a wisp 1000 times.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 454,
+    "taskId": 195,
+    "locality": "Global",
+    "task": "Pickpocket anyone 1000 times.",
+    "information": "Pickpocket anyone 1000 times.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 455,
+    "taskId": 203,
+    "locality": "Global",
+    "task": "Unlock all of the Lodestones.",
+    "information": "Unlock all of the lodestones.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 456,
+    "taskId": 772,
+    "locality": "Global",
+    "task": "Make 1,000 potions of any kind.",
+    "information": "Make 1,000 potions of any kind.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 457,
+    "taskId": 781,
+    "locality": "Global",
+    "task": "Clean 1,000 of any herb.",
+    "information": "Clean 1,000 of any herb.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 458,
+    "taskId": 788,
+    "locality": "Global",
+    "task": "Complete 50 laps of any Agility course.",
+    "information": "Complete 50 laps of any Agility course.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 459,
+    "taskId": 789,
+    "locality": "Global",
+    "task": "Complete 100 laps of any Agility course.",
+    "information": "Complete 100 laps of any Agility course.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 460,
+    "taskId": 792,
+    "locality": "Global",
+    "task": "Smith 50 of any metal weapon or armour piece.",
+    "information": "Smith 50 of any metal weapon or armour piece.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 461,
+    "taskId": 793,
+    "locality": "Global",
+    "task": "Smith 100 of any metal weapon or armour piece.",
+    "information": "Smith 100 of any metal weapon or armour piece.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 462,
+    "taskId": 800,
+    "locality": "Global",
+    "task": "Cook 1,000 fish.",
+    "information": "Cook 1,000 fish.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 463,
+    "taskId": 818,
+    "locality": "Global",
+    "task": "Catch 1,000 Hunter creatures.",
+    "information": "Catch 1,000 Hunter creatures.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 464,
+    "taskId": 820,
+    "locality": "Global",
+    "task": "Complete 15 Slayer tasks.",
+    "information": "Complete 15 Slayer tasks.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 465,
+    "taskId": 835,
+    "locality": "Global",
+    "task": "Complete 150 Easy clue scrolls.",
+    "information": "Complete 150 easy clue scrolls.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 466,
+    "taskId": 838,
+    "locality": "Global",
+    "task": "Collect 50 unique items for the General clue rewards collection log.",
+    "information": "Collect 50 unique items for the general clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 467,
+    "taskId": 872,
+    "locality": "Global",
+    "task": "Craft 10,000 runes.",
+    "information": "Craft 10,000 runes.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 468,
+    "taskId": 873,
+    "locality": "Global",
+    "task": "Craft 20,000 runes.",
+    "information": "Craft 20,000 runes.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 469,
+    "taskId": 888,
+    "locality": "Global",
+    "task": "Obtain 75 Quest Points.",
+    "information": "Obtain 75 quest points.",
+    "requirements": "75 Quest points",
+    "points": 80
+  },
+  {
+    "id": 470,
+    "taskId": 889,
+    "locality": "Global",
+    "task": "Obtain 100 Quest Points.",
+    "information": "Obtain 100 quest points.",
+    "requirements": "100 Quest points",
+    "points": 80
+  },
+  {
+    "id": 471,
+    "taskId": 895,
+    "locality": "Global",
+    "task": "Complete 150 Medium clue scrolls.",
+    "information": "Complete 150 medium clue scrolls.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 472,
+    "taskId": 898,
+    "locality": "Global",
+    "task": "Complete 75 Hard clue scrolls.",
+    "information": "Complete 75 hard clue scrolls.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 473,
+    "taskId": 899,
+    "locality": "Global",
+    "task": "Complete 150 Hard clue scrolls.",
+    "information": "Complete 150 hard clue scrolls.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 474,
+    "taskId": 902,
+    "locality": "Global",
+    "task": "Collect 25 unique items for the Easy clue rewards collection log.",
+    "information": "Collect 25 unique items for the easy clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 475,
+    "taskId": 903,
+    "locality": "Global",
+    "task": "Collect 50 unique items for the Easy clue rewards collection log.",
+    "information": "Collect 50 unique items for the easy clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 476,
+    "taskId": 906,
+    "locality": "Global",
+    "task": "Collect 25 unique items for the Medium clue rewards collection log.",
+    "information": "Collect 25 unique items for the medium clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 477,
+    "taskId": 907,
+    "locality": "Global",
+    "task": "Collect 50 unique items for the Medium clue rewards collection log.",
+    "information": "Collect 50 unique items for the medium clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 478,
+    "taskId": 909,
+    "locality": "Global",
+    "task": "Collect 10 unique items for the Hard clue rewards collection log.",
+    "information": "Collect 10 unique items for the hard clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 479,
+    "taskId": 910,
+    "locality": "Global",
+    "task": "Collect 25 unique items for the Hard clue rewards collection log.",
+    "information": "Collect 25 unique items for the hard clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 480,
+    "taskId": 914,
+    "locality": "Global",
+    "task": "Equip any Dragon mask.",
+    "information": "Equip any dragon mask.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 481,
+    "taskId": 915,
+    "locality": "Global",
+    "task": "Make any Perfect Juju Potion.",
+    "information": "Make any perfect juju potion.",
+    "requirements": "75 Herblore",
+    "points": 80
+  },
+  {
+    "id": 482,
+    "taskId": 916,
+    "locality": "Global",
+    "task": "Make 15 Antifire Potions.",
+    "information": "Make 15 antifire potions.",
+    "requirements": "69 Herblore",
+    "points": 80
+  },
+  {
+    "id": 483,
+    "taskId": 917,
+    "locality": "Global",
+    "task": "Clean 50 Grimy Cadantine.",
+    "information": "Clean 50 grimy cadantine.",
+    "requirements": "65 Herblore",
+    "points": 80
+  },
+  {
+    "id": 484,
+    "taskId": 918,
+    "locality": "Global",
+    "task": "Clean 100 Grimy Lantadyme.",
+    "information": "Clean 100 grimy lantadyme.",
+    "requirements": "67 Herblore",
+    "points": 80
+  },
+  {
+    "id": 485,
+    "taskId": 919,
+    "locality": "Global",
+    "task": "Clean 100 Dwarf Weed.",
+    "information": "Clean 100 grimy dwarf weed.",
+    "requirements": "70 Herblore",
+    "points": 80
+  },
+  {
+    "id": 486,
+    "taskId": 920,
+    "locality": "Global",
+    "task": "Clean 100 Arbuck.",
+    "information": "Clean 100 grimy arbuck.",
+    "requirements": "77 Herblore, 77 Farming",
+    "points": 80
+  },
+  {
+    "id": 487,
+    "taskId": 921,
+    "locality": "Global",
+    "task": "Equip a Yew shortbow.",
+    "information": "Equip a yew shortbow.",
+    "requirements": "40 Ranged",
+    "points": 80
+  },
+  {
+    "id": 488,
+    "taskId": 922,
+    "locality": "Global",
+    "task": "Equip a Magic shortbow.",
+    "information": "Equip a magic shortbow.",
+    "requirements": "50 Ranged",
+    "points": 80
+  },
+  {
+    "id": 489,
+    "taskId": 923,
+    "locality": "Global",
+    "task": "Fletch some Broad Arrows or Bolts.",
+    "information": "Fletch some broad arrows or bolts.",
+    "requirements": "52 Fletching",
+    "points": 80
+  },
+  {
+    "id": 490,
+    "taskId": 924,
+    "locality": "Global",
+    "task": "Fletch 100 Yew shortbows (unstrung).",
+    "information": "Fletch 100 Yew shortbows (unstrung).",
+    "requirements": "65 Fletching",
+    "points": 80
+  },
+  {
+    "id": 491,
+    "taskId": 925,
+    "locality": "Global",
+    "task": "Fletch 100 Yew stocks.",
+    "information": "Fletch 100 yew stocks.",
+    "requirements": "69 Fletching",
+    "points": 80
+  },
+  {
+    "id": 492,
+    "taskId": 926,
+    "locality": "Global",
+    "task": "Fletch a Rune Crossbow.",
+    "information": "Fletch a rune crossbow.",
+    "requirements": "69 Fletching",
+    "points": 80
+  },
+  {
+    "id": 493,
+    "taskId": 927,
+    "locality": "Global",
+    "task": "Fletch 35 or more arrow shafts from a single log.",
+    "information": "Fletch 35 or more arrow shafts from a single log.",
+    "requirements": "60 Fletching",
+    "points": 80
+  },
+  {
+    "id": 494,
+    "taskId": 928,
+    "locality": "Global",
+    "task": "Fletch 500 Adamant arrows.",
+    "information": "Fletch 500 adamant arrows.",
+    "requirements": "60 Fletching",
+    "points": 80
+  },
+  {
+    "id": 495,
+    "taskId": 929,
+    "locality": "Global",
+    "task": "Fletch 750 Rune arrows.",
+    "information": "Fletch 750 rune arrows.",
+    "requirements": "75 Fletching",
+    "points": 80
+  },
+  {
+    "id": 496,
+    "taskId": 930,
+    "locality": "Global",
+    "task": "Fletch 75 Onyx bolts.",
+    "information": "Fletch 75 onyx bolts.",
+    "requirements": "73 Fletching",
+    "points": 80
+  },
+  {
+    "id": 497,
+    "taskId": 931,
+    "locality": "Global",
+    "task": "Equip a Rune Ceremonial Sword.",
+    "information": "Equip a rune ceremonial sword.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 498,
+    "taskId": 932,
+    "locality": "Global",
+    "task": "Equip a full set of the Blacksmith's outfit.",
+    "information": "Equip a full set of the blacksmith's outfit.",
+    "requirements": "Total of 250% Artisans' Workshop respect",
+    "points": 80
+  },
+  {
+    "id": 499,
+    "taskId": 933,
+    "locality": "Global",
+    "task": "Power up the Artisan's Workshop with a Luminite Injector.",
+    "information": "Power up the Artisan's Workshop with a luminite Injector.",
+    "requirements": "100% Artisans' Workshop respect",
+    "points": 80
+  },
+  {
+    "id": 500,
+    "taskId": 934,
+    "locality": "Global",
+    "task": "Mine 50 Orichalcite Ore.",
+    "information": "Mine 50 orichalcite ore.",
+    "requirements": "60 Mining",
+    "points": 80
+  },
+  {
+    "id": 501,
+    "taskId": 935,
+    "locality": "Global",
+    "task": "Mine 50 Drakolith.",
+    "information": "Mine 50 drakolith",
+    "requirements": "60 Mining",
+    "points": 80
+  },
+  {
+    "id": 502,
+    "taskId": 936,
+    "locality": "Global",
+    "task": "Mine 60 Necrite Ore.",
+    "information": "Mine 60 necrite ore.",
+    "requirements": "70 Mining",
+    "points": 80
+  },
+  {
+    "id": 503,
+    "taskId": 937,
+    "locality": "Global",
+    "task": "Mine 60 Phasmatite.",
+    "information": "Mine 60 phasmatite.",
+    "requirements": "70 Mining",
+    "points": 80
+  },
+  {
+    "id": 504,
+    "taskId": 938,
+    "locality": "Global",
+    "task": "Harvest 20 Grimy Kwuarm.",
+    "information": "Harvest 20 grimy kwuarm.",
+    "requirements": "56 Farming",
+    "points": 80
+  },
+  {
+    "id": 505,
+    "taskId": 939,
+    "locality": "Global",
+    "task": "Catch 100 Shark.",
+    "information": "Catch 100 raw sharks.",
+    "requirements": "76 Fishing",
+    "points": 80
+  },
+  {
+    "id": 506,
+    "taskId": 940,
+    "locality": "Global",
+    "task": "Catch 100 Green Blubber Jellyfish.",
+    "information": "Catch 100 green blubber jellyfish.",
+    "requirements": "68 Fishing",
+    "points": 80
+  },
+  {
+    "id": 507,
+    "taskId": 941,
+    "locality": "Global",
+    "task": "Catch a Spirit Impling.",
+    "information": "Catch a spirit impling.",
+    "requirements": "54 Hunter",
+    "points": 80
+  },
+  {
+    "id": 508,
+    "taskId": 942,
+    "locality": "Global",
+    "task": "Equip a Slayer helmet.",
+    "information": "Equip a Slayer helmet.",
+    "requirements": "55 Crafting, 35 Slayer",
+    "points": 80
+  },
+  {
+    "id": 509,
+    "taskId": 944,
+    "locality": "Global",
+    "task": "Complete a Soul Reaper task.",
+    "information": "Complete a Soul Reaper task.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 510,
+    "taskId": 945,
+    "locality": "Global",
+    "task": "Complete 5 Soul Reaper tasks.",
+    "information": "Complete 5 Soul Reaper tasks.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 511,
+    "taskId": 947,
+    "locality": "Global",
+    "task": "Equip a full set of Orikalkum armour.",
+    "information": "Equip a full set of orikalkum armour.",
+    "requirements": "60 Smithing, 60 Defence",
+    "points": 80
+  },
+  {
+    "id": 512,
+    "taskId": 948,
+    "locality": "Global",
+    "task": "Equip a full set of Necronium armour.",
+    "information": "Equip a full set of necronium armour.",
+    "requirements": "70 Smithing, 70 Defence",
+    "points": 80
+  },
+  {
+    "id": 513,
+    "taskId": 949,
+    "locality": "Global",
+    "task": "Equip a full set of Black Dragonhide armour.",
+    "information": "Equip a full set of black dragonhide armour.",
+    "requirements": "60 Defence, 60 Crafting",
+    "points": 80
+  },
+  {
+    "id": 514,
+    "taskId": 950,
+    "locality": "Global",
+    "task": "Equip a full set of Royal Dragonhide armour.",
+    "information": "Equip a full set of royal dragonhide armour.",
+    "requirements": "65 Defence, 65 Crafting",
+    "points": 80
+  },
+  {
+    "id": 515,
+    "taskId": 951,
+    "locality": "Global",
+    "task": "Cast a Wave spell.",
+    "information": "Cast a wave spell.",
+    "requirements": "62 Magic",
+    "points": 80
+  },
+  {
+    "id": 516,
+    "taskId": 952,
+    "locality": "Global",
+    "task": "Burn 75 Yew logs.",
+    "information": "Burn 75 yew logs.",
+    "requirements": "60 Firemaking",
+    "points": 80
+  },
+  {
+    "id": 517,
+    "taskId": 953,
+    "locality": "Global",
+    "task": "Unlock the Ring of Quests from May's Quest Caravan.",
+    "information": "Unlock the Ring of Quests from May's Quest Caravan.",
+    "requirements": "75 Quest points",
+    "points": 80
+  },
+  {
+    "id": 518,
+    "taskId": 954,
+    "locality": "Global",
+    "task": "Complete 250 clues of any tier.",
+    "information": "Complete 250 clues of any tier.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 519,
+    "taskId": 955,
+    "locality": "Global",
+    "task": "Complete 500 clues of any tier.",
+    "information": "Complete 500 clues of any tier.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 520,
+    "taskId": 956,
+    "locality": "Global",
+    "task": "Complete an Elite clue scroll.",
+    "information": "Complete an elite clue scroll.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 521,
+    "taskId": 957,
+    "locality": "Global",
+    "task": "Complete 25 Elite clue scrolls.",
+    "information": "Complete 25 elite clue scrolls.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 522,
+    "taskId": 960,
+    "locality": "Global",
+    "task": "Complete a Master clue scroll.",
+    "information": "Complete a master clue scroll.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 523,
+    "taskId": 964,
+    "locality": "Global",
+    "task": "Collect 5 unique items for the Elite clue rewards collection log.",
+    "information": "Collect 5 unique items for the elite clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 524,
+    "taskId": 965,
+    "locality": "Global",
+    "task": "Collect 10 unique items for the Elite clue rewards collection log.",
+    "information": "Collect 10 unique items for the elite clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 525,
+    "taskId": 966,
+    "locality": "Global",
+    "task": "Collect 20 unique items for the Elite clue rewards collection log.",
+    "information": "Collect 20 unique items for the elite clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 526,
+    "taskId": 968,
+    "locality": "Global",
+    "task": "Collect 5 unique items for the Master clue rewards collection log.",
+    "information": "Collect 5 unique items for the master clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 527,
+    "taskId": 1002,
+    "locality": "Global",
+    "task": "Catch a Manta ray.",
+    "information": "Catch a raw manta ray.",
+    "requirements": "81 Fishing",
+    "points": 80
+  },
+  {
+    "id": 528,
+    "taskId": 1101,
+    "locality": "Global",
+    "task": "Reach level 70 in any skill.",
+    "information": "Reach level 70 in any skill.",
+    "requirements": "Any skill at level 70",
+    "points": 80
+  },
+  {
+    "id": 529,
+    "taskId": 1102,
+    "locality": "Global",
+    "task": "Reach level 80 in any skill.",
+    "information": "Reach level 80 in any skill.",
+    "requirements": "Any skill at level 80",
+    "points": 80
+  },
+  {
+    "id": 530,
+    "taskId": 1106,
+    "locality": "Global",
+    "task": "Reach at least level 40 in all non-elite skills.",
+    "information": "Reach at least level 40 in all non-elite skills.",
+    "requirements": "All skills except Invention at level 40",
+    "points": 80
+  },
+  {
+    "id": 531,
+    "taskId": 1107,
+    "locality": "Global",
+    "task": "Reach at least level 60 in all non-elite skills.",
+    "information": "Reach at least level 60 in all non-elite skills.",
+    "requirements": "All skills except Invention at level 60",
+    "points": 80
+  },
+  {
+    "id": 532,
+    "taskId": 1108,
+    "locality": "Global",
+    "task": "Reach at least level 70 in all non-elite skills.",
+    "information": "Reach at least level 70 in all non-elite skills.",
+    "requirements": "All skills except Invention at level 70",
+    "points": 80
+  },
+  {
+    "id": 533,
+    "taskId": 140,
+    "locality": "Global",
+    "task": "Reach maximum combat level.",
+    "information": "Reach maximum combat level.",
+    "requirements": "138 Combat",
+    "points": 150
+  },
+  {
+    "id": 534,
+    "taskId": 145,
+    "locality": "Global",
+    "task": "Reach total level 2000.",
+    "information": "Reach total level 2000.",
+    "requirements": "2000 Skills Total level",
+    "points": 150
+  },
+  {
+    "id": 535,
+    "taskId": 821,
+    "locality": "Global",
+    "task": "Complete 50 Slayer tasks.",
+    "information": "Complete 50 Slayer tasks.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 536,
+    "taskId": 822,
+    "locality": "Global",
+    "task": "Complete 75 Slayer tasks.",
+    "information": "Complete 75 Slayer tasks.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 537,
+    "taskId": 890,
+    "locality": "Global",
+    "task": "Obtain 125 Quest Points.",
+    "information": "Obtain 125 quest points.",
+    "requirements": "125 Quest points",
+    "points": 150
+  },
+  {
+    "id": 538,
+    "taskId": 911,
+    "locality": "Global",
+    "task": "Collect 75 unique items for the Hard clue rewards collection log.",
+    "information": "Collect 75 unique items for the hard clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 539,
+    "taskId": 946,
+    "locality": "Global",
+    "task": "Complete 10 Soul Reaper tasks.",
+    "information": "Complete 10 Soul Reaper tasks.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 540,
+    "taskId": 958,
+    "locality": "Global",
+    "task": "Complete 75 Elite clue scrolls.",
+    "information": "Complete 75 elite clue scrolls.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 541,
+    "taskId": 959,
+    "locality": "Global",
+    "task": "Complete 150 Elite clue scrolls.",
+    "information": "Complete 150 elite clue scrolls.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 542,
+    "taskId": 961,
+    "locality": "Global",
+    "task": "Complete 25 Master clue scrolls.",
+    "information": "Complete 25 master clue scrolls.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 543,
+    "taskId": 962,
+    "locality": "Global",
+    "task": "Complete 75 Master clue scrolls.",
+    "information": "Complete 75 master clue scrolls.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 544,
+    "taskId": 967,
+    "locality": "Global",
+    "task": "Collect 35 unique items for the Elite clue rewards collection log.",
+    "information": "Collect 35 unique items for the elite clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 545,
+    "taskId": 969,
+    "locality": "Global",
+    "task": "Collect 10 unique items for the Master clue rewards collection log.",
+    "information": "Collect 10 unique items for the master clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 546,
+    "taskId": 970,
+    "locality": "Global",
+    "task": "Collect 15 unique items for the Master clue rewards collection log.",
+    "information": "Collect 15 unique items for the master clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 547,
+    "taskId": 971,
+    "locality": "Global",
+    "task": "Collect 30 unique items for the Master clue rewards collection log.",
+    "information": "Collect 30 unique items for the master clue rewards collection log.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 548,
+    "taskId": 972,
+    "locality": "Global",
+    "task": "Make 25 Powerburst Potions.",
+    "information": "Make 25 powerbursts.",
+    "requirements": "92 Herblore",
+    "points": 150
+  },
+  {
+    "id": 549,
+    "taskId": 973,
+    "locality": "Global",
+    "task": "Make 25 Bomb Potions.",
+    "information": "Make 25 bomb potions.",
+    "requirements": "93 Herblore",
+    "points": 150
+  },
+  {
+    "id": 550,
+    "taskId": 974,
+    "locality": "Global",
+    "task": "Make 5 Perfect Plus Potions.",
+    "information": "Make 5 perfect plus potions.",
+    "requirements": "84 Herblore",
+    "points": 150
+  },
+  {
+    "id": 551,
+    "taskId": 975,
+    "locality": "Global",
+    "task": "Make 15 Overload Potions.",
+    "information": "Make 15 overloads.",
+    "requirements": "96 Herblore",
+    "points": 150
+  },
+  {
+    "id": 552,
+    "taskId": 976,
+    "locality": "Global",
+    "task": "Make a Spiritual Prayer Potion.",
+    "information": "Make a spiritual prayer potion.",
+    "requirements": "97 Herblore",
+    "points": 150
+  },
+  {
+    "id": 553,
+    "taskId": 977,
+    "locality": "Global",
+    "task": "Fletch 200 Magic stocks.",
+    "information": "Fletch 200 magic stocks.",
+    "requirements": "82 Fletching",
+    "points": 150
+  },
+  {
+    "id": 554,
+    "taskId": 978,
+    "locality": "Global",
+    "task": "Fletch 750 Elder arrow shafts.",
+    "information": "Fletch 750 elder arrow shafts.",
+    "requirements": "90 Fletching",
+    "points": 150
+  },
+  {
+    "id": 555,
+    "taskId": 979,
+    "locality": "Global",
+    "task": "Fletch 20 Elder shortbow (unstrung)",
+    "information": "Fletch 20 unstrung elder shortbows",
+    "requirements": "90 Fletching",
+    "points": 150
+  },
+  {
+    "id": 556,
+    "taskId": 980,
+    "locality": "Global",
+    "task": "Fletch an Eternal magic shortbow (Martial) or Primal crossbow (martial).",
+    "information": "Fletch an eternal magic shortbow (martial) or primal crossbow (martial).",
+    "requirements": "95 Fletching",
+    "points": 150
+  },
+  {
+    "id": 557,
+    "taskId": 981,
+    "locality": "Global",
+    "task": "Fletch 1,000 Eternal magic shafts.",
+    "information": "Fletch 1,000 eternal magic shafts.",
+    "requirements": "90 Fletching",
+    "points": 150
+  },
+  {
+    "id": 558,
+    "taskId": 982,
+    "locality": "Global",
+    "task": "Fletch 1,500 Primal arrows.",
+    "information": "Fletch 1,500 primal arrows.",
+    "requirements": "92 Fletching",
+    "points": 150
+  },
+  {
+    "id": 559,
+    "taskId": 983,
+    "locality": "Global",
+    "task": "Fletch an Eternal Magic Wood Box.",
+    "information": "Fletch an eternal magic wood box.",
+    "requirements": "90 Fletching",
+    "points": 150
+  },
+  {
+    "id": 560,
+    "taskId": 984,
+    "locality": "Global",
+    "task": "Fletch 350 Rune darts.",
+    "information": "Fletch 350 rune darts.",
+    "requirements": "81 Fletching",
+    "points": 150
+  },
+  {
+    "id": 561,
+    "taskId": 985,
+    "locality": "Global",
+    "task": "Smith a Primal Ore Box.",
+    "information": "Smith a primal ore box.",
+    "requirements": "99 Smithing",
+    "points": 150
+  },
+  {
+    "id": 562,
+    "taskId": 986,
+    "locality": "Global",
+    "task": "Smith 10,000 Armour Spikes.",
+    "information": "Smith 10,000 armour spikes.",
+    "requirements": "80 Smithing",
+    "points": 150
+  },
+  {
+    "id": 563,
+    "taskId": 987,
+    "locality": "Global",
+    "task": "Smith 10,000 Primal Armour Spikes.",
+    "information": "Smith 10,000 primal armour spikes.",
+    "requirements": "99 Smithing",
+    "points": 150
+  },
+  {
+    "id": 564,
+    "taskId": 988,
+    "locality": "Global",
+    "task": "Mine each of the 10 ores on the surface of the Daemonheim peninsula in under 5 minutes.",
+    "information": "Mine each of the 10 ores on the surface of the Daemonheim peninsula in under 5 minutes.",
+    "requirements": "80 Mining",
+    "points": 150
+  },
+  {
+    "id": 565,
+    "taskId": 989,
+    "locality": "Global",
+    "task": "Mine 70 Banite Ore.",
+    "information": "Mine 70 banite ore.",
+    "requirements": "80 Mining",
+    "points": 150
+  },
+  {
+    "id": 566,
+    "taskId": 990,
+    "locality": "Global",
+    "task": "Mine 100 Dark or Light Animica.",
+    "information": "Mine 100 dark or light animica.",
+    "requirements": "90 Mining",
+    "points": 150
+  },
+  {
+    "id": 567,
+    "taskId": 991,
+    "locality": "Global",
+    "task": "Open 10 Metamorphic Geodes.",
+    "information": "Open 10 metamorphic geodes. These are found randomly while mining from rocks which require at least level 60 Mining",
+    "requirements": "60 Mining",
+    "points": 150
+  },
+  {
+    "id": 568,
+    "taskId": 992,
+    "locality": "Global",
+    "task": "Harvest 40 Grimy Lantadyme.",
+    "information": "Harvest 40 grimy lantadyme.",
+    "requirements": "73 Farming",
+    "points": 150
+  },
+  {
+    "id": 569,
+    "taskId": 993,
+    "locality": "Global",
+    "task": "Harvest 50 Grimy Fellstalk.",
+    "information": "Harvest 50 grimy fellstalk.",
+    "requirements": "91 Farming",
+    "points": 150
+  },
+  {
+    "id": 570,
+    "taskId": 994,
+    "locality": "Global",
+    "task": "Plant an Avocado seed in a bush patch.",
+    "information": "Plant an avocado seed in a bush patch.",
+    "requirements": "69 Farming",
+    "points": 150
+  },
+  {
+    "id": 571,
+    "taskId": 995,
+    "locality": "Global",
+    "task": "Harvest 20 Lychee.",
+    "information": "Harvest 20 lychee.",
+    "requirements": "99 Farming",
+    "points": 150
+  },
+  {
+    "id": 572,
+    "taskId": 996,
+    "locality": "Global",
+    "task": "Harvest 24 Starbloom Flowers.",
+    "information": "Harvest 24 starbloom flowers.",
+    "requirements": "84 Farming",
+    "points": 150
+  },
+  {
+    "id": 573,
+    "taskId": 997,
+    "locality": "Global",
+    "task": "Catch 150 Rocktail.",
+    "information": "Catch 150 raw rocktails.",
+    "requirements": "90 Fishing",
+    "points": 150
+  },
+  {
+    "id": 574,
+    "taskId": 998,
+    "locality": "Global",
+    "task": "Catch 200 Sailfish.",
+    "information": "Catch 200 raw sailfish.",
+    "requirements": "97 Fishing",
+    "points": 150
+  },
+  {
+    "id": 575,
+    "taskId": 999,
+    "locality": "Global",
+    "task": "Catch 150 Blue Blubber Jellyfish.",
+    "information": "Catch 150 raw blue blubber jellyfish.",
+    "requirements": "91 Fishing",
+    "points": 150
+  },
+  {
+    "id": 576,
+    "taskId": 1000,
+    "locality": "Global",
+    "task": "Obtain the highest boost available in the 'Fishing Frenzy' activity.",
+    "information": "Obtain the highest boost available in the 'Fishing Frenzy' activity at Deep Sea Fishing.",
+    "requirements": "94 Fishing",
+    "points": 150
+  },
+  {
+    "id": 577,
+    "taskId": 1001,
+    "locality": "Global",
+    "task": "Catch a Cavefish.",
+    "information": "Catch a raw cavefish.",
+    "requirements": "85 Fishing, 80 Cooking",
+    "points": 150
+  },
+  {
+    "id": 578,
+    "taskId": 1003,
+    "locality": "Global",
+    "task": "Manually bury or scatter each of the listed bones and ashes.",
+    "information": "Complete the Bury All achievement.",
+    "requirements": "90 Prayer",
+    "points": 150
+  },
+  {
+    "id": 579,
+    "taskId": 1004,
+    "locality": "Global",
+    "task": "Activate Soul Split prayer.",
+    "information": "Activate Soul Split prayer.",
+    "requirements": "92 Prayer",
+    "points": 150
+  },
+  {
+    "id": 580,
+    "taskId": 1005,
+    "locality": "Global",
+    "task": "Catch a Dragon Impling.",
+    "information": "Catch a dragon impling.",
+    "requirements": "80 Hunter",
+    "points": 150
+  },
+  {
+    "id": 581,
+    "taskId": 1006,
+    "locality": "Global",
+    "task": "Catch a Kingly Impling.",
+    "information": "Catch a kingly impling.",
+    "requirements": "90 Hunter",
+    "points": 150
+  },
+  {
+    "id": 582,
+    "taskId": 1007,
+    "locality": "Global",
+    "task": "Equip a full set of Bane armour.",
+    "information": "Equip a full set of bane armour.",
+    "requirements": "80 Smithing, 80 Defence",
+    "points": 150
+  },
+  {
+    "id": 583,
+    "taskId": 1008,
+    "locality": "Global",
+    "task": "Equip a full set of Elder Rune armour.",
+    "information": "Equip a full set of elder rune armour.",
+    "requirements": "90 Smithing, 90 Defence",
+    "points": 150
+  },
+  {
+    "id": 584,
+    "taskId": 1009,
+    "locality": "Global",
+    "task": "Cast a Surge spell.",
+    "information": "Cast a Surge spell.",
+    "requirements": "81 Magic",
+    "points": 150
+  },
+  {
+    "id": 585,
+    "taskId": 1010,
+    "locality": "Global",
+    "task": "Burn 100 Magic Logs",
+    "information": "Burn 100 magic logs",
+    "requirements": "75 Firemaking",
+    "points": 150
+  },
+  {
+    "id": 586,
+    "taskId": 1011,
+    "locality": "Global",
+    "task": "Burn 10 Elder logs.",
+    "information": "Burn 10 elder logs.",
+    "requirements": "90 Firemaking",
+    "points": 150
+  },
+  {
+    "id": 587,
+    "taskId": 1012,
+    "locality": "Global",
+    "task": "Reach level 99 in the Agility skill.",
+    "information": "Reach level 99 Agility.",
+    "requirements": "99 Agility",
+    "points": 150
+  },
+  {
+    "id": 588,
+    "taskId": 1013,
+    "locality": "Global",
+    "task": "Reach level 99 in the Archaeology skill.",
+    "information": "Reach level 99 Archaeology.",
+    "requirements": "99 Archaeology",
+    "points": 150
+  },
+  {
+    "id": 589,
+    "taskId": 1014,
+    "locality": "Global",
+    "task": "Reach level 99 in the Attack skill.",
+    "information": "Reach level 99 Attack.",
+    "requirements": "99 Attack",
+    "points": 150
+  },
+  {
+    "id": 590,
+    "taskId": 1015,
+    "locality": "Global",
+    "task": "Reach level 99 in the Construction skill.",
+    "information": "Reach level 99 Construction.",
+    "requirements": "99 Construction",
+    "points": 150
+  },
+  {
+    "id": 591,
+    "taskId": 1016,
+    "locality": "Global",
+    "task": "Reach level 99 in the Cooking skill.",
+    "information": "Reach level 99 Cooking.",
+    "requirements": "99 Cooking",
+    "points": 150
+  },
+  {
+    "id": 592,
+    "taskId": 1017,
+    "locality": "Global",
+    "task": "Reach level 99 in the Crafting skill.",
+    "information": "Reach level 99 Crafting.",
+    "requirements": "99 Crafting",
+    "points": 150
+  },
+  {
+    "id": 593,
+    "taskId": 1018,
+    "locality": "Global",
+    "task": "Reach level 99 in the Defence skill.",
+    "information": "Reach level 99 Defence.",
+    "requirements": "99 Defence",
+    "points": 150
+  },
+  {
+    "id": 594,
+    "taskId": 1019,
+    "locality": "Global",
+    "task": "Reach level 99 in the Divination skill.",
+    "information": "Reach level 99 Divination.",
+    "requirements": "99 Divination",
+    "points": 150
+  },
+  {
+    "id": 595,
+    "taskId": 1020,
+    "locality": "Global",
+    "task": "Reach level 99 in the Dungeoneering skill.",
+    "information": "Reach level 99 Dungeoneering.",
+    "requirements": "99 Dungeoneering",
+    "points": 150
+  },
+  {
+    "id": 596,
+    "taskId": 1021,
+    "locality": "Global",
+    "task": "Reach level 99 in the Farming skill.",
+    "information": "Reach level 99 Farming.",
+    "requirements": "99 Farming",
+    "points": 150
+  },
+  {
+    "id": 597,
+    "taskId": 1022,
+    "locality": "Global",
+    "task": "Reach level 99 in the Firemaking skill. (Where arson is its own reward.)",
+    "information": "Reach level 99 Firemaking.",
+    "requirements": "99 Firemaking",
+    "points": 150
+  },
+  {
+    "id": 598,
+    "taskId": 1023,
+    "locality": "Global",
+    "task": "Reach level 99 in the Fishing skill.",
+    "information": "Reach level 99 Fishing.",
+    "requirements": "99 Fishing",
+    "points": 150
+  },
+  {
+    "id": 599,
+    "taskId": 1024,
+    "locality": "Global",
+    "task": "Reach level 99 in the Fletching skill.",
+    "information": "Reach level 99 Fletching.",
+    "requirements": "99 Fletching",
+    "points": 150
+  },
+  {
+    "id": 600,
+    "taskId": 1025,
+    "locality": "Global",
+    "task": "Reach level 99 in the Herblore skill.",
+    "information": "Reach level 99 Herblore.",
+    "requirements": "99 Herblore",
+    "points": 150
+  },
+  {
+    "id": 601,
+    "taskId": 1026,
+    "locality": "Global",
+    "task": "Reach level 99 in the Constitution skill.",
+    "information": "Reach level 99 Constitution.",
+    "requirements": "99 Constitution",
+    "points": 150
+  },
+  {
+    "id": 602,
+    "taskId": 1027,
+    "locality": "Global",
+    "task": "Reach level 99 in the Hunter skill.",
+    "information": "Reach level 99 Hunter.",
+    "requirements": "99 Hunter",
+    "points": 150
+  },
+  {
+    "id": 603,
+    "taskId": 1028,
+    "locality": "Global",
+    "task": "Reach level 99 in the Invention skill.",
+    "information": "Reach level 99 Invention.",
+    "requirements": "99 Invention",
+    "points": 150
+  },
+  {
+    "id": 604,
+    "taskId": 1029,
+    "locality": "Global",
+    "task": "Reach level 99 in the Magic skill.",
+    "information": "Reach level 99 Magic.",
+    "requirements": "99 Magic",
+    "points": 150
+  },
+  {
+    "id": 605,
+    "taskId": 1030,
+    "locality": "Global",
+    "task": "Reach level 99 in the Mining skill.",
+    "information": "Reach level 99 Mining.",
+    "requirements": "99 Mining",
+    "points": 150
+  },
+  {
+    "id": 606,
+    "taskId": 1031,
+    "locality": "Global",
+    "task": "Reach level 99 in the Necromancy skill.",
+    "information": "Reach level 99 Necromancy.",
+    "requirements": "99 Necromancy",
+    "points": 150
+  },
+  {
+    "id": 607,
+    "taskId": 1032,
+    "locality": "Global",
+    "task": "Reach level 99 in the Prayer skill.",
+    "information": "Reach level 99 Prayer.",
+    "requirements": "99 Prayer",
+    "points": 150
+  },
+  {
+    "id": 608,
+    "taskId": 1033,
+    "locality": "Global",
+    "task": "Reach level 99 in the Ranged skill.",
+    "information": "Reach level 99 Ranged.",
+    "requirements": "99 Ranged",
+    "points": 150
+  },
+  {
+    "id": 609,
+    "taskId": 1034,
+    "locality": "Global",
+    "task": "Reach level 99 in the Runecrafting skill.",
+    "information": "Reach level 99 Runecrafting.",
+    "requirements": "99 Runecrafting",
+    "points": 150
+  },
+  {
+    "id": 610,
+    "taskId": 1035,
+    "locality": "Global",
+    "task": "Reach level 99 in the Slayer skill.",
+    "information": "Reach level 99 Slayer.",
+    "requirements": "99 Slayer",
+    "points": 150
+  },
+  {
+    "id": 611,
+    "taskId": 1036,
+    "locality": "Global",
+    "task": "Reach level 99 in the Smithing skill.",
+    "information": "Reach level 99 Smithing.",
+    "requirements": "99 Smithing",
+    "points": 150
+  },
+  {
+    "id": 612,
+    "taskId": 1037,
+    "locality": "Global",
+    "task": "Reach level 99 in the Strength skill.",
+    "information": "Reach level 99 Strength.",
+    "requirements": "99 Strength",
+    "points": 150
+  },
+  {
+    "id": 613,
+    "taskId": 1038,
+    "locality": "Global",
+    "task": "Reach level 99 in the Summoning skill.",
+    "information": "Reach level 99 Summoning.",
+    "requirements": "99 Summoning",
+    "points": 150
+  },
+  {
+    "id": 614,
+    "taskId": 1039,
+    "locality": "Global",
+    "task": "Reach level 99 in the Thieving skill.",
+    "information": "Reach level 99 Thieving.",
+    "requirements": "99 Thieving",
+    "points": 150
+  },
+  {
+    "id": 615,
+    "taskId": 1040,
+    "locality": "Global",
+    "task": "Reach level 99 in the Woodcutting skill.",
+    "information": "Reach level 99 Woodcutting.",
+    "requirements": "99 Woodcutting",
+    "points": 150
+  },
+  {
+    "id": 616,
+    "taskId": 1041,
+    "locality": "Global",
+    "task": "Reach level 110 in the Mining skill.",
+    "information": "Reach level 110 Mining.",
+    "requirements": "110 Mining",
+    "points": 150
+  },
+  {
+    "id": 617,
+    "taskId": 1042,
+    "locality": "Global",
+    "task": "Reach level 110 in the Smithing skill.",
+    "information": "Reach level 110 Smithing.",
+    "requirements": "110 Smithing",
+    "points": 150
+  },
+  {
+    "id": 618,
+    "taskId": 1043,
+    "locality": "Global",
+    "task": "Reach level 110 in the Crafting skill.",
+    "information": "Reach level 110 Crafting",
+    "requirements": "110 Crafting",
+    "points": 150
+  },
+  {
+    "id": 619,
+    "taskId": 1044,
+    "locality": "Global",
+    "task": "Reach level 110 in the Firemaking skill.",
+    "information": "Reach level 110 Firemaking.",
+    "requirements": "110 Firemaking",
+    "points": 150
+  },
+  {
+    "id": 620,
+    "taskId": 1045,
+    "locality": "Global",
+    "task": "Reach level 110 in the Fletching skill.",
+    "information": "Reach level 110 Fletching.",
+    "requirements": "110 Fletching",
+    "points": 150
+  },
+  {
+    "id": 621,
+    "taskId": 1046,
+    "locality": "Global",
+    "task": "Reach level 110 in the Woodcutting skill.",
+    "information": "Reach level 110 Woodcutting.",
+    "requirements": "110 Woodcutting",
+    "points": 150
+  },
+  {
+    "id": 622,
+    "taskId": 1047,
+    "locality": "Global",
+    "task": "Reach level 110 in the Runecrafting skill.",
+    "information": "Reach level 110 Runecrafting.",
+    "requirements": "110 Runecrafting",
+    "points": 150
+  },
+  {
+    "id": 623,
+    "taskId": 1048,
+    "locality": "Global",
+    "task": "Reach level 120 in the Dungeoneering skill.",
+    "information": "Reach level 120 Dungeoneering.",
+    "requirements": "120 Dungeoneering",
+    "points": 150
+  },
+  {
+    "id": 624,
+    "taskId": 1049,
+    "locality": "Global",
+    "task": "Reach level 120 in the Farming skill.",
+    "information": "Reach level 120 Farming.",
+    "requirements": "120 Farming",
+    "points": 150
+  },
+  {
+    "id": 625,
+    "taskId": 1050,
+    "locality": "Global",
+    "task": "Reach level 120 in the Herblore skill.",
+    "information": "Reach level 120 Herblore.",
+    "requirements": "120 Herblore",
+    "points": 150
+  },
+  {
+    "id": 626,
+    "taskId": 1051,
+    "locality": "Global",
+    "task": "Reach level 120 in the Slayer skill.",
+    "information": "Reach level 120 Slayer.",
+    "requirements": "120 Slayer",
+    "points": 150
+  },
+  {
+    "id": 627,
+    "taskId": 1052,
+    "locality": "Global",
+    "task": "Reach level 120 in the Invention skill.",
+    "information": "Reach level 120 Invention.",
+    "requirements": "120 Invention",
+    "points": 150
+  },
+  {
+    "id": 628,
+    "taskId": 1053,
+    "locality": "Global",
+    "task": "Reach level 120 in the Archaeology skill.",
+    "information": "Reach level 120 Archaeology",
+    "requirements": "120 Archaeology",
+    "points": 150
+  },
+  {
+    "id": 629,
+    "taskId": 1054,
+    "locality": "Global",
+    "task": "Reach level 120 in the Necromancy skill.",
+    "information": "Reach level 120 Necromancy.",
+    "requirements": "120 Necromancy",
+    "points": 150
+  },
+  {
+    "id": 630,
+    "taskId": 1055,
+    "locality": "Global",
+    "task": "Obtain 50 Million Agility XP.",
+    "information": "Obtain 50 million Agility XP.",
+    "requirements": "50,000,000 Agility XP",
+    "points": 150
+  },
+  {
+    "id": 631,
+    "taskId": 1056,
+    "locality": "Global",
+    "task": "Obtain 50 Million Construction XP.",
+    "information": "Obtain 50 million Construction XP.",
+    "requirements": "50,000,000 Construction XP",
+    "points": 150
+  },
+  {
+    "id": 632,
+    "taskId": 1057,
+    "locality": "Global",
+    "task": "Obtain 50 Million Cooking XP.",
+    "information": "Obtain 50 million Cooking XP.",
+    "requirements": "50,000,000 Cooking XP",
+    "points": 150
+  },
+  {
+    "id": 633,
+    "taskId": 1058,
+    "locality": "Global",
+    "task": "Obtain 50 Million Crafting XP.",
+    "information": "Obtain 50 million Crafting XP.",
+    "requirements": "50,000,000 Crafting XP",
+    "points": 150
+  },
+  {
+    "id": 634,
+    "taskId": 1059,
+    "locality": "Global",
+    "task": "Obtain 50 Million Farming XP.",
+    "information": "Obtain 50 million Farming XP.",
+    "requirements": "50,000,000 Farming XP",
+    "points": 150
+  },
+  {
+    "id": 635,
+    "taskId": 1060,
+    "locality": "Global",
+    "task": "Obtain 50 Million Firemaking XP.",
+    "information": "Obtain 50 million Firemaking XP.",
+    "requirements": "50,000,000 Firemaking XP",
+    "points": 150
+  },
+  {
+    "id": 636,
+    "taskId": 1061,
+    "locality": "Global",
+    "task": "Obtain 50 Million Fishing XP.",
+    "information": "Obtain 50 million Fishing XP.",
+    "requirements": "50,000,000 Fishing XP",
+    "points": 150
+  },
+  {
+    "id": 637,
+    "taskId": 1062,
+    "locality": "Global",
+    "task": "Obtain 50 Million Fletching XP.",
+    "information": "Obtain 50 million Fletching XP.",
+    "requirements": "50,000,000 Fletching XP",
+    "points": 150
+  },
+  {
+    "id": 638,
+    "taskId": 1063,
+    "locality": "Global",
+    "task": "Obtain 50 Million Herblore XP.",
+    "information": "Obtain 50 million Herblore XP.",
+    "requirements": "50,000,000 Herblore XP",
+    "points": 150
+  },
+  {
+    "id": 639,
+    "taskId": 1064,
+    "locality": "Global",
+    "task": "Obtain 50 Million Hunter XP.",
+    "information": "Obtain 50 million Hunter XP.",
+    "requirements": "50,000,000 Hunter XP",
+    "points": 150
+  },
+  {
+    "id": 640,
+    "taskId": 1065,
+    "locality": "Global",
+    "task": "Obtain 50 Million Mining XP.",
+    "information": "Obtain 50 million Mining XP.",
+    "requirements": "50,000,000 Mining XP",
+    "points": 150
+  },
+  {
+    "id": 641,
+    "taskId": 1066,
+    "locality": "Global",
+    "task": "Obtain 50 Million Prayer XP.",
+    "information": "Obtain 50 million Prayer XP.",
+    "requirements": "50,000,000 Prayer XP",
+    "points": 150
+  },
+  {
+    "id": 642,
+    "taskId": 1067,
+    "locality": "Global",
+    "task": "Obtain 50 Million Runecrafting XP.",
+    "information": "Obtain 50 million Runecrafting XP.",
+    "requirements": "50,000,000 Runecrafting XP",
+    "points": 150
+  },
+  {
+    "id": 643,
+    "taskId": 1068,
+    "locality": "Global",
+    "task": "Obtain 50 Million Slayer XP.",
+    "information": "Obtain 50 million Slayer XP.",
+    "requirements": "50,000,000 Slayer XP",
+    "points": 150
+  },
+  {
+    "id": 644,
+    "taskId": 1069,
+    "locality": "Global",
+    "task": "Obtain 50 Million Smithing XP.",
+    "information": "Obtain 50 million Smithing XP.",
+    "requirements": "50,000,000 Smithing XP",
+    "points": 150
+  },
+  {
+    "id": 645,
+    "taskId": 1070,
+    "locality": "Global",
+    "task": "Obtain 50 Million Thieving XP.",
+    "information": "Obtain 50 million Thieving XP.",
+    "requirements": "50,000,000 Thieving XP",
+    "points": 150
+  },
+  {
+    "id": 646,
+    "taskId": 1071,
+    "locality": "Global",
+    "task": "Obtain 50 Million Woodcutting XP.",
+    "information": "Obtain 50 million Woodcutting XP.",
+    "requirements": "50,000,000 Woodcutting XP",
+    "points": 150
+  },
+  {
+    "id": 647,
+    "taskId": 1072,
+    "locality": "Global",
+    "task": "Obtain 50 Million Dungeoneering XP.",
+    "information": "Obtain 50 million Dungeoneering XP.",
+    "requirements": "50,000,000 Dungeoneering XP",
+    "points": 150
+  },
+  {
+    "id": 648,
+    "taskId": 1073,
+    "locality": "Global",
+    "task": "Obtain 50 Million Invention XP.",
+    "information": "Obtain 50 million Invention XP.",
+    "requirements": "50,000,000 Invention XP",
+    "points": 150
+  },
+  {
+    "id": 649,
+    "taskId": 1074,
+    "locality": "Global",
+    "task": "Obtain 50 Million Divination XP.",
+    "information": "Obtain 50 million Divination XP.",
+    "requirements": "50,000,000 Divination XP",
+    "points": 150
+  },
+  {
+    "id": 650,
+    "taskId": 1075,
+    "locality": "Global",
+    "task": "Obtain 50 Million Archaeology XP.",
+    "information": "Obtain 50 million Archaeology XP.",
+    "requirements": "50,000,000 Archaeology XP",
+    "points": 150
+  },
+  {
+    "id": 651,
+    "taskId": 1076,
+    "locality": "Global",
+    "task": "Obtain 50 Million Attack XP.",
+    "information": "Obtain 50 million Attack XP.",
+    "requirements": "50,000,000 Attack XP",
+    "points": 150
+  },
+  {
+    "id": 652,
+    "taskId": 1077,
+    "locality": "Global",
+    "task": "Obtain 50 Million Constitution XP.",
+    "information": "Obtain 50 million Constitution XP.",
+    "requirements": "50,000,000 Constitution XP",
+    "points": 150
+  },
+  {
+    "id": 653,
+    "taskId": 1078,
+    "locality": "Global",
+    "task": "Obtain 50 Million Strength XP.",
+    "information": "Obtain 50 million Strength XP.",
+    "requirements": "50,000,000 Strength XP",
+    "points": 150
+  },
+  {
+    "id": 654,
+    "taskId": 1079,
+    "locality": "Global",
+    "task": "Obtain 50 Million Defence XP.",
+    "information": "Obtain 50 million Defence XP.",
+    "requirements": "50,000,000 Defence XP",
+    "points": 150
+  },
+  {
+    "id": 655,
+    "taskId": 1080,
+    "locality": "Global",
+    "task": "Obtain 50 Million Ranged XP.",
+    "information": "Obtain 50 million Ranged XP.",
+    "requirements": "50,000,000 Ranged XP",
+    "points": 150
+  },
+  {
+    "id": 656,
+    "taskId": 1081,
+    "locality": "Global",
+    "task": "Obtain 50 Million Magic XP.",
+    "information": "Obtain 50 million Magic XP.",
+    "requirements": "50,000,000 Magic XP",
+    "points": 150
+  },
+  {
+    "id": 657,
+    "taskId": 1082,
+    "locality": "Global",
+    "task": "Obtain 50 Million Summoning XP.",
+    "information": "Obtain 50 million Summoning XP.",
+    "requirements": "50,000,000 Summoning XP",
+    "points": 150
+  },
+  {
+    "id": 658,
+    "taskId": 1083,
+    "locality": "Global",
+    "task": "Obtain 50 Million Necromancy XP.",
+    "information": "Obtain 50 million Necromancy XP.",
+    "requirements": "50,000,000 Necromancy XP",
+    "points": 150
+  },
+  {
+    "id": 659,
+    "taskId": 1084,
+    "locality": "Global",
+    "task": "Complete 750 clues of any tier.",
+    "information": "Complete 750 clues of any tier.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 660,
+    "taskId": 1085,
+    "locality": "Global",
+    "task": "Complete 1000 clues of any tier.",
+    "information": "Complete 1000 clues of any tier.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 661,
+    "taskId": 1086,
+    "locality": "Global",
+    "task": "Make 5 Elder Overload Salve Potions.",
+    "information": "Make 5 elder overload salves.",
+    "requirements": "107 Herblore",
+    "points": 150
+  },
+  {
+    "id": 662,
+    "taskId": 1087,
+    "locality": "Global",
+    "task": "Equip an Eternal Magic shortbow.",
+    "information": "Equip an eternal magic shortbow.",
+    "requirements": "95 Ranged, 90 Defence",
+    "points": 150
+  },
+  {
+    "id": 663,
+    "taskId": 1094,
+    "locality": "Global",
+    "task": "Equip a full set of Primal armour.",
+    "information": "Equip a full set of primal armour.",
+    "requirements": "99 Smithing, 99 Defence",
+    "points": 150
+  },
+  {
+    "id": 664,
+    "taskId": 1103,
+    "locality": "Global",
+    "task": "Reach level 90 in any skill.",
+    "information": "Reach level 90 in any skill.",
+    "requirements": "Any skill at level 90",
+    "points": 150
+  },
+  {
+    "id": 665,
+    "taskId": 1104,
+    "locality": "Global",
+    "task": "Reach level 95 in any skill.",
+    "information": "Reach level 95 in any skill.",
+    "requirements": "Any skill at level 95",
+    "points": 150
+  },
+  {
+    "id": 666,
+    "taskId": 1109,
+    "locality": "Global",
+    "task": "Reach at least level 80 in all non-elite skills.",
+    "information": "Reach at least level 80 in all non-elite skills.",
+    "requirements": "All skills except Invention at level 80",
+    "points": 150
+  },
+  {
+    "id": 667,
+    "taskId": 1110,
+    "locality": "Global",
+    "task": "Reach at least level 90 in all non-elite skills.",
+    "information": "Reach at least level 90 in all non-elite skills.",
+    "requirements": "All skills except Invention at level 90",
+    "points": 150
+  },
+  {
+    "id": 668,
+    "taskId": 447,
+    "locality": "Global",
+    "task": "Help the Archivist recover all core memory data in the Hall of Memories.",
+    "information": "Recover all core memory data in the Hall of Memories.",
+    "requirements": "70 Divination",
+    "points": 150
+  },
+  {
+    "id": 669,
+    "taskId": 448,
+    "locality": "Global",
+    "task": "Attune and hand all engrams in to the Memorial to Guthix.",
+    "information": "Hand all engrams in to the Memorial to Guthix.",
+    "requirements": "82 Divination",
+    "points": 150
+  },
+  {
+    "id": 670,
+    "taskId": 146,
+    "locality": "Global",
+    "task": "Reach maximum total level.",
+    "information": "Reach maximum total level.",
+    "requirements": "Maximum total level",
+    "points": 150
+  },
+  {
+    "id": 671,
+    "taskId": 963,
+    "locality": "Global",
+    "task": "Complete 150 Master clue scrolls.",
+    "information": "Complete 150 master clue scrolls.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 672,
+    "taskId": 1088,
+    "locality": "Global",
+    "task": "Work with Ramarno (in Camdozaal) to obtain a pickaxe of life and death.",
+    "information": "Create a pickaxe of life and death.",
+    "requirements": "99 Mining",
+    "points": 150
+  },
+  {
+    "id": 673,
+    "taskId": 1089,
+    "locality": "Global",
+    "task": "Have something planted and living in every farming patch.",
+    "information": "Have something planted and living in every farming patch.",
+    "requirements": "99 Farming",
+    "points": 150
+  },
+  {
+    "id": 674,
+    "taskId": 1090,
+    "locality": "Global",
+    "task": "Work with Ramarno (in Camdozaal) to obtain a hatchet of bloom and blight.",
+    "information": "Create a hatchet of bloom and blight.",
+    "requirements": "99 Woodcutting",
+    "points": 150
+  },
+  {
+    "id": 675,
+    "taskId": 1091,
+    "locality": "Global",
+    "task": "Equip any Masterwork weapon.",
+    "information": "Equip any masterwork weapon.",
+    "requirements": "92 Attack",
+    "points": 150
+  },
+  {
+    "id": 676,
+    "taskId": 1092,
+    "locality": "Global",
+    "task": "Equip a full set of Masterwork armour.",
+    "information": "Equip a full set of masterwork armour.",
+    "requirements": "99 Smithing, 92 Defence",
+    "points": 150
+  },
+  {
+    "id": 677,
+    "taskId": 1093,
+    "locality": "Global",
+    "task": "Unlock the Richie pet from helping Richie accumulate wealth at the Grand Exchange.",
+    "information": "Donate 100,000,000 GP to Richie.",
+    "requirements": "100,000,000 gp",
+    "points": 150
+  },
+  {
+    "id": 678,
+    "taskId": 1095,
+    "locality": "Global",
+    "task": "Obtain 200 Million XP in any single skill.",
+    "information": "Obtain 200 Million XP in any single skill.",
+    "requirements": "200,000,000 XP in any skill",
+    "points": 150
+  },
+  {
+    "id": 679,
+    "taskId": 1096,
+    "locality": "Global",
+    "task": "Fill all of the Treasure Trail hidey-holes. You can find a complete list of hidey-holes at the noticeboard by Zaida.",
+    "information": "Fill all of the Treasure Trail hidey-holes.",
+    "requirements": "Various",
+    "points": 150
+  },
+  {
+    "id": 680,
+    "taskId": 1097,
+    "locality": "Global",
+    "task": "Obtain a dye, or a piece of Third-age or Second-age gear from a clue scroll.",
+    "information": "Obtain a dye, or a piece of Third-age or Second-age gear from a clue scroll.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 681,
+    "taskId": 1111,
+    "locality": "Global",
+    "task": "Reach at least level 95 in all non-elite skills.",
+    "information": "Reach at least level 95 in all non-elite skills.",
+    "requirements": "All skills except Invention at level 95",
+    "points": 150
+  },
+  {
+    "id": 682,
+    "taskId": 403,
+    "locality": "Kandarin: Gnomes",
+    "task": "Complete the Gnome Stronghold Agility Course.",
+    "information": "Complete the Gnome Stronghold Agility Course.",
+    "requirements": "1 Agility",
+    "points": 10
+  },
+  {
+    "id": 683,
+    "taskId": 404,
+    "locality": "Kandarin: Feldip Hills",
+    "task": "Catch a Crimson Swift in the Feldip Hills.",
+    "information": "Catch a crimson swift in the Feldip Hills.",
+    "requirements": "1 Hunter",
+    "points": 10
+  },
+  {
+    "id": 684,
+    "taskId": 405,
+    "locality": "Kandarin: Ardougne",
+    "task": "Defeat a Tortoise with riders in Kandarin.",
+    "information": "Defeat a tortoise with riders in Kandarin.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 685,
+    "taskId": 406,
+    "locality": "Kandarin: Seers Village",
+    "task": "Complete the quest: You Are It.",
+    "information": "Complete You Are It.",
+    "requirements": "See quest page",
+    "points": 10
+  },
+  {
+    "id": 686,
+    "taskId": 407,
+    "locality": "Kandarin: Gnomes",
+    "task": "Let Brimstail teleport you to the Rune Essence mine.",
+    "information": "Let Brimstail teleport you to the Rune Essence mine.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 687,
+    "taskId": 408,
+    "locality": "Kandarin: Feldip Hills",
+    "task": "Equip a Marksman hat.",
+    "information": "Equip a marksman hat.",
+    "requirements": "125 chompy bird kills",
+    "points": 10
+  },
+  {
+    "id": 688,
+    "taskId": 410,
+    "locality": "Kandarin: Ardougne",
+    "task": "Learn how many beans make five (complete the Player Owned Farm tutorial).",
+    "information": "Complete the player-owned farm tutorial at Manor Farm.",
+    "requirements": "17 Farming, 20 Construction",
+    "points": 10
+  },
+  {
+    "id": 689,
+    "taskId": 412,
+    "locality": "Kandarin: Ardougne",
+    "task": "Teleport to the Wilderness using the lever in Ardougne.",
+    "information": "Pull the lever in Ardougne.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 690,
+    "taskId": 413,
+    "locality": "Kandarin: Yanille",
+    "task": "Use a ring of duelling to teleport to Castle Wars.",
+    "information": "Teleport to Castle Wars with a ring of duelling.",
+    "requirements": "27 Magic, 27 Crafting",
+    "points": 10
+  },
+  {
+    "id": 691,
+    "taskId": 414,
+    "locality": "Kandarin: Gnomes",
+    "task": "Make a Pineapple Punch cocktail.",
+    "information": "Make a pineapple punch cocktail.",
+    "requirements": "8 Cooking",
+    "points": 10
+  },
+  {
+    "id": 692,
+    "taskId": 415,
+    "locality": "Kandarin: Ardougne",
+    "task": "Fletch 50 Maple shieldbow (unstrung) in Kandarin.",
+    "information": "Fletch 50 unstrung maple shieldbows in Kandarin.",
+    "requirements": "55 Fletching",
+    "points": 30
+  },
+  {
+    "id": 693,
+    "taskId": 416,
+    "locality": "Kandarin: Ardougne",
+    "task": "Pickpocket a Knight of Ardougne 50 times.",
+    "information": "Pickpocket a knight of Ardougne 50 times.",
+    "requirements": "55 Thieving",
+    "points": 30
+  },
+  {
+    "id": 694,
+    "taskId": 417,
+    "locality": "Kandarin: Ardougne",
+    "task": "Complete the Barbarian Outpost Agility Course.",
+    "information": "Complete the Barbarian Outpost Agility Course.",
+    "requirements": "35 Agility",
+    "points": 30
+  },
+  {
+    "id": 695,
+    "taskId": 419,
+    "locality": "Kandarin: Ardougne",
+    "task": "Catch a red salamander from the Hunter area outside of Ourania Altar.",
+    "information": "Catch a red salamander.",
+    "requirements": "59 Hunter",
+    "points": 30
+  },
+  {
+    "id": 696,
+    "taskId": 420,
+    "locality": "Kandarin: Ardougne",
+    "task": "Enter the Fishing Guild.",
+    "information": "Enter the Fishing Guild.",
+    "requirements": "68 Fishing",
+    "points": 30
+  },
+  {
+    "id": 697,
+    "taskId": 421,
+    "locality": "Kandarin: Gnomes",
+    "task": "Check a grown Papaya Tree inside Tree Gnome Stronghold.",
+    "information": "Check a grown papaya tree inside Tree Gnome Stronghold.",
+    "requirements": "57 Farming",
+    "points": 30
+  },
+  {
+    "id": 698,
+    "taskId": 422,
+    "locality": "Kandarin: Ardougne",
+    "task": "Kill a mithril dragon.",
+    "information": "Defeat a mithril dragon.",
+    "requirements": "N/A",
+    "points": 30
+  },
+  {
+    "id": 699,
+    "taskId": 423,
+    "locality": "Kandarin: Yanille",
+    "task": "Enter the Magic Guild in Yanille.",
+    "information": "Enter the Wizards' Guild.",
+    "requirements": "66 Magic",
+    "points": 30
+  },
+  {
+    "id": 700,
+    "taskId": 424,
+    "locality": "Kandarin: Ardougne",
+    "task": "Defeat a Fire Giant in Kandarin.",
+    "information": "Defeat a fire giant in Kandarin.",
+    "requirements": "N/A",
+    "points": 30
+  },
+  {
+    "id": 701,
+    "taskId": 425,
+    "locality": "Kandarin: Seers Village",
+    "task": "Use the Chivalry Prayer.",
+    "information": "Use the Chivalry prayer.",
+    "requirements": "60 Prayer, 65 Defence",
+    "points": 30
+  },
+  {
+    "id": 702,
+    "taskId": 426,
+    "locality": "Kandarin: Yanille",
+    "task": "Be on the winning side in a game of Castle Wars.",
+    "information": "Win a game of Castle Wars.",
+    "requirements": "N/A",
+    "points": 30
+  },
+  {
+    "id": 703,
+    "taskId": 427,
+    "locality": "Kandarin: Seers Village",
+    "task": "Complete the quest: Elemental Workshop II.",
+    "information": "Complete Elemental Workshop II.",
+    "requirements": "See quest page",
+    "points": 30
+  },
+  {
+    "id": 704,
+    "taskId": 428,
+    "locality": "Kandarin: Feldip Hills",
+    "task": "Equip an Ogre Forester Hat.",
+    "information": "Equip an ogre forester hat.",
+    "requirements": "300 chompy bird kills",
+    "points": 30
+  },
+  {
+    "id": 705,
+    "taskId": 429,
+    "locality": "Kandarin: Ardougne",
+    "task": "Complete the task set: Easy Ardougne.",
+    "information": "Complete the Easy Ardougne achievements.",
+    "requirements": "See Easy Ardougne achievements page",
+    "points": 30
+  },
+  {
+    "id": 706,
+    "taskId": 430,
+    "locality": "Kandarin: Gnomes",
+    "task": "Create the listed gnome cocktails.",
+    "information": "Make one of each type of cocktail.",
+    "requirements": "37 Cooking",
+    "points": 30
+  },
+  {
+    "id": 707,
+    "taskId": 431,
+    "locality": "Kandarin: Ardougne",
+    "task": "Earn a total amount of 10,000 beans.",
+    "information": "Earn a total of 10,000 beans from selling animals in player-owned farm.",
+    "requirements": "17 Farming",
+    "points": 30
+  },
+  {
+    "id": 708,
+    "taskId": 434,
     "locality": "Kandarin: Ardougne",
     "task": "Complete the task set: Medium Ardougne.",
     "information": "Complete the Medium Ardougne achievements.",
@@ -3268,7 +6381,278 @@
     "points": 30
   },
   {
-    "id": 408,
+    "id": 709,
+    "taskId": 435,
+    "locality": "Kandarin: Ardougne",
+    "task": "Throw coins into the deep sea whirlpool.",
+    "information": "Throw some gold coins into the whirlpool at the Deep Sea Fishing platform.",
+    "requirements": "68 Fishing",
+    "points": 80
+  },
+  {
+    "id": 710,
+    "taskId": 436,
+    "locality": "Kandarin: Ardougne",
+    "task": "Solve the Archaeology mystery: Leap of Faith.",
+    "information": "Solve the Leap of Faith Archaeology mystery.",
+    "requirements": "70 Archaeology",
+    "points": 80
+  },
+  {
+    "id": 711,
+    "taskId": 437,
+    "locality": "Kandarin: Ardougne",
+    "task": "Collect all breeds of chinchompa at the Player Owned Farm.",
+    "information": "Breed all types of chinchompas.",
+    "requirements": "54 Farming, 20 Construction",
+    "points": 80
+  },
+  {
+    "id": 712,
+    "taskId": 438,
+    "locality": "Kandarin: Ardougne",
+    "task": "Equip one piece of the Fishing outfit.",
+    "information": "Equip one piece of the fishing outfit.",
+    "requirements": "140 fishing tokens",
+    "points": 80
+  },
+  {
+    "id": 713,
+    "taskId": 439,
+    "locality": "Kandarin: Ardougne",
+    "task": "Defeat the Penance Queen.",
+    "information": "Defeat the Penance Queen.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 714,
+    "taskId": 440,
+    "locality": "Kandarin: Ardougne",
+    "task": "Pickpocket a Hero.",
+    "information": "Pickpocket a hero.",
+    "requirements": "80 Thieving",
+    "points": 80
+  },
+  {
+    "id": 715,
+    "taskId": 441,
+    "locality": "Kandarin: Ardougne",
+    "task": "Catch 50 Red Chinchompas in Kandarin.",
+    "information": "Catch 50 carnivorous chinchompas in Kandarin.",
+    "requirements": "63 Hunter",
+    "points": 80
+  },
+  {
+    "id": 716,
+    "taskId": 442,
+    "locality": "Kandarin: Feldip Hills",
+    "task": "Equip an Ogre Expert hat.",
+    "information": "Equip an Ogre Expert hat.",
+    "requirements": "1,000 chompy bird kills",
+    "points": 80
+  },
+  {
+    "id": 717,
+    "taskId": 445,
+    "locality": "Kandarin: Seers Village",
+    "task": "Use the Piety Prayer.",
+    "information": "Use the Piety Prayer.",
+    "requirements": "70 Prayer, 70 Defence",
+    "points": 80
+  },
+  {
+    "id": 718,
+    "taskId": 446,
+    "locality": "Kandarin: Ardougne",
+    "task": "Complete the task set: Hard Ardougne.",
+    "information": "Complete the Hard Ardougne achievements.",
+    "requirements": "See Hard Ardougne achievements page",
+    "points": 80
+  },
+  {
+    "id": 719,
+    "taskId": 449,
+    "locality": "Kandarin: Ardougne",
+    "task": "Equip a dragon full helm.",
+    "information": "Equip a dragon full helm.",
+    "requirements": "60 Defence",
+    "points": 150
+  },
+  {
+    "id": 720,
+    "taskId": 450,
+    "locality": "Kandarin: Ardougne",
+    "task": "Chop an Elder Tree until it no longer has logs remaining.",
+    "information": "Chop an elder tree until it no longer has logs remaining.",
+    "requirements": "90 Woodcutting",
+    "points": 150
+  },
+  {
+    "id": 721,
+    "taskId": 451,
+    "locality": "Kandarin: Ardougne",
+    "task": "Obtain a Crystal Geode from a Crystal Tree.",
+    "information": "Obtain a crystal geode from a crystal tree.",
+    "requirements": "94 Farming",
+    "points": 150
+  },
+  {
+    "id": 722,
+    "taskId": 452,
+    "locality": "Kandarin: Ardougne",
+    "task": "Reach Howl's Workshop in the Stormguard Citadel.",
+    "information": "Partial completion of the Howl's Floating Workshop mystery.",
+    "requirements": "95 Archaeology",
+    "points": 150
+  },
+  {
+    "id": 723,
+    "taskId": 453,
+    "locality": "Kandarin: Feldip Hills",
+    "task": "Equip a Dragon Archer hat.",
+    "information": "Equip a Dragon Archer hat.",
+    "requirements": "2,000 chompy bird kills",
+    "points": 150
+  },
+  {
+    "id": 724,
+    "taskId": 454,
+    "locality": "Kandarin: Ardougne",
+    "task": "Complete the task set: Elite Ardougne.",
+    "information": "Complete the Elite Ardougne achievements.",
+    "requirements": "See Elite Ardougne achievements page",
+    "points": 150
+  },
+  {
+    "id": 725,
+    "taskId": 455,
+    "locality": "Kandarin: Ardougne",
+    "task": "Successfully breed a royal dragon.",
+    "information": "Breed a royal dragon.",
+    "requirements": "92 Farming",
+    "points": 150
+  },
+  {
+    "id": 726,
+    "taskId": 457,
+    "locality": "Kandarin: Ardougne",
+    "task": "Defeat an Automaton after 'The World Wakes'.",
+    "information": "Defeat an automaton after The World Wakes.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 727,
+    "taskId": 456,
+    "locality": "Kandarin: Feldip Hills",
+    "task": "Equip an Expert Dragon Archer hat.",
+    "information": "Equip an Expert Dragon Archer hat.",
+    "requirements": "4,000 chompy bird kills",
+    "points": 150
+  },
+  {
+    "id": 728,
+    "taskId": 458,
+    "locality": "Kandarin: Ardougne",
+    "task": "Throw 100,000,000 gold coins into the Whirlpool at the Deep Sea Fishing platform.",
+    "information": "Throw 100,000,000 gold coins into the Whirlpool at the Deep Sea Fishing platform.",
+    "requirements": "68 Fishing",
+    "points": 150
+  },
+  {
+    "id": 729,
+    "taskId": 572,
+    "locality": "Karamja",
+    "task": "Collect 5 seaweed from anywhere on Karamja.",
+    "information": "Collect 5 seaweed from anywhere on Karamja.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 730,
+    "taskId": 573,
+    "locality": "Karamja",
+    "task": "Fill up Luthas' crate near the Musa Point plantation with bananas and receive 30 coins for your work.",
+    "information": "Fill up Luthas' crate near the Banana plantation with bananas and talk to him to receive 30 coins for your work.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 731,
+    "taskId": 574,
+    "locality": "Karamja",
+    "task": "Claim a ticket from Brimhaven Agility Arena.",
+    "information": "Claim a ticket from Brimhaven Agility Arena.",
+    "requirements": "1 Agility",
+    "points": 10
+  },
+  {
+    "id": 732,
+    "taskId": 575,
+    "locality": "Karamja",
+    "task": "Kill a snake.",
+    "information": "Kill a snake.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 733,
+    "taskId": 576,
+    "locality": "Karamja",
+    "task": "Catch a Karambwanji.",
+    "information": "Catch a raw karambwanji.",
+    "requirements": "5 Fishing",
+    "points": 10
+  },
+  {
+    "id": 734,
+    "taskId": 577,
+    "locality": "Karamja",
+    "task": "Be assigned a Slayer task in Shilo Village.",
+    "information": "Be assigned a Slayer task in Shilo Village.",
+    "requirements": "100 Combat, 50 Slayer",
+    "points": 10
+  },
+  {
+    "id": 735,
+    "taskId": 578,
+    "locality": "Karamja",
+    "task": "Defeat a Greater Demon on Karamja.",
+    "information": "Defeat a greater demon on Karamja.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 736,
+    "taskId": 579,
+    "locality": "Karamja",
+    "task": "Pick a pineapple on Karamja.",
+    "information": "Pick a pineapple on Karamja from the pineapple plants near the lodestone.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 737,
+    "taskId": 580,
+    "locality": "Karamja",
+    "task": "Enter the Brimhaven Dungeon.",
+    "information": "Enter the Brimhaven Dungeon.",
+    "requirements": "875 coins",
+    "points": 10
+  },
+  {
+    "id": 738,
+    "taskId": 581,
+    "locality": "Karamja",
+    "task": "Cross the spiky pit using the stepping stones within Brimhaven Dungeon.",
+    "information": "Cross the spiky pit using the stepping stones within Brimhaven Dungeon.",
+    "requirements": "12 Agility",
+    "points": 10
+  },
+  {
+    "id": 739,
+    "taskId": 582,
     "locality": "Karamja",
     "task": "Complete the task set: Easy Karamja.",
     "information": "Complete the Easy Karamja achievements.",
@@ -3276,7 +6660,8 @@
     "points": 30
   },
   {
-    "id": 409,
+    "id": 740,
+    "taskId": 583,
     "locality": "Karamja",
     "task": "Craft 50 Nature runes.",
     "information": "Craft 50 nature runes.",
@@ -3284,15 +6669,17 @@
     "points": 30
   },
   {
-    "id": 410,
+    "id": 741,
+    "taskId": 584,
     "locality": "Karamja",
     "task": "Catch a salmon on Karamja.",
     "information": "Catch a salmon on Karamja.",
-    "requirements": "30 Fishing, Completion of Shilo Village",
+    "requirements": "30 Fishing",
     "points": 30
   },
   {
-    "id": 411,
+    "id": 742,
+    "taskId": 585,
     "locality": "Karamja",
     "task": "Get Stiles to exchange some of your fish for bank notes.",
     "information": "Get Stiles to exchange some of your fish for bank notes.",
@@ -3300,7 +6687,8 @@
     "points": 30
   },
   {
-    "id": 412,
+    "id": 743,
+    "taskId": 586,
     "locality": "Karamja",
     "task": "Convert 100 gleaming memories in an energy rift.",
     "information": "Convert 100 gleaming memories in an energy rift.",
@@ -3308,7 +6696,8 @@
     "points": 30
   },
   {
-    "id": 413,
+    "id": 744,
+    "taskId": 587,
     "locality": "Karamja",
     "task": "Mine a drakolith rock in the Tai Bwo Wannai mine.",
     "information": "Mine a drakolith rock in the Tai Bwo Wannai mine.",
@@ -3316,15 +6705,17 @@
     "points": 30
   },
   {
-    "id": 414,
+    "id": 745,
+    "taskId": 588,
     "locality": "Karamja",
     "task": "Mine a ruby from a gem rock in Shilo Village.",
     "information": "Mine a ruby from a gem rock in Shilo Village.",
-    "requirements": "30 Mining, Completion of Shilo Village",
+    "requirements": "30 Mining",
     "points": 30
   },
   {
-    "id": 415,
+    "id": 746,
+    "taskId": 589,
     "locality": "Karamja",
     "task": "Enter the Hardwood Grove in Tai Bwo Wannai.",
     "information": "Enter the Hardwood Grove in Tai Bwo Wannai.",
@@ -3332,7 +6723,8 @@
     "points": 30
   },
   {
-    "id": 416,
+    "id": 747,
+    "taskId": 590,
     "locality": "Karamja",
     "task": "Complete the quest: Dragon Slayer.",
     "information": "Complete Dragon Slayer.",
@@ -3340,7 +6732,8 @@
     "points": 30
   },
   {
-    "id": 417,
+    "id": 748,
+    "taskId": 591,
     "locality": "Karamja",
     "task": "Check a grown banana tree on Karamja.",
     "information": "Check a grown banana tree on Karamja.",
@@ -3348,7 +6741,8 @@
     "points": 30
   },
   {
-    "id": 418,
+    "id": 749,
+    "taskId": 592,
     "locality": "Karamja",
     "task": "Defeat a TzHaar.",
     "information": "Defeat a TzHaar.",
@@ -3356,7 +6750,8 @@
     "points": 30
   },
   {
-    "id": 419,
+    "id": 750,
+    "taskId": 593,
     "locality": "Karamja",
     "task": "Equip an Obsidian cape.",
     "information": "Equip an obsidian cape.",
@@ -3364,7 +6759,8 @@
     "points": 30
   },
   {
-    "id": 420,
+    "id": 751,
+    "taskId": 594,
     "locality": "Karamja",
     "task": "Kill a metal dragon in Brimhaven Dungeon.",
     "information": "Kill a metal dragon in Brimhaven Dungeon.",
@@ -3372,7 +6768,8 @@
     "points": 30
   },
   {
-    "id": 421,
+    "id": 752,
+    "taskId": 595,
     "locality": "Karamja",
     "task": "Catch 25 lobsters on Karamja.",
     "information": "Catch 25 lobsters on Karamja.",
@@ -3380,7 +6777,8 @@
     "points": 30
   },
   {
-    "id": 422,
+    "id": 753,
+    "taskId": 596,
     "locality": "Karamja",
     "task": "Equip a Toktz-Ket-Xil.",
     "information": "Equip a Toktz-Ket-Xil.",
@@ -3388,7 +6786,8 @@
     "points": 30
   },
   {
-    "id": 423,
+    "id": 754,
+    "taskId": 597,
     "locality": "Karamja",
     "task": "Equip a Tzhaar-Ket-Om.",
     "information": "Equip a Tzhaar-Ket-Om.",
@@ -3396,7 +6795,8 @@
     "points": 30
   },
   {
-    "id": 424,
+    "id": 755,
+    "taskId": 598,
     "locality": "Karamja",
     "task": "Equip a Toktz-Xil-Ak.",
     "information": "Equip a Toktz-Xil-Ak.",
@@ -3404,7 +6804,8 @@
     "points": 30
   },
   {
-    "id": 425,
+    "id": 756,
+    "taskId": 599,
     "locality": "Karamja",
     "task": "Equip a Toktz-Xil-Ek.",
     "information": "Equip a Toktz-Xil-Ek.",
@@ -3412,7 +6813,8 @@
     "points": 30
   },
   {
-    "id": 426,
+    "id": 757,
+    "taskId": 600,
     "locality": "Karamja",
     "task": "Complete the task set: Medium Karamja.",
     "information": "Complete the Medium Karamja achievements.",
@@ -3420,7 +6822,638 @@
     "points": 30
   },
   {
-    "id": 427,
+    "id": 758,
+    "taskId": 601,
+    "locality": "Karamja",
+    "task": "Use the stepping stone across the river in Shilo village.",
+    "information": "Use the stepping stones Agility Shortcut in Shilo Village.",
+    "requirements": "74 Agility",
+    "points": 80
+  },
+  {
+    "id": 759,
+    "taskId": 602,
+    "locality": "Karamja",
+    "task": "Equip a full set of Obsidian armour.",
+    "information": "Equip a full set of obsidian armour.",
+    "requirements": "60 Defence, 80 Smithing",
+    "points": 80
+  },
+  {
+    "id": 760,
+    "taskId": 603,
+    "locality": "Karamja",
+    "task": "Equip a Red Topaz Machete.",
+    "information": "Equip a red topaz machete.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 761,
+    "taskId": 604,
+    "locality": "Karamja",
+    "task": "Find a Gout Tuber.",
+    "information": "Find a gout tuber.",
+    "requirements": "10 Woodcutting",
+    "points": 80
+  },
+  {
+    "id": 762,
+    "taskId": 605,
+    "locality": "Karamja",
+    "task": "Defeat TzTok-Jad.",
+    "information": "Defeat TzTok-Jad once.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 763,
+    "taskId": 606,
+    "locality": "Karamja",
+    "task": "Defeat TzTok-Jad. (25 times)",
+    "information": "Defeat TzTok-Jad 25 times.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 764,
+    "taskId": 607,
+    "locality": "Karamja",
+    "task": "Use your fire cape on TzTok-Jad before defeating them.",
+    "information": "Use your fire cape on TzTok-Jad before defeating them.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 765,
+    "taskId": 608,
+    "locality": "Karamja",
+    "task": "Equip a Fire Cape.",
+    "information": "Equip a fire cape.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 766,
+    "taskId": 609,
+    "locality": "Karamja",
+    "task": "Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.",
+    "information": "Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.",
+    "requirements": "60 Defence",
+    "points": 80
+  },
+  {
+    "id": 767,
+    "taskId": 610,
+    "locality": "Karamja",
+    "task": "Repair the fairy ring inside the Kharazi jungle.",
+    "information": "Repair the fairy ring inside the Kharazi jungle.",
+    "requirements": "Partial completion of Legends' Quest",
+    "points": 80
+  },
+  {
+    "id": 768,
+    "taskId": 611,
+    "locality": "Karamja",
+    "task": "Access the Gemstone cavern.",
+    "information": "Access the gemstone cavern.",
+    "requirements": "Hard Karamja achievements",
+    "points": 80
+  },
+  {
+    "id": 769,
+    "taskId": 612,
+    "locality": "Karamja",
+    "task": "Catch a Draconic jadinko at Herblore Habitat.",
+    "information": "Catch a draconic jadinko at Herblore Habitat.",
+    "requirements": "80 Hunter",
+    "points": 80
+  },
+  {
+    "id": 770,
+    "taskId": 613,
+    "locality": "Karamja",
+    "task": "Craft a Bolas.",
+    "information": "Craft a bolas.",
+    "requirements": "87 Fletching, 80 Slayer",
+    "points": 80
+  },
+  {
+    "id": 771,
+    "taskId": 614,
+    "locality": "Karamja",
+    "task": "Complete the task set: Hard Karamja.",
+    "information": "Complete the Hard Karamja achievements.",
+    "requirements": "See Hard Karamja achievements page",
+    "points": 80
+  },
+  {
+    "id": 772,
+    "taskId": 615,
+    "locality": "Karamja",
+    "task": "Collect 60 Agility Arena tickets from the Brimhaven Agility Arena.",
+    "information": "Receive 60 Agility Arena tickets",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 773,
+    "taskId": 617,
+    "locality": "Karamja",
+    "task": "Defeat TzTok-Jad in less than 45:00.",
+    "information": "Defeat TzTok-Jad in less than 45:00.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 774,
+    "taskId": 618,
+    "locality": "Karamja",
+    "task": "Complete the Fight Kiln.",
+    "information": "Complete the Fight Kiln.",
+    "requirements": "Completion of The Elder Kiln",
+    "points": 80
+  },
+  {
+    "id": 775,
+    "taskId": 620,
+    "locality": "Karamja",
+    "task": "Equip a TokHaar-Kal-Ket.",
+    "information": "Equip a TokHaar-Kal-Ket.",
+    "requirements": "Completion of The Elder Kiln",
+    "points": 80
+  },
+  {
+    "id": 776,
+    "taskId": 621,
+    "locality": "Karamja",
+    "task": "Equip a TokHaar-Kal-Xil.",
+    "information": "Equip a TokHaar-Kal-Xil.",
+    "requirements": "Completion of The Elder Kiln",
+    "points": 80
+  },
+  {
+    "id": 777,
+    "taskId": 622,
+    "locality": "Karamja",
+    "task": "Equip a TokHaar-Kal-Mej.",
+    "information": "Equip a TokHaar-Kal-Mej.",
+    "requirements": "Completion of The Elder Kiln",
+    "points": 80
+  },
+  {
+    "id": 778,
+    "taskId": 623,
+    "locality": "Karamja",
+    "task": "Equip a TokHaar-Kal-Mor.",
+    "information": "Equip a TokHaar-Kal-Mor.",
+    "requirements": "Completion of The Elder Kiln",
+    "points": 80
+  },
+  {
+    "id": 779,
+    "taskId": 624,
+    "locality": "Karamja",
+    "task": "Complete the Fight Kiln and collect an uncut onyx.",
+    "information": "Complete the Fight Kiln and collect an uncut onyx.",
+    "requirements": "Completion of The Elder Kiln",
+    "points": 80
+  },
+  {
+    "id": 780,
+    "taskId": 629,
+    "locality": "Karamja",
+    "task": "Complete all TzTok-Jad combat achievements.",
+    "information": "Complete all TzTok-Jad combat achievements.",
+    "requirements": "See TzTok-Jad achievements page",
+    "points": 80
+  },
+  {
+    "id": 781,
+    "taskId": 616,
+    "locality": "Karamja",
+    "task": "Purchase an uncut onyx from Tzhaar-Hur-Lek's ore and gem store.",
+    "information": "Purchase an uncut onyx from TzHaar-Hur-Lek's Ore and Gem Store.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 782,
+    "taskId": 619,
+    "locality": "Karamja",
+    "task": "Defeat the Har-Aken. (10 times)",
+    "information": "Defeat Har-Aken 10 times.",
+    "requirements": "Completion of The Elder Kiln",
+    "points": 150
+  },
+  {
+    "id": 783,
+    "taskId": 625,
+    "locality": "Karamja",
+    "task": "Defeat 10 gemstone dragons inside the Gemstone cavern.",
+    "information": "Defeat 10 gemstone dragons inside the Gemstone cavern.",
+    "requirements": "95 Slayer",
+    "points": 150
+  },
+  {
+    "id": 784,
+    "taskId": 626,
+    "locality": "Karamja",
+    "task": "Equip a piece of Gemstone armour.",
+    "information": "Equip a piece of gemstone armour.",
+    "requirements": "95 Slayer, 80 Defence, 80 Smithing",
+    "points": 150
+  },
+  {
+    "id": 785,
+    "taskId": 627,
+    "locality": "Karamja",
+    "task": "Complete the task set: Elite Karamja.",
+    "information": "Complete the Elite Karamja achievements.",
+    "requirements": "See Elite Karamja achievements page",
+    "points": 150
+  },
+  {
+    "id": 786,
+    "taskId": 628,
+    "locality": "Karamja",
+    "task": "Complete all Har-Aken combat achievements.",
+    "information": "Complete all Har-Aken combat achievements.",
+    "requirements": "See Har-Aken achievements page",
+    "points": 150
+  },
+  {
+    "id": 787,
+    "taskId": 0,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Progress through the Leagues tutorial to unlock your first relic.",
+    "information": "Progress through the Leagues tutorial to unlock your first relic.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 788,
+    "taskId": 2,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Climb to the top of the Wizards' Tower.",
+    "information": "Climb to the top of the Wizards' Tower.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 789,
+    "taskId": 3,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Have Ned make you some rope from balls of wool.",
+    "information": "Have Ned make you some rope from 4 balls of wool.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 790,
+    "taskId": 4,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Siphon from a fire essling in the Runespan.",
+    "information": "Siphon from a fire essling in the Runespan.",
+    "requirements": "14 Runecrafting",
+    "points": 10
+  },
+  {
+    "id": 791,
+    "taskId": 5,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Convert at least one pale memory into energy.",
+    "information": "Convert at least one pale memory into energy.",
+    "requirements": "1 Divination",
+    "points": 10
+  },
+  {
+    "id": 792,
+    "taskId": 15,
+    "locality": "Misthalin: Edgeville",
+    "task": "Kill a mugger near the Edgeville lodestone.",
+    "information": "Kill a mugger near the Edgeville lodestone.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 793,
+    "taskId": 16,
+    "locality": "Misthalin: Edgeville",
+    "task": "Mine some coal in the centre of Barbarian village.",
+    "information": "Mine some coal in the centre of Barbarian Village.",
+    "requirements": "20 Mining",
+    "points": 10
+  },
+  {
+    "id": 794,
+    "taskId": 22,
+    "locality": "Misthalin: Fort Forinthry",
+    "task": "Use the bank in the workshop at Fort Forinthry.",
+    "information": "Use the bank in the workshop at Fort Forinthry.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 795,
+    "taskId": 27,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Kill a giant rat in Lumbridge Swamp.",
+    "information": "Kill a giant rat in Lumbridge Swamp.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 796,
+    "taskId": 28,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Kill a goblin in Lumbridge.",
+    "information": "Kill a goblin in Lumbridge.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 797,
+    "taskId": 29,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Kill a giant spider in Lumbridge or Lumbridge Swamp.",
+    "information": "Kill a giant spider in Lumbridge or Lumbridge Swamp.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 798,
+    "taskId": 30,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Milk a cow.",
+    "information": "Milk a cow.",
+    "requirements": "A bucket",
+    "points": 10
+  },
+  {
+    "id": 799,
+    "taskId": 32,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Talk to Hans and find out how old you are.",
+    "information": "Talk to Hans and find out how old you are.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 800,
+    "taskId": 33,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Complete the quest: The Blood Pact.",
+    "information": "Complete The Blood Pact.",
+    "requirements": "See quest page",
+    "points": 10
+  },
+  {
+    "id": 801,
+    "taskId": 35,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Catch some shrimp in the fishing spot to the east of Lumbridge Swamp.",
+    "information": "Catch some shrimp in the fishing spot to the east of Lumbridge Swamp.",
+    "requirements": "1 Fishing",
+    "points": 10
+  },
+  {
+    "id": 802,
+    "taskId": 36,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Smelt a steel bar in the furnace in Lumbridge.",
+    "information": "Smelt a steel bar in the furnace in Lumbridge.",
+    "requirements": "20 Smithing",
+    "points": 10
+  },
+  {
+    "id": 803,
+    "taskId": 37,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Cook some rat meat on a fire in Lumbridge Swamp.",
+    "information": "Cook some rat meat on a campfire in Lumbridge Swamp.",
+    "requirements": "1 Cooking",
+    "points": 10
+  },
+  {
+    "id": 804,
+    "taskId": 38,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Mine iron ore from the mining site south-west of Lumbridge Swamp.",
+    "information": "Mine iron ore from the mining site south-west of Lumbridge Swamp.",
+    "requirements": "10 Mining",
+    "points": 10
+  },
+  {
+    "id": 805,
+    "taskId": 39,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Craft a water rune at the Water Altar.",
+    "information": "Craft a water rune at the Water altar.",
+    "requirements": "5 Runecrafting",
+    "points": 10
+  },
+  {
+    "id": 806,
+    "taskId": 40,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Complete a task from Jacquelyn, the Lumbridge Slayer master.",
+    "information": "Complete a task from Jacquelyn, the Lumbridge Slayer master.",
+    "requirements": "1 Slayer",
+    "points": 10
+  },
+  {
+    "id": 807,
+    "taskId": 41,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Fill a Charmed Sack with corruption at the Nexus in Lumbridge Swamp.",
+    "information": "Fill a charmed sack with corruption at the Nexus in Lumbridge Swamp.",
+    "requirements": "1 Prayer",
+    "points": 10
+  },
+  {
+    "id": 808,
+    "taskId": 61,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Complete the quest: Necromancy!.",
+    "information": "Complete Necromancy!",
+    "requirements": "See quest page",
+    "points": 10
+  },
+  {
+    "id": 809,
+    "taskId": 62,
+    "locality": "Misthalin: City of Um",
+    "task": "Upgrade a piece of Death Skull or Deathwarden equipment to tier 20.",
+    "information": "Upgrade a piece of death skull or deathwarden equipment to tier 20.",
+    "requirements": "20 Necromancy, 15 Smithing or 15 Crafting",
+    "points": 10
+  },
+  {
+    "id": 810,
+    "taskId": 63,
+    "locality": "Misthalin: City of Um",
+    "task": "Craft some spirit or bone runes.",
+    "information": "Craft some spirit or bone runes.",
+    "requirements": "1 Runecrafting",
+    "points": 10
+  },
+  {
+    "id": 811,
+    "taskId": 64,
+    "locality": "Misthalin: City of Um",
+    "task": "Complete a Lesser Necroplasm ritual.",
+    "information": "Complete a Lesser Necroplasm ritual.",
+    "requirements": "5 Necromancy",
+    "points": 10
+  },
+  {
+    "id": 812,
+    "taskId": 65,
+    "locality": "Misthalin: City of Um",
+    "task": "Conjure a skeleton at the City of Um ritual site.",
+    "information": "Conjure a Skeleton Warrior at the Um ritual site.",
+    "requirements": "2 Necromancy",
+    "points": 10
+  },
+  {
+    "id": 813,
+    "taskId": 66,
+    "locality": "Misthalin: City of Um",
+    "task": "Conjure a zombie at the City of Um ritual site.",
+    "information": "Conjure a Putrid Zombie at the Um ritual site.",
+    "requirements": "40 Necromancy",
+    "points": 10
+  },
+  {
+    "id": 814,
+    "taskId": 67,
+    "locality": "Misthalin: City of Um",
+    "task": "Conjure a ghost at the City of Um ritual site.",
+    "information": "Conjure a Vengeful Ghost at the Um ritual site.",
+    "requirements": "40 Necromancy",
+    "points": 10
+  },
+  {
+    "id": 815,
+    "taskId": 94,
+    "locality": "Misthalin: Varrock",
+    "task": "Kill a dark wizard.",
+    "information": "Kill a dark wizard.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 816,
+    "taskId": 95,
+    "locality": "Misthalin: Varrock",
+    "task": "Enter the Earth Altar using an earth tiara or talisman.",
+    "information": "Enter the earth altar using an earth tiara or talisman.",
+    "requirements": "1 Runecrafting",
+    "points": 10
+  },
+  {
+    "id": 817,
+    "taskId": 96,
+    "locality": "Misthalin: Varrock",
+    "task": "Have Elsie tell you a story.",
+    "information": "Have Elsie tell you a story, she is found upstairs in the church in Varrock. You must give her a cup of tea",
+    "requirements": "A cup of tea",
+    "points": 10
+  },
+  {
+    "id": 818,
+    "taskId": 97,
+    "locality": "Misthalin: Varrock",
+    "task": "Give a bone to one of Varrock's stray dogs (or to your pet stray dog if you have one).",
+    "information": "Use some bones on one of Varrock's stray dogs (or to your pet stray dog if you have one).",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 819,
+    "taskId": 98,
+    "locality": "Misthalin: Varrock",
+    "task": "Claim a free clue scroll from Zaida at the Grand Exchange.",
+    "information": "Claim a free clue scroll from Zaida at the Grand Exchange.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 820,
+    "taskId": 99,
+    "locality": "Misthalin: Fort Forinthry",
+    "task": "Give Bill a beer in Fort Forinthry.",
+    "information": "Give Bill a beer in Fort Forinthry.",
+    "requirements": "A beer",
+    "points": 10
+  },
+  {
+    "id": 821,
+    "taskId": 100,
+    "locality": "Misthalin: Varrock",
+    "task": "Complete the Archaeology tutorial.",
+    "information": "Complete the Archaeology tutorial.",
+    "requirements": "1 Archaeology",
+    "points": 10
+  },
+  {
+    "id": 822,
+    "taskId": 101,
+    "locality": "Misthalin: Fort Forinthry",
+    "task": "Make a plank yourself on the sawmill in Fort Forinthry.",
+    "information": "Make a plank yourself on the sawmill in Fort Forinthry.",
+    "requirements": "1 Construction",
+    "points": 10
+  },
+  {
+    "id": 823,
+    "taskId": 102,
+    "locality": "Misthalin: Varrock",
+    "task": "Mine some iron ore in the mining spot south-west of Varrock.",
+    "information": "Mine some iron ore in the mining spot south-west of Varrock.",
+    "requirements": "10 Mining",
+    "points": 10
+  },
+  {
+    "id": 824,
+    "taskId": 103,
+    "locality": "Misthalin: Varrock",
+    "task": "Steal from the Varrock tea stall.",
+    "information": "Steal from the Varrock tea stall.",
+    "requirements": "5 Thieving",
+    "points": 10
+  },
+  {
+    "id": 825,
+    "taskId": 104,
+    "locality": "Misthalin: Varrock",
+    "task": "Pan in the river at the Digsite.",
+    "information": "This can only be completed after the point during The Dig Site quest where the panning guide teaches you how to pan for gold. You can then use the panning point. If you complete the quest without completing this achievement the task will be completed by attempting to pan with a panning tray in your inventory.",
+    "requirements": "Partial completion of The Dig Site",
+    "points": 10
+  },
+  {
+    "id": 826,
+    "taskId": 184,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Harvest a memory from a pale wisp.",
+    "information": "Harvest a pale memory from a pale wisp.",
+    "requirements": "1 Divination",
+    "points": 10
+  },
+  {
+    "id": 827,
+    "taskId": 185,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Harvest 10 memories from a pale wisp.",
+    "information": "Harvest 10 pale memories from a pale wisp.",
+    "requirements": "1 Divination",
+    "points": 10
+  },
+  {
+    "id": 828,
+    "taskId": 1,
     "locality": "Misthalin: Draynor Village",
     "task": "Kill the lesser demon in the Wizards' Tower.",
     "information": "Kill the lesser demon in the Wizards' Tower.",
@@ -3428,7 +7461,8 @@
     "points": 30
   },
   {
-    "id": 428,
+    "id": 829,
+    "taskId": 6,
     "locality": "Misthalin: Draynor Village",
     "task": "Hunt a yellow wizard in the RuneSpan and give them some items.",
     "information": "Hunt a yellow wizard in the Runespan and give them some items.",
@@ -3436,7 +7470,8 @@
     "points": 30
   },
   {
-    "id": 429,
+    "id": 830,
+    "taskId": 7,
     "locality": "Misthalin: Draynor Village",
     "task": "Use the Rune Goldberg Machine to create Vis wax.",
     "information": "Use the Rune Goldberg Machine to create vis wax.",
@@ -3444,7 +7479,8 @@
     "points": 30
   },
   {
-    "id": 430,
+    "id": 831,
+    "taskId": 8,
     "locality": "Misthalin: Draynor Village",
     "task": "Siphon from a nature esshound in the Runespan.",
     "information": "Siphon from a nature esshound in the Runespan.",
@@ -3452,7 +7488,8 @@
     "points": 30
   },
   {
-    "id": 431,
+    "id": 832,
+    "taskId": 9,
     "locality": "Misthalin: Draynor Village",
     "task": "Siphon Rune dust from a RuneSphere in the RuneSpan.",
     "information": "Siphon rune dust from a Runesphere in the RuneSpan.",
@@ -3460,7 +7497,8 @@
     "points": 30
   },
   {
-    "id": 432,
+    "id": 833,
+    "taskId": 17,
     "locality": "Misthalin: Edgeville",
     "task": "Fully complete the Stronghold of Player Safety.",
     "information": "Fully complete the Stronghold of Player Safety by pulling an old lever on the upper floor and then opening the treasure chest in the secure sector.",
@@ -3468,7 +7506,8 @@
     "points": 30
   },
   {
-    "id": 433,
+    "id": 834,
+    "taskId": 23,
     "locality": "Misthalin: Fort Forinthry",
     "task": "Complete the quest: New Foundations.",
     "information": "Complete New Foundations.",
@@ -3476,7 +7515,8 @@
     "points": 30
   },
   {
-    "id": 434,
+    "id": 835,
+    "taskId": 26,
     "locality": "Misthalin: Lumbridge",
     "task": "Complete the task set: Beginner Lumbridge.",
     "information": "Given by Explorer Jack in Lumbridge for completing all Beginner Tasks in Lumbridge.",
@@ -3484,7 +7524,8 @@
     "points": 30
   },
   {
-    "id": 435,
+    "id": 836,
+    "taskId": 34,
     "locality": "Misthalin: Draynor Village",
     "task": "Complete the quest: Duck Quest.",
     "information": "Complete Duck Quest.",
@@ -3492,7 +7533,8 @@
     "points": 30
   },
   {
-    "id": 436,
+    "id": 837,
+    "taskId": 42,
     "locality": "Misthalin: Lumbridge",
     "task": "Complete the task set: Easy Lumbridge.",
     "information": "Given by Bob, the axe seller in Lumbridge, for completing all Easy Tasks in Lumbridge.",
@@ -3500,7 +7542,8 @@
     "points": 30
   },
   {
-    "id": 437,
+    "id": 838,
+    "taskId": 43,
     "locality": "Misthalin: Lumbridge",
     "task": "Complete the task set: Medium Lumbridge.",
     "information": "Given by Ned in Draynor Village for completing all Medium Tasks in Lumbridge.",
@@ -3508,7 +7551,8 @@
     "points": 30
   },
   {
-    "id": 438,
+    "id": 839,
+    "taskId": 44,
     "locality": "Misthalin: Lumbridge",
     "task": "Drink from the Tears of Guthix.",
     "information": "Drink from the Tears of Guthix.",
@@ -3516,7 +7560,8 @@
     "points": 30
   },
   {
-    "id": 439,
+    "id": 840,
+    "taskId": 45,
     "locality": "Misthalin: Lumbridge",
     "task": "Complete world 25 in Shattered Worlds.",
     "information": "Reach world 25 in Shattered Worlds.",
@@ -3524,7 +7569,8 @@
     "points": 30
   },
   {
-    "id": 440,
+    "id": 841,
+    "taskId": 46,
     "locality": "Misthalin: Lumbridge",
     "task": "Catch 20 implings in Puro-Puro.",
     "information": "Catch 20 implings in Puro-Puro.",
@@ -3532,7 +7578,8 @@
     "points": 30
   },
   {
-    "id": 441,
+    "id": 842,
+    "taskId": 47,
     "locality": "Misthalin: Lumbridge",
     "task": "Complete the quest: Sheep Shearer (miniquest).",
     "information": "Complete Sheep Shearer miniquest.",
@@ -3540,7 +7587,8 @@
     "points": 30
   },
   {
-    "id": 442,
+    "id": 843,
+    "taskId": 48,
     "locality": "Misthalin: Lumbridge",
     "task": "Cut a willow tree east of Lumbridge Castle.",
     "information": "Cut the willow tree east of Lumbridge Castle, by the bridge across the River Lum.",
@@ -3548,15 +7596,17 @@
     "points": 30
   },
   {
-    "id": 443,
+    "id": 844,
+    "taskId": 49,
     "locality": "Misthalin: Lumbridge",
     "task": "Craft 50 Water Runes.",
     "information": "Craft 50 water runes.",
-    "requirements": "5 Runecrafting, Water talisman or equivalent",
+    "requirements": "5 Runecrafting",
     "points": 30
   },
   {
-    "id": 444,
+    "id": 845,
+    "taskId": 50,
     "locality": "Misthalin: Lumbridge",
     "task": "Pickpocket a H.A.M. member.",
     "information": "Pickpocket a H.A.M. member.",
@@ -3564,55 +7614,62 @@
     "points": 30
   },
   {
-    "id": 445,
+    "id": 846,
+    "taskId": 51,
     "locality": "Misthalin: Lumbridge",
     "task": "Churn some butter.",
     "information": "Make a pat of butter by using a bucket of milk at a dairy churn",
-    "requirements": "38 Cooking, Bucket of milk",
+    "requirements": "38 Cooking",
     "points": 30
   },
   {
-    "id": 446,
+    "id": 847,
+    "taskId": 52,
     "locality": "Misthalin: Lumbridge",
     "task": "Craft 50 cosmic runes.",
     "information": "Craft 50 cosmic runes.",
-    "requirements": "27 Runecrafting, Cosmic talisman or equivalent, completion of Lost City quest",
+    "requirements": "27 Runecrafting",
     "points": 30
   },
   {
-    "id": 447,
+    "id": 848,
+    "taskId": 53,
     "locality": "Misthalin: Lumbridge",
     "task": "Steal a lantern from a cave goblin.",
     "information": "Steal a lantern from a cave goblin (only the ones in Dorgesh-Kaan have the lantern as a possible loot from pickpocketting).",
-    "requirements": "36 Thieving, Completion of Death to the Dorgeshuun quest",
+    "requirements": "36 Thieving",
     "points": 30
   },
   {
-    "id": 448,
+    "id": 849,
+    "taskId": 54,
     "locality": "Misthalin: Lumbridge",
     "task": "Use the range in Lumbridge Castle to bake a cake.",
     "information": "Use the range in Lumbridge Castle to bake a cake.",
-    "requirements": "40 Cooking, Completion of Cook's Assistant quest",
+    "requirements": "40 Cooking",
     "points": 30
   },
   {
-    "id": 449,
+    "id": 850,
+    "taskId": 68,
     "locality": "Misthalin: City of Um",
     "task": "Have either a Putrid Zombie or Vengeful Ghost conjured while fighting the matching creature.",
     "information": "Have either a Putrid Zombie or Vengeful Ghost conjured while fighting the matching creature.",
-    "requirements": "40 Necromancy, Unlock the ability to conjure at tier 3 of talents, conduit, ectoplasm?",
+    "requirements": "40 Necromancy",
     "points": 30
   },
   {
-    "id": 450,
+    "id": 851,
+    "taskId": 69,
     "locality": "Misthalin: City of Um",
     "task": "Learn how to craft moonstone jewellery.",
     "information": "Learn how to craft moonstone jewellery.",
-    "requirements": "50 Necromancy, Brown apron or keepsaked override",
+    "requirements": "50 Necromancy",
     "points": 30
   },
   {
-    "id": 451,
+    "id": 852,
+    "taskId": 70,
     "locality": "Misthalin: City of Um",
     "task": "Disgruntle an inhabitant of Um by wearing a bedsheet.",
     "information": "Disgruntle an inhabitant of Um by wearing a bedsheet, see Poor Imitation for NPCs which can be disgruntled.",
@@ -3620,31 +7677,35 @@
     "points": 30
   },
   {
-    "id": 452,
+    "id": 853,
+    "taskId": 71,
     "locality": "Misthalin: City of Um",
     "task": "Upgrade a piece of Death Skull or Deathwarden equipment to tier 50.",
     "information": "Upgrade a piece of Death Skull or Deathwarden equipment to tier 50.",
-    "requirements": "20 Necromancy, Completion of Necromancy! and Kili Row. See also Kili's Knowledge III",
+    "requirements": "20 Necromancy",
     "points": 30
   },
   {
-    "id": 453,
+    "id": 854,
+    "taskId": 72,
     "locality": "Misthalin: City of Um",
     "task": "Complete a communion ritual using a memento.",
     "information": "Complete a communion ritual using a memento.",
-    "requirements": "5 Necromancy, Completion of Necromancy!",
+    "requirements": "5 Necromancy",
     "points": 30
   },
   {
-    "id": 454,
+    "id": 855,
+    "taskId": 73,
     "locality": "Misthalin: City of Um",
     "task": "Conjure a Phantom Guardian at the City of Um ritual site.",
     "information": "Conjure a Phantom Guardian at the Um ritual site.",
-    "requirements": "70 Necromancy, Conjure Phantom Guardian unlocked from the Well of Souls",
+    "requirements": "70 Necromancy",
     "points": 30
   },
   {
-    "id": 455,
+    "id": 856,
+    "taskId": 74,
     "locality": "Misthalin: City of Um",
     "task": "Complete the task set: Easy Underworld.",
     "information": "Complete the Easy Underworld achievements.",
@@ -3652,7 +7713,8 @@
     "points": 30
   },
   {
-    "id": 456,
+    "id": 857,
+    "taskId": 84,
     "locality": "Misthalin: City of Um",
     "task": "Complete the task set: Medium Underworld.",
     "information": "Complete the Medium Underworld achievements.",
@@ -3660,7 +7722,8 @@
     "points": 30
   },
   {
-    "id": 457,
+    "id": 858,
+    "taskId": 105,
     "locality": "Misthalin: Varrock",
     "task": "Complete the task set: Easy Varrock.",
     "information": "Given by Rat Burgiss south of Varrock for completing all Easy Tasks in Varrock.",
@@ -3668,7 +7731,8 @@
     "points": 30
   },
   {
-    "id": 458,
+    "id": 859,
+    "taskId": 106,
     "locality": "Misthalin: Varrock",
     "task": "Complete the task set: Medium Varrock.",
     "information": "Given by Reldo in Varrock Palace's library for completing all Medium Tasks in Varrock.",
@@ -3676,7 +7740,8 @@
     "points": 30
   },
   {
-    "id": 459,
+    "id": 860,
+    "taskId": 107,
     "locality": "Misthalin: Edgeville",
     "task": "Browse through Oziach's Armour Shop.",
     "information": "Browse through Oziach's Armour Shop.",
@@ -3684,15 +7749,17 @@
     "points": 30
   },
   {
-    "id": 460,
+    "id": 861,
+    "taskId": 108,
     "locality": "Misthalin: Varrock",
     "task": "Enter the Cooks' Guild.",
     "information": "Enter the Cooks' Guild.",
-    "requirements": "32 Cooking, Chef's hat of equivalent, see Cooks' Guild for alternatives",
+    "requirements": "32 Cooking",
     "points": 30
   },
   {
-    "id": 461,
+    "id": 862,
+    "taskId": 109,
     "locality": "Misthalin: Varrock",
     "task": "Complete the quest: Demon Slayer.",
     "information": "Complete Demon Slayer.",
@@ -3700,7 +7767,8 @@
     "points": 30
   },
   {
-    "id": 462,
+    "id": 863,
+    "taskId": 110,
     "locality": "Misthalin: Varrock",
     "task": "Complete the quest: Vampyre Slayer.",
     "information": "Complete Vampyre Slayer.",
@@ -3708,7 +7776,8 @@
     "points": 30
   },
   {
-    "id": 463,
+    "id": 864,
+    "taskId": 111,
     "locality": "Misthalin: Varrock",
     "task": "Mine 50 pure essence.",
     "information": "Mine 50 pure essence.",
@@ -3716,7 +7785,8 @@
     "points": 30
   },
   {
-    "id": 464,
+    "id": 865,
+    "taskId": 112,
     "locality": "Misthalin: Varrock",
     "task": "Pickpocket a guard in Varrock Palace's courtyard.",
     "information": "Pickpocket a Varrock guard.",
@@ -3724,7 +7794,8 @@
     "points": 30
   },
   {
-    "id": 465,
+    "id": 866,
+    "taskId": 113,
     "locality": "Misthalin: Varrock",
     "task": "Gather and convert 50 bright memories.",
     "information": "Gather and convert 50 bright memories.",
@@ -3732,7 +7803,683 @@
     "points": 30
   },
   {
-    "id": 466,
+    "id": 867,
+    "taskId": 10,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Siphon from a death esswraith in the RuneSpan.",
+    "information": "Siphon from a death esswraith in the RuneSpan.",
+    "requirements": "66 Runecrafting",
+    "points": 80
+  },
+  {
+    "id": 868,
+    "taskId": 12,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Obtain the Massive Pouch from the RuneSpan.",
+    "information": "Obtain the massive pouch from the RuneSpan.",
+    "requirements": "90 Runecrafting",
+    "points": 80
+  },
+  {
+    "id": 869,
+    "taskId": 14,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Equip the full Master Runecrafter skilling outfit.",
+    "information": "Equip the full master runecrafter robes set.",
+    "requirements": "50 Runecrafting",
+    "points": 80
+  },
+  {
+    "id": 870,
+    "taskId": 18,
+    "locality": "Misthalin: Edgeville",
+    "task": "Complete the task set: Hard Varrock.",
+    "information": "Complete all of the Hard Varrock achievements and claim rewards from Vannaka in Edgeville.",
+    "requirements": "See Hard Varrock achievements page",
+    "points": 80
+  },
+  {
+    "id": 871,
+    "taskId": 19,
+    "locality": "Misthalin: Edgeville",
+    "task": "Make a waka canoe near Edgeville.",
+    "information": "Make a waka canoe near Edgeville.",
+    "requirements": "57 Woodcutting",
+    "points": 80
+  },
+  {
+    "id": 872,
+    "taskId": 20,
+    "locality": "Misthalin: Edgeville",
+    "task": "Chop down the Edgeville elder tree.",
+    "information": "Chop down the Edgeville elder tree.",
+    "requirements": "90 Woodcutting",
+    "points": 80
+  },
+  {
+    "id": 873,
+    "taskId": 24,
+    "locality": "Misthalin: Fort Forinthry",
+    "task": "Upgrade the workshop in Fort Forinthry to Tier 3.",
+    "information": "Upgrade the workshop in Fort Forinthry to tier 3.",
+    "requirements": "75 Construction",
+    "points": 80
+  },
+  {
+    "id": 874,
+    "taskId": 31,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Enter Zanaris via Lumbridge Swamp.",
+    "information": "Enter Zanaris via Lumbridge Swamp.",
+    "requirements": "Partial completion of Lost City",
+    "points": 80
+  },
+  {
+    "id": 875,
+    "taskId": 55,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Complete the task set: Hard Lumbridge.",
+    "information": "Complete all Hard Tasks in Lumbridge and claim rewards from Ned in Draynor Village.",
+    "requirements": "See Hard Lumbridge achievements page",
+    "points": 80
+  },
+  {
+    "id": 876,
+    "taskId": 56,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Unlock the Bladed Dive ability from Shattered Worlds.",
+    "information": "Unlock the Bladed Dive ability from Shattered Worlds.",
+    "requirements": "63,000,000 shattered anima",
+    "points": 80
+  },
+  {
+    "id": 877,
+    "taskId": 57,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Smith a mithril platebody on the anvil in the jailhouse sewers.",
+    "information": "Smith a mithril platebody on the anvil in Draynor Sewers.",
+    "requirements": "30 Smithing",
+    "points": 80
+  },
+  {
+    "id": 878,
+    "taskId": 58,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Fully grow a magic tree in Lumbridge.",
+    "information": "Fully grow a magic tree in Lumbridge.",
+    "requirements": "75 Farming",
+    "points": 80
+  },
+  {
+    "id": 879,
+    "taskId": 75,
+    "locality": "Misthalin: City of Um",
+    "task": "Defeat Hermod, the Spirit of War.",
+    "information": "Defeat Hermod, the Spirit of War once.",
+    "requirements": "Completion of The Spirit of War",
+    "points": 80
+  },
+  {
+    "id": 880,
+    "taskId": 76,
+    "locality": "Misthalin: City of Um",
+    "task": "Defeat Hermod, the Spirit of War. (100 times)",
+    "information": "Defeat Hermod, the Spirit of War 100 times.",
+    "requirements": "Completion of The Spirit of War",
+    "points": 80
+  },
+  {
+    "id": 881,
+    "taskId": 77,
+    "locality": "Misthalin: City of Um",
+    "task": "Rest whilst listening to the Dead Beats in the City of Um.",
+    "information": "Rest whilst listening to the Dead Beats in the City of Um.",
+    "requirements": "Completion of That Old Black Magic",
+    "points": 80
+  },
+  {
+    "id": 882,
+    "taskId": 78,
+    "locality": "Misthalin: City of Um",
+    "task": "Smelt a necronium bar at the smithy in the City of Um.",
+    "information": "Smelt a necronium bar at the smithy in the City of Um.",
+    "requirements": "70 Smithing",
+    "points": 80
+  },
+  {
+    "id": 883,
+    "taskId": 79,
+    "locality": "Misthalin: City of Um",
+    "task": "Create a passing bracelet, performing each step in the City of Um.",
+    "information": "Create a passing bracelet, performing each step in the City of Um.",
+    "requirements": "60 Necromancy, 79 Crafting, 68 Magic",
+    "points": 80
+  },
+  {
+    "id": 884,
+    "taskId": 80,
+    "locality": "Misthalin: City of Um",
+    "task": "Catch a ghostly impling while wearing a full set of ghostly robes.",
+    "information": "Catch a ghostly impling while wearing a full set of ghostly robes.",
+    "requirements": "68 Hunter",
+    "points": 80
+  },
+  {
+    "id": 885,
+    "taskId": 81,
+    "locality": "Misthalin: City of Um",
+    "task": "Upgrade a set of Death Skull equipment to tier 70.",
+    "information": "Upgrade a set of Death Skull equipment to tier 70.",
+    "requirements": "70 Necromancy",
+    "points": 80
+  },
+  {
+    "id": 886,
+    "taskId": 82,
+    "locality": "Misthalin: City of Um",
+    "task": "Complete a Powerful Communion ritual.",
+    "information": "Complete a powerful communion ritual.",
+    "requirements": "90 Necromancy",
+    "points": 80
+  },
+  {
+    "id": 887,
+    "taskId": 83,
+    "locality": "Misthalin: City of Um",
+    "task": "Conjure an undead army at the City of Um ritual site.",
+    "information": "Conjure an undead army at the City of Um ritual site.",
+    "requirements": "99 Necromancy",
+    "points": 80
+  },
+  {
+    "id": 888,
+    "taskId": 114,
+    "locality": "Misthalin: Varrock",
+    "task": "Obtain a new set of Family Crest gauntlets from Dimintheis.",
+    "information": "Obtain a new set of family gauntlets from Dimintheis.",
+    "requirements": "Completion of Family Crest",
+    "points": 80
+  },
+  {
+    "id": 889,
+    "taskId": 115,
+    "locality": "Misthalin: Varrock",
+    "task": "Talk to Romily Weaklax and give him a wild pie.",
+    "information": "Talk to Romily Weaklax and give him a wild pie.",
+    "requirements": "85 Cooking",
+    "points": 80
+  },
+  {
+    "id": 890,
+    "taskId": 116,
+    "locality": "Misthalin: Varrock",
+    "task": "Harness the power of three relics at once.",
+    "information": "Activate 3 Archaeology relics at once",
+    "requirements": "25 Archaeology",
+    "points": 80
+  },
+  {
+    "id": 891,
+    "taskId": 117,
+    "locality": "Misthalin: Varrock",
+    "task": "Mine 50 Dark Animica from the Empty Throne Room.",
+    "information": "Mine 50 dark animica from the Empty Throne Room.",
+    "requirements": "90 Mining",
+    "points": 80
+  },
+  {
+    "id": 892,
+    "taskId": 118,
+    "locality": "Misthalin: Varrock",
+    "task": "Defeat Kerapac, the bound.",
+    "information": "Defeat Kerapac, the bound once.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 893,
+    "taskId": 120,
+    "locality": "Misthalin: Varrock",
+    "task": "Defeat the Arch-Glacor.",
+    "information": "Defeat the Arch-Glacor.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 894,
+    "taskId": 762,
+    "locality": "Misthalin: City of Um",
+    "task": "Defeat Nakatra, Devourer Eternal.",
+    "information": "Defeat Nakatra, Devourer Eternal.",
+    "requirements": "Completion of Soul Searching",
+    "points": 80
+  },
+  {
+    "id": 895,
+    "taskId": 764,
+    "locality": "Misthalin: City of Um",
+    "task": "Cleanse the Gate of Elidinis.",
+    "information": "Cleanse the Gate of Elidinis.",
+    "requirements": "Completion of Ode of the Devourer",
+    "points": 80
+  },
+  {
+    "id": 896,
+    "taskId": 766,
+    "locality": "Misthalin: City of Um",
+    "task": "Complete the task set: Hard Underworld.",
+    "information": "Complete the Hard Underworld achievements.",
+    "requirements": "See Hard Underworld achievements page",
+    "points": 80
+  },
+  {
+    "id": 897,
+    "taskId": 11,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Navigate the RuneSpan using a Greater Conjuration Platorm.",
+    "information": "Navigate the RuneSpan using a greater conjuration platform.",
+    "requirements": "81 Runecrafting",
+    "points": 150
+  },
+  {
+    "id": 898,
+    "taskId": 13,
+    "locality": "Misthalin: Draynor Village",
+    "task": "Obtain the Greater Runic Staff from the RuneSpan.",
+    "information": "Obtain the greater runic staff from the RuneSpan.",
+    "requirements": "75 Runecrafting",
+    "points": 150
+  },
+  {
+    "id": 899,
+    "taskId": 21,
+    "locality": "Misthalin: Edgeville",
+    "task": "Complete the task set: Elite Varrock.",
+    "information": "Given by Vannaka in Edgeville for completing all of the Elite Varrock achievements.",
+    "requirements": "See Elite Varrock achievements page",
+    "points": 150
+  },
+  {
+    "id": 900,
+    "taskId": 25,
+    "locality": "Misthalin: Fort Forinthry",
+    "task": "Upgrade the guardhouse in Fort Forinthry to Tier 3.",
+    "information": "Upgrade the guardhouse in Fort Forinthry to tier 3.",
+    "requirements": "77 Construction",
+    "points": 150
+  },
+  {
+    "id": 901,
+    "taskId": 59,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Defeat 150 tormented demons.",
+    "information": "Defeat 150 tormented demons.",
+    "requirements": "Completion of While Guthix Sleeps",
+    "points": 150
+  },
+  {
+    "id": 902,
+    "taskId": 60,
+    "locality": "Misthalin: Lumbridge",
+    "task": "Equip a dragon crossbow.",
+    "information": "Equip a dragon crossbow.",
+    "requirements": "64 Ranged",
+    "points": 150
+  },
+  {
+    "id": 903,
+    "taskId": 85,
+    "locality": "Misthalin: City of Um",
+    "task": "Defeat Rasial, the First Necromancer.",
+    "information": "Defeat Rasial, the First Necromancer once.",
+    "requirements": "Completion of all Necromancy quests",
+    "points": 150
+  },
+  {
+    "id": 904,
+    "taskId": 86,
+    "locality": "Misthalin: City of Um",
+    "task": "Defeat Rasial, the First Necromancer. (100 times)",
+    "information": "Defeat Rasial, the First Necromancer 100 times.",
+    "requirements": "Completion of all Necromancy quests",
+    "points": 150
+  },
+  {
+    "id": 905,
+    "taskId": 87,
+    "locality": "Misthalin: City of Um",
+    "task": "Equip an Omni guard.",
+    "information": "Equip an omni guard.",
+    "requirements": "95 Necromancy",
+    "points": 150
+  },
+  {
+    "id": 906,
+    "taskId": 88,
+    "locality": "Misthalin: City of Um",
+    "task": "Equip a Soulbound lantern.",
+    "information": "Equip a soulbound lantern",
+    "requirements": "95 Necromancy",
+    "points": 150
+  },
+  {
+    "id": 907,
+    "taskId": 89,
+    "locality": "Misthalin: City of Um",
+    "task": "Equip a full set of Robes of the First Necromancer.",
+    "information": "Equip a full set of First Necromancer's equipment.",
+    "requirements": "95 Defence",
+    "points": 150
+  },
+  {
+    "id": 908,
+    "taskId": 90,
+    "locality": "Misthalin: City of Um",
+    "task": "Give a blueberry pie to Thalmund in the City of Um.",
+    "information": "Give a blueberry pie to Thalmund in the City of Um.",
+    "requirements": "30 Cooking",
+    "points": 150
+  },
+  {
+    "id": 909,
+    "taskId": 91,
+    "locality": "Misthalin: City of Um",
+    "task": "Track 8 of the owls in the City of Um.",
+    "information": "Track 8 of the owls in the City of Um. See Birds of Prey for details.",
+    "requirements": "Completion of all Necromancy quests",
+    "points": 150
+  },
+  {
+    "id": 910,
+    "taskId": 92,
+    "locality": "Misthalin: Varrock",
+    "task": "Defeat Croesus.",
+    "information": "Defeat Croesus 1 time.",
+    "requirements": "88 Woodcutting, 88 Mining, 88 Fishing, 88 Hunter",
+    "points": 150
+  },
+  {
+    "id": 911,
+    "taskId": 93,
+    "locality": "Misthalin: Varrock",
+    "task": "Defeat Croesus. (100 times)",
+    "information": "Defeat Croesus 100 times.",
+    "requirements": "88 Woodcutting, 88 Mining, 88 Fishing, 88 Hunter",
+    "points": 150
+  },
+  {
+    "id": 912,
+    "taskId": 119,
+    "locality": "Misthalin: Varrock",
+    "task": "Defeat Kerapac, the bound. (100 times)",
+    "information": "Defeat Kerapac, the bound 100 times.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 913,
+    "taskId": 121,
+    "locality": "Misthalin: Varrock",
+    "task": "Defeat the Arch-Glacor in hard mode. (100 times)",
+    "information": "Defeat the Arch-Glacor in hard mode 100 times.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 914,
+    "taskId": 124,
+    "locality": "Misthalin: Varrock",
+    "task": "Equip either a Dark Shard of Leng or a Dark Sliver of Leng.",
+    "information": "Equip either a Dark Shard of Leng or a Dark Sliver of Leng.",
+    "requirements": "92 Attack",
+    "points": 150
+  },
+  {
+    "id": 915,
+    "taskId": 125,
+    "locality": "Misthalin: Varrock",
+    "task": "Craft 100 earth runes simultaneously without aid from an explorer's ring, pouches or familiars.",
+    "information": "Craft 100 earth runes simultaneously without aid from an explorer's ring, Runecrafting pouches or familiars.",
+    "requirements": "99 Runecrafting",
+    "points": 150
+  },
+  {
+    "id": 916,
+    "taskId": 126,
+    "locality": "Misthalin: Varrock",
+    "task": "Bake a summer pie in the Cooking Guild from scratch.",
+    "information": "Bake a summer pie in the Cooking Guild from scratch.",
+    "requirements": "95 Cooking",
+    "points": 150
+  },
+  {
+    "id": 917,
+    "taskId": 758,
+    "locality": "Misthalin: Varrock",
+    "task": "Defeat TzKal-Zuk.",
+    "information": "Defeat TzKal-Zuk once.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 918,
+    "taskId": 759,
+    "locality": "Misthalin: Varrock",
+    "task": "Defeat TzKal-Zuk. (10 times)",
+    "information": "Defeat TzKal-Zuk 10 times.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 919,
+    "taskId": 760,
+    "locality": "Misthalin: City of Um",
+    "task": "Craft a soul rune at the soul altar with a soul cape equipped.",
+    "information": "Craft a soul rune at the soul altar with a soul cape equipped.",
+    "requirements": "90 Runecrafting",
+    "points": 150
+  },
+  {
+    "id": 920,
+    "taskId": 761,
+    "locality": "Misthalin: City of Um",
+    "task": "Upgrade a set of Death Skull equipment to tier 90.",
+    "information": "Upgrade a set of Death Skull equipment to tier 90.",
+    "requirements": "90 Necromancy",
+    "points": 150
+  },
+  {
+    "id": 921,
+    "taskId": 763,
+    "locality": "Misthalin: City of Um",
+    "task": "Defeat Nakatra, Devourer Eternal. (100 times)",
+    "information": "Defeat Nakatra, Devourer Eternal 100 times.",
+    "requirements": "Completion of Soul Searching",
+    "points": 150
+  },
+  {
+    "id": 922,
+    "taskId": 765,
+    "locality": "Misthalin: City of Um",
+    "task": "Cleanse the Gate of Elidinis. (100 times)",
+    "information": "Cleanse The Gate of Elidinis 100 times.",
+    "requirements": "Completion of Ode of the Devourer",
+    "points": 150
+  },
+  {
+    "id": 923,
+    "taskId": 769,
+    "locality": "Misthalin: City of Um",
+    "task": "Complete the task set: Elite Underworld.",
+    "information": "Complete the Elite Underworld achievements.",
+    "requirements": "See Elite Underworld achievements page",
+    "points": 150
+  },
+  {
+    "id": 924,
+    "taskId": 1114,
+    "locality": "Misthalin: Fort Forinthry",
+    "task": "Defeat Zemouregal & Vorkath.",
+    "information": "Defeat Zemouregal & Vorkath.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 925,
+    "taskId": 1115,
+    "locality": "Misthalin: Fort Forinthry",
+    "task": "Defeat Zemouregal & Vorkath. (100 times)",
+    "information": "Defeat Zemouregal & Vorkath 100 times.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 926,
+    "taskId": 122,
+    "locality": "Misthalin: Varrock",
+    "task": "Equip an Ek-ZekKil.",
+    "information": "Equip an Ek-ZekKil.",
+    "requirements": "95 Melee",
+    "points": 150
+  },
+  {
+    "id": 927,
+    "taskId": 123,
+    "locality": "Misthalin: Varrock",
+    "task": "Equip a Fractured Staff of Armadyl.",
+    "information": "Equip a Fractured Staff of Armadyl.",
+    "requirements": "95 Magic",
+    "points": 150
+  },
+  {
+    "id": 928,
+    "taskId": 767,
+    "locality": "Misthalin: City of Um",
+    "task": "Complete all Sanctum of Rebirth combat achievements.",
+    "information": "Complete all Sanctum of Rebirth combat achievements.",
+    "requirements": "See Sanctum of Rebirth achievements page",
+    "points": 150
+  },
+  {
+    "id": 929,
+    "taskId": 768,
+    "locality": "Misthalin: City of Um",
+    "task": "Complete all of Rasial, the First Necromancer's combat achievements.",
+    "information": "Complete all of Rasial, the First Necromancer's combat achievements.",
+    "requirements": "See Rasial, the First Necromancer achievements page",
+    "points": 150
+  },
+  {
+    "id": 930,
+    "taskId": 1116,
+    "locality": "Misthalin: Varrock",
+    "task": "Equip an igneous Kal-Zuk cape.",
+    "information": "Equip an igneous Kal-Zuk cape.",
+    "requirements": "99 Defence",
+    "points": 150
+  },
+  {
+    "id": 931,
+    "taskId": 693,
+    "locality": "Morytania",
+    "task": "Take an easy companion through an easy route of Temple Trekking.",
+    "information": "Complete an Easy Temple Trek.",
+    "requirements": "Completion of In Aid of the Myreque",
+    "points": 10
+  },
+  {
+    "id": 932,
+    "taskId": 694,
+    "locality": "Morytania",
+    "task": "Craft your own snelm in Morytania.",
+    "information": "Craft a snelm.",
+    "requirements": "15 Crafting",
+    "points": 10
+  },
+  {
+    "id": 933,
+    "taskId": 695,
+    "locality": "Morytania",
+    "task": "Defeat a Werewolf in Morytania.",
+    "information": "Defeat a Werewolf in Morytania.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 934,
+    "taskId": 696,
+    "locality": "Morytania",
+    "task": "Pass through the Holy barrier.",
+    "information": "Pass through the Holy barrier.",
+    "requirements": "Defeat a Ghoul (Paterdomus)",
+    "points": 10
+  },
+  {
+    "id": 935,
+    "taskId": 697,
+    "locality": "Morytania",
+    "task": "Enter through the western gate of Port Phasmatys.",
+    "information": "Pass through the western gate of Port Phasmatys.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 936,
+    "taskId": 698,
+    "locality": "Morytania",
+    "task": "Activate the lodestone in Canifis.",
+    "information": "Activate the Canifis lodestone.",
+    "requirements": "Access to Morytania",
+    "points": 10
+  },
+  {
+    "id": 937,
+    "taskId": 699,
+    "locality": "Morytania",
+    "task": "Kill anything on the ground floor of the Slayer Tower.",
+    "information": "Kill anything on the ground floor of the Slayer Tower.",
+    "requirements": "1 Slayer",
+    "points": 10
+  },
+  {
+    "id": 938,
+    "taskId": 700,
+    "locality": "Morytania",
+    "task": "Using either a Silver Sickle or the Ivandis Flail, grow some fungus in the swamp using Bloom.",
+    "information": "Cast Bloom using a blessed sickle or the Ivandis flail in Mort Myre Swamp.",
+    "requirements": "18 Crafting",
+    "points": 10
+  },
+  {
+    "id": 939,
+    "taskId": 701,
+    "locality": "Morytania",
+    "task": "Defeat 5 Feral Vampyres in the Haunted Woods.",
+    "information": "Defeat 5 feral vampyres in the Haunted Woods.",
+    "requirements": "Access to Morytania",
+    "points": 10
+  },
+  {
+    "id": 940,
+    "taskId": 702,
+    "locality": "Morytania",
+    "task": "Use an ectophial to return to Port Phasmatys.",
+    "information": "Use an ectophial to return to Port Phasmatys.",
+    "requirements": "Completion of Ghosts Ahoy",
+    "points": 10
+  },
+  {
+    "id": 941,
+    "taskId": 703,
+    "locality": "Morytania",
+    "task": "Visit Dragontooth Island by boat.",
+    "information": "Visit Dragontooth Island by boat.",
+    "requirements": "Ghostspeak amulet",
+    "points": 10
+  },
+  {
+    "id": 942,
+    "taskId": 704,
     "locality": "Morytania",
     "task": "Complete the task set: Easy Morytania.",
     "information": "Complete the Easy Morytania achievements.",
@@ -3740,7 +8487,8 @@
     "points": 30
   },
   {
-    "id": 467,
+    "id": 943,
+    "taskId": 705,
     "locality": "Morytania",
     "task": "Take a medium companion through a medium route of Temple Trekking.",
     "information": "Take a medium companion through a medium route of Temple Trekking.",
@@ -3748,7 +8496,8 @@
     "points": 30
   },
   {
-    "id": 468,
+    "id": 944,
+    "taskId": 706,
     "locality": "Morytania",
     "task": "Visit Mos Le'Harmless.",
     "information": "Visit Mos Le'Harmless.",
@@ -3756,7 +8505,8 @@
     "points": 30
   },
   {
-    "id": 469,
+    "id": 945,
+    "taskId": 707,
     "locality": "Morytania",
     "task": "Visit Harmony Island.",
     "information": "Visit Harmony Island.",
@@ -3764,7 +8514,8 @@
     "points": 30
   },
   {
-    "id": 470,
+    "id": 946,
+    "taskId": 708,
     "locality": "Morytania",
     "task": "Visit the Everlight dig site.",
     "information": "Visit the Everlight dig site.",
@@ -3772,15 +8523,17 @@
     "points": 30
   },
   {
-    "id": 471,
+    "id": 947,
+    "taskId": 709,
     "locality": "Morytania",
     "task": "Finish a game of Werewolf Skullball.",
     "information": "Finish a game of Werewolf Skullball.",
-    "requirements": "25 Agility, Completion of Creature of Fenkenstrain",
+    "requirements": "25 Agility",
     "points": 30
   },
   {
-    "id": 472,
+    "id": 948,
+    "taskId": 710,
     "locality": "Morytania",
     "task": "Defeat the six Barrows Brothers and loot their chest.",
     "information": "Defeat the six Barrows Brothers and loot their chest once.",
@@ -3788,7 +8541,8 @@
     "points": 30
   },
   {
-    "id": 473,
+    "id": 949,
+    "taskId": 711,
     "locality": "Morytania",
     "task": "Defeat the six Barrows Brothers and loot their chest. (100 times)",
     "information": "Defeat the six Barrows Brothers and loot their chest 100 times.",
@@ -3796,15 +8550,17 @@
     "points": 30
   },
   {
-    "id": 474,
+    "id": 950,
+    "taskId": 712,
     "locality": "Morytania",
     "task": "Equip a Barrows weapon.",
     "information": "Equip a barrows weapon.",
-    "requirements": "Either 70 Magic, 70 Attack, or 70 Ranged",
+    "requirements": "70 Magic, 70 Attack, or 70 Ranged",
     "points": 30
   },
   {
-    "id": 475,
+    "id": 951,
+    "taskId": 713,
     "locality": "Morytania",
     "task": "Equip a piece of Barrows armour.",
     "information": "Equip a piece of barrows armour.",
@@ -3812,7 +8568,8 @@
     "points": 30
   },
   {
-    "id": 476,
+    "id": 952,
+    "taskId": 714,
     "locality": "Morytania",
     "task": "Equip a Salve Amulet (e).",
     "information": "Equip a salve amulet (e).",
@@ -3820,15 +8577,17 @@
     "points": 30
   },
   {
-    "id": 477,
+    "id": 953,
+    "taskId": 715,
     "locality": "Morytania",
     "task": "Make a batch of cannonballs in Port Phasmatys.",
     "information": "Make a batch of cannonballs in Port Phasmatys.",
-    "requirements": "35 Smithing, Completion of Dwarf Cannon",
+    "requirements": "35 Smithing",
     "points": 30
   },
   {
-    "id": 478,
+    "id": 954,
+    "taskId": 716,
     "locality": "Morytania",
     "task": "Catch 10 Green salamanders.",
     "information": "Catch 10 Green salamanders.",
@@ -3836,7 +8595,8 @@
     "points": 30
   },
   {
-    "id": 479,
+    "id": 955,
+    "taskId": 717,
     "locality": "Morytania",
     "task": "Complete the quest: Haunted Mine.",
     "information": "Complete Haunted Mine.",
@@ -3844,7 +8604,8 @@
     "points": 30
   },
   {
-    "id": 480,
+    "id": 956,
+    "taskId": 718,
     "locality": "Morytania",
     "task": "Harvest bittercap mushrooms in the farming patch near Canifis.",
     "information": "Harvest bittercap mushrooms in the farming patch near Canifis.",
@@ -3852,15 +8613,440 @@
     "points": 30
   },
   {
-    "id": 481,
+    "id": 957,
+    "taskId": 719,
     "locality": "Morytania",
     "task": "Complete the task set: Medium Morytania.",
-    "information": "",
-    "requirements": "N/A",
+    "information": "Complete the Medium Morytania achievements.",
+    "requirements": "See Medium Morytania achievements page",
     "points": 30
   },
   {
-    "id": 482,
+    "id": 958,
+    "taskId": 720,
+    "locality": "Morytania",
+    "task": "Take a hard companion through a hard route of Temple Trekking.",
+    "information": "Take a hard companion through a hard route of Temple Trekking.",
+    "requirements": "Completion of In Aid of the Myreque",
+    "points": 80
+  },
+  {
+    "id": 959,
+    "taskId": 721,
+    "locality": "Morytania",
+    "task": "Mine 30 Phasmatite.",
+    "information": "Mine 30 phasmatite at Port Phasmatys south mine.",
+    "requirements": "70 Mining",
+    "points": 80
+  },
+  {
+    "id": 960,
+    "taskId": 722,
+    "locality": "Morytania",
+    "task": "Defeat 25 Gargoyles.",
+    "information": "Defeat 25 gargoyles.",
+    "requirements": "75 Slayer",
+    "points": 80
+  },
+  {
+    "id": 961,
+    "taskId": 723,
+    "locality": "Morytania",
+    "task": "Defeat 35 Aberrant Spectres.",
+    "information": "Defeat 35 aberrant spectres.",
+    "requirements": "60 Slayer",
+    "points": 80
+  },
+  {
+    "id": 962,
+    "taskId": 724,
+    "locality": "Morytania",
+    "task": "Equip a full set of Ahrim's equipment, including the staff.",
+    "information": "Equip a full set of Ahrim's equipment, including the staff.",
+    "requirements": "70 Defence, 70 Magic",
+    "points": 80
+  },
+  {
+    "id": 963,
+    "taskId": 725,
+    "locality": "Morytania",
+    "task": "Equip a full set of Dharok's equipment, including the greataxe.",
+    "information": "Equip a full set of Dharok's equipment, including the greataxe.",
+    "requirements": "70 Defence, 70 Attack",
+    "points": 80
+  },
+  {
+    "id": 964,
+    "taskId": 726,
+    "locality": "Morytania",
+    "task": "Equip a full set of Guthan's equipment, including the warspear.",
+    "information": "Equip a full set of Guthan's equipment, including the Guthan's warspear.",
+    "requirements": "70 Defence, 70 Attack",
+    "points": 80
+  },
+  {
+    "id": 965,
+    "taskId": 727,
+    "locality": "Morytania",
+    "task": "Equip a full set of Torag's equipment, including the hammer.",
+    "information": "Equip a full set of Torag's equipment, including the hammer.",
+    "requirements": "70 Defence, 70 Attack",
+    "points": 80
+  },
+  {
+    "id": 966,
+    "taskId": 728,
+    "locality": "Morytania",
+    "task": "Equip a full set of Verac's equipment, including the flail.",
+    "information": "Equip a full set of Verac's equipment, including the flail.",
+    "requirements": "70 Defence, 70 Attack",
+    "points": 80
+  },
+  {
+    "id": 967,
+    "taskId": 729,
+    "locality": "Morytania",
+    "task": "Equip a full set of Karil's equipment, including the 2h crossbow.",
+    "information": "Equip a full set of Karil's equipment, including the 2h crossbow.",
+    "requirements": "70 Defence, 70 Ranged",
+    "points": 80
+  },
+  {
+    "id": 968,
+    "taskId": 730,
+    "locality": "Morytania",
+    "task": "Complete the quest: The Branches of Darkmeyer.",
+    "information": "Complete The Branches of Darkmeyer.",
+    "requirements": "See quest page",
+    "points": 80
+  },
+  {
+    "id": 969,
+    "taskId": 731,
+    "locality": "Morytania",
+    "task": "Burn 20 Blisterwood logs.",
+    "information": "Burn 20 blisterwood logs.",
+    "requirements": "76 Woodcutting, 76 Firemaking",
+    "points": 80
+  },
+  {
+    "id": 970,
+    "taskId": 732,
+    "locality": "Morytania",
+    "task": "Fully level up all Temple Trekking companions.",
+    "information": "Fully level up all Temple Trekking companions.",
+    "requirements": "Completion of In Aid of the Myreque",
+    "points": 80
+  },
+  {
+    "id": 971,
+    "taskId": 733,
+    "locality": "Morytania",
+    "task": "Catch 5 sharks in Burgh de Rott.",
+    "information": "Catch 5 sharks in Burgh de Rott.",
+    "requirements": "76 Fishing",
+    "points": 80
+  },
+  {
+    "id": 972,
+    "taskId": 734,
+    "locality": "Morytania",
+    "task": "Complete the task set: Hard Morytania.",
+    "information": "Complete the Hard Morytania achievements.",
+    "requirements": "See Hard Morytania achievements page",
+    "points": 80
+  },
+  {
+    "id": 973,
+    "taskId": 735,
+    "locality": "Morytania",
+    "task": "Defeat 30 Abyssal Demons.",
+    "information": "Defeat 30 abyssal demons.",
+    "requirements": "85 Slayer",
+    "points": 150
+  },
+  {
+    "id": 974,
+    "taskId": 736,
+    "locality": "Morytania",
+    "task": "Harvest 200 radiant energy from Radiant Wisps.",
+    "information": "Harvest 200 radiant energy from radiant wisps.",
+    "requirements": "85 Divination",
+    "points": 150
+  },
+  {
+    "id": 975,
+    "taskId": 737,
+    "locality": "Morytania",
+    "task": "Defeat 20 Celestial Dragons.",
+    "information": "Defeat 20 celestial dragons.",
+    "requirements": "Completion of One of a Kind",
+    "points": 150
+  },
+  {
+    "id": 976,
+    "taskId": 738,
+    "locality": "Morytania",
+    "task": "Defeat Araxxi.",
+    "information": "Defeat Araxxi once.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 977,
+    "taskId": 739,
+    "locality": "Morytania",
+    "task": "Defeat Araxxi. (100 times)",
+    "information": "Defeat Araxxi 100 times.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 978,
+    "taskId": 740,
+    "locality": "Morytania",
+    "task": "Defeat the empowered Barrows Brothers.",
+    "information": "Complete one Rise of the Six encounter.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 979,
+    "taskId": 741,
+    "locality": "Morytania",
+    "task": "Defeat the empowered Barrows Brothers.",
+    "information": "Complete 100 Rise of the Six encounters.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 980,
+    "taskId": 742,
+    "locality": "Morytania",
+    "task": "Equip a Noxious Scythe.",
+    "information": "Equip a noxious scythe.",
+    "requirements": "90 Attack",
+    "points": 150
+  },
+  {
+    "id": 981,
+    "taskId": 743,
+    "locality": "Morytania",
+    "task": "Equip a Noxious Staff.",
+    "information": "Equip a noxious staff.",
+    "requirements": "90 Magic",
+    "points": 150
+  },
+  {
+    "id": 982,
+    "taskId": 744,
+    "locality": "Morytania",
+    "task": "Equip a Noxious Bow.",
+    "information": "Equip a noxious bow.",
+    "requirements": "90 Ranged",
+    "points": 150
+  },
+  {
+    "id": 983,
+    "taskId": 745,
+    "locality": "Morytania",
+    "task": "Equip a full set of Linza's equipment, including the hammer and shield.",
+    "information": "Equip a full set of Linza the Disgraced's equipment, including the hammer and shield.",
+    "requirements": "80 Defence, 80 Attack",
+    "points": 150
+  },
+  {
+    "id": 984,
+    "taskId": 746,
+    "locality": "Morytania",
+    "task": "Equip a full set of Akrisae's equipment, including the war mace.",
+    "information": "Equip a full set of Akrisae the Doomed's equipment, including the war mace.",
+    "requirements": "80 Defence, 80 Attack",
+    "points": 150
+  },
+  {
+    "id": 985,
+    "taskId": 747,
+    "locality": "Morytania",
+    "task": "Equip a Malevolent Kiteshield.",
+    "information": "Equip a malevolent kiteshield.",
+    "requirements": "90 Defence",
+    "points": 150
+  },
+  {
+    "id": 986,
+    "taskId": 748,
+    "locality": "Morytania",
+    "task": "Equip a Merciless Kiteshield.",
+    "information": "Equip a merciless kiteshield.",
+    "requirements": "90 Defence",
+    "points": 150
+  },
+  {
+    "id": 987,
+    "taskId": 749,
+    "locality": "Morytania",
+    "task": "Equip a Vengeful Kiteshield.",
+    "information": "Equip a vengeful kiteshield.",
+    "requirements": "90 Defence",
+    "points": 150
+  },
+  {
+    "id": 988,
+    "taskId": 750,
+    "locality": "Morytania",
+    "task": "Complete all the Everlight mysteries.",
+    "information": "Complete all of the Everlight Dig Site mysteries.",
+    "requirements": "98 Archaeology",
+    "points": 150
+  },
+  {
+    "id": 989,
+    "taskId": 751,
+    "locality": "Morytania",
+    "task": "Obtain an Araxyte Pheremone drop.",
+    "information": "Obtain an araxyte pheremone drop.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 990,
+    "taskId": 752,
+    "locality": "Morytania",
+    "task": "Complete the task set: Elite Morytania.",
+    "information": "Complete the Elite Morytania achievements.",
+    "requirements": "See Elite Morytania achievements page",
+    "points": 150
+  },
+  {
+    "id": 991,
+    "taskId": 753,
+    "locality": "Morytania",
+    "task": "Enter the Morytania Slayer Tower resource dungeon.",
+    "information": "Enter the Morytania Slayer Tower resource dungeon.",
+    "requirements": "95 Dungeoneering",
+    "points": 150
+  },
+  {
+    "id": 992,
+    "taskId": 757,
+    "locality": "Morytania",
+    "task": "Read the book acquired from Roberta outside the Everlight porcelain clay mine.",
+    "information": "Read On the Origin of Centaurs.",
+    "requirements": "42 Archaeology",
+    "points": 150
+  },
+  {
+    "id": 993,
+    "taskId": 754,
+    "locality": "Morytania",
+    "task": "Fully explore the history of the Everlight Dig Site.",
+    "information": "Complete the Mastery - Everlight achievements.",
+    "requirements": "98 Archaeology",
+    "points": 150
+  },
+  {
+    "id": 994,
+    "taskId": 755,
+    "locality": "Morytania",
+    "task": "Complete all Araxxor and Araxxi combat achievements.",
+    "information": "Complete all Araxxor and Araxxi combat achievements.",
+    "requirements": "See Araxxor achievements page",
+    "points": 150
+  },
+  {
+    "id": 995,
+    "taskId": 756,
+    "locality": "Morytania",
+    "task": "Complete the quest: River of Blood.",
+    "information": "Complete River of Blood.",
+    "requirements": "See quest page",
+    "points": 150
+  },
+  {
+    "id": 996,
+    "taskId": 514,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Cook a Rabbit in Tirannwn.",
+    "information": "Cook a raw rabbit in Tirannwn.",
+    "requirements": "1 Cooking",
+    "points": 10
+  },
+  {
+    "id": 997,
+    "taskId": 515,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Attempt to pass a leaf trap.",
+    "information": "Attempt to pass a leaf trap.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 998,
+    "taskId": 516,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Use the Bank in Lletya.",
+    "information": "Use the bank in Lletya.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 999,
+    "taskId": 517,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Charter a ship from Port Tyras.",
+    "information": "Charter a ship from Port Tyras.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1000,
+    "taskId": 518,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Climb the Tower of Voices.",
+    "information": "Climb the Tower of Voices.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1001,
+    "taskId": 519,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Burn some logs using the everlasting bonfire in the Tower of Voices.",
+    "information": "Burn some logs using the everlasting bonfire in the Tower of Voices.",
+    "requirements": "1 Firemaking",
+    "points": 10
+  },
+  {
+    "id": 1002,
+    "taskId": 520,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Activate the lodestone in Prifddinas.",
+    "information": "Activate the Prifddinas lodestone.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1003,
+    "taskId": 521,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Activate the lodestone in Tirannwn.",
+    "information": "Activate the Tirannwn lodestone.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1004,
+    "taskId": 522,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Restore your prayer using the altar in Lletya.",
+    "information": "Restore your prayer using the altar in Lletya.",
+    "requirements": "1 Prayer",
+    "points": 10
+  },
+  {
+    "id": 1005,
+    "taskId": 523,
     "locality": "Elven Lands: Tirranwn",
     "task": "Complete the task set: Easy Tirannwn.",
     "information": "Complete the Easy Tirannwn achievements.",
@@ -3868,7 +9054,8 @@
     "points": 30
   },
   {
-    "id": 483,
+    "id": 1006,
+    "taskId": 524,
     "locality": "Elven Lands: Tirranwn",
     "task": "Check a grown Papaya Tree in Lletya.",
     "information": "Check a grown papaya tree in Lletya.",
@@ -3876,7 +9063,8 @@
     "points": 30
   },
   {
-    "id": 484,
+    "id": 1007,
+    "taskId": 525,
     "locality": "Elven Lands: Tirranwn",
     "task": "Craft 50 Death Runes.",
     "information": "Craft 50 death runes.",
@@ -3884,15 +9072,17 @@
     "points": 30
   },
   {
-    "id": 485,
+    "id": 1008,
+    "taskId": 526,
     "locality": "Elven Lands: Tirranwn",
     "task": "Move your house to Prifddinas.",
     "information": "Move your player-owned house's location to Prifddinas by speaking to an estate agent.",
-    "requirements": "75 Construction, 50,000",
+    "requirements": "75 Construction",
     "points": 30
   },
   {
-    "id": 486,
+    "id": 1009,
+    "taskId": 527,
     "locality": "Elven Lands: Tirranwn",
     "task": "Use an Elven Teleport Crystal.",
     "information": "Use a crystal teleport seed.",
@@ -3900,7 +9090,8 @@
     "points": 30
   },
   {
-    "id": 487,
+    "id": 1010,
+    "taskId": 528,
     "locality": "Elven Lands: Tirranwn",
     "task": "Equip Iban's staff.",
     "information": "Equip Iban's staff.",
@@ -3908,7 +9099,8 @@
     "points": 30
   },
   {
-    "id": 488,
+    "id": 1011,
+    "taskId": 529,
     "locality": "Elven Lands: Tirranwn",
     "task": "Catch 10 Pawyas in Isafdar.",
     "information": "Catch 10 pawyas in Isafdar.",
@@ -3916,7 +9108,8 @@
     "points": 30
   },
   {
-    "id": 489,
+    "id": 1012,
+    "taskId": 530,
     "locality": "Elven Lands: Tirranwn",
     "task": "Mine 200 soft clay in Prifddinas.",
     "information": "Mine 200 soft clay in Prifddinas.",
@@ -3924,7 +9117,8 @@
     "points": 30
   },
   {
-    "id": 490,
+    "id": 1013,
+    "taskId": 531,
     "locality": "Elven Lands: Tirranwn",
     "task": "Use the fairy ring in the Amlodd district.",
     "information": "Use the fairy ring in the Amlodd district.",
@@ -3932,7 +9126,8 @@
     "points": 30
   },
   {
-    "id": 491,
+    "id": 1014,
+    "taskId": 532,
     "locality": "Elven Lands: Tirranwn",
     "task": "Complete the task set: Medium Tirannwn.",
     "information": "Complete the Medium Tirannwn achievements.",
@@ -3940,7 +9135,449 @@
     "points": 30
   },
   {
-    "id": 492,
+    "id": 1015,
+    "taskId": 533,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Plant a mushroom seed in the mushroom patch in Isafdar.",
+    "information": "Plant a mushroom seed in the mushroom patch in Isafdar.",
+    "requirements": "53 Farming",
+    "points": 80
+  },
+  {
+    "id": 1016,
+    "taskId": 534,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Defeat 30 Cadarn warriors in Prifddinas.",
+    "information": "Defeat 30 Cadarn warriors in Prifddinas.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 1017,
+    "taskId": 535,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Harvest some harmony moss from a harmony pillar.",
+    "information": "Harvest some harmony moss from a harmony pillar.",
+    "requirements": "75 Farming",
+    "points": 80
+  },
+  {
+    "id": 1018,
+    "taskId": 536,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Complete the Hefin Agility course with a light creature familiar summoned.",
+    "information": "Complete the Hefin Agility course with a light creature familiar summoned.",
+    "requirements": "77 Agility, 88 Summoning, 71 Divination",
+    "points": 80
+  },
+  {
+    "id": 1019,
+    "taskId": 537,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Cleanse the Corrupted Seren stone with 5 cleansing crystals.",
+    "information": "Cleanse the corrupted Seren stone with 5 cleansing crystals.",
+    "requirements": "75 Prayer",
+    "points": 80
+  },
+  {
+    "id": 1020,
+    "taskId": 538,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Complete 10 laps of the Hefin agility course.",
+    "information": "Complete 10 laps of the Hefin agility course.",
+    "requirements": "77 Agility",
+    "points": 80
+  },
+  {
+    "id": 1021,
+    "taskId": 539,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Harvest 100 Incandescent energy from Incandescent Wisps.",
+    "information": "Harvest 100 incandescent energy from incandescent wisps.",
+    "requirements": "95 Divination",
+    "points": 80
+  },
+  {
+    "id": 1022,
+    "taskId": 540,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Equip a Dark bow.",
+    "information": "Equip a dark bow.",
+    "requirements": "90 Slayer, 70 Ranged, 70 Defence",
+    "points": 80
+  },
+  {
+    "id": 1023,
+    "taskId": 541,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Defeat 30 Dark beasts in Tirannwn.",
+    "information": "Defeat 30 dark beasts in Tirannwn.",
+    "requirements": "90 Slayer",
+    "points": 80
+  },
+  {
+    "id": 1024,
+    "taskId": 542,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Equip a Crystal halberd.",
+    "information": "Equip a crystal halberd.",
+    "requirements": "50 Agility, 70 Attack",
+    "points": 80
+  },
+  {
+    "id": 1025,
+    "taskId": 543,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Equip a Crystal shield.",
+    "information": "Equip a crystal shield.",
+    "requirements": "50 Agility, 70 Defence",
+    "points": 80
+  },
+  {
+    "id": 1026,
+    "taskId": 544,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Equip a Crystal bow.",
+    "information": "Equip a crystal bow.",
+    "requirements": "50 Agility, 70 Ranged",
+    "points": 80
+  },
+  {
+    "id": 1027,
+    "taskId": 545,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Catch 25 Grenwalls in Isafdar.",
+    "information": "Catch 25 grenwalls in Isafdar.",
+    "requirements": "77 Hunter",
+    "points": 80
+  },
+  {
+    "id": 1028,
+    "taskId": 546,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Defeat 10 Elf warriors in Lletya.",
+    "information": "Defeat 10 elf warriors in Lletya.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 1029,
+    "taskId": 547,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Chop 50 Magic logs in Tirannwn.",
+    "information": "Chop 50 magic logs in Tirannwn.",
+    "requirements": "80 Woodcutting",
+    "points": 80
+  },
+  {
+    "id": 1030,
+    "taskId": 548,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Open the crystal chest in Prifddinas 10 times.",
+    "information": "Open the crystal chest in Prifddinas 10 times.",
+    "requirements": "N/A",
+    "points": 80
+  },
+  {
+    "id": 1031,
+    "taskId": 549,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Charge a piece of Dragonstone jewellery using the Tears of Seren.",
+    "information": "Charge a piece of dragonstone jewellery using the Tears of Seren.",
+    "requirements": "Completion of Legends' Quest",
+    "points": 80
+  },
+  {
+    "id": 1032,
+    "taskId": 550,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Complete the task set: Hard Tirannwn.",
+    "information": "Complete the Hard Tirannwn achievements.",
+    "requirements": "See Hard Tirannwn achievements page",
+    "points": 80
+  },
+  {
+    "id": 1033,
+    "taskId": 551,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Enter the Gorajo Hoardstalker resource dungeon.",
+    "information": "Enter the Gorajo Hoardstalker resource dungeon.",
+    "requirements": "95 Dungeoneering",
+    "points": 150
+  },
+  {
+    "id": 1034,
+    "taskId": 552,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Have Lady Ithell create a crystal pickaxe, hatchet, or mattock.",
+    "information": "Have Lady Ithell create a crystal pickaxe, hatchet, or mattock.",
+    "requirements": "70 Smithing, 70 Invention",
+    "points": 150
+  },
+  {
+    "id": 1035,
+    "taskId": 553,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Find all of the memoriam crystals in Prifddinas.",
+    "information": "Find all of the memoriam crystals in Prifddinas.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 1036,
+    "taskId": 554,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Aid Lord Amlodd in cleansing shadow cores.",
+    "information": "Complete the I'm Forever Washing Shadows achievement.",
+    "requirements": "71 Divination",
+    "points": 150
+  },
+  {
+    "id": 1037,
+    "taskId": 555,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Help Lady Ithell with crystal singing research.",
+    "information": "Complete the Sing for the Lady achievement.",
+    "requirements": "75 Smithing, 75 Crafting",
+    "points": 150
+  },
+  {
+    "id": 1038,
+    "taskId": 556,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Aid Lady Trahaearn in removing some corruption by smelting 100 corrupted ore.",
+    "information": "Complete the Uncorrupted Ore achievement.",
+    "requirements": "75 Mining, 75 Smithing",
+    "points": 150
+  },
+  {
+    "id": 1039,
+    "taskId": 557,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Check a grown Crystal Tree in the Tower of Voices.",
+    "information": "Check a grown crystal tree in the Tower of Voices.",
+    "requirements": "94 Farming",
+    "points": 150
+  },
+  {
+    "id": 1040,
+    "taskId": 558,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Have 4 elven clans suspect you of thieving at the same time.",
+    "information": "Have 4 elven clans suspect you of thieving at the same time. If you have the Five Finger Discount relic this task is completed when pickpocketing an elf.",
+    "requirements": "75 Thieving",
+    "points": 150
+  },
+  {
+    "id": 1041,
+    "taskId": 559,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Chop a log from an elder tree you have grown in the Prifddinas farming patch, then fletch it into a shortbow.",
+    "information": "Chop a log from an elder tree you have grown in the Prifddinas farming patch, then fletch it into an elder shortbow.",
+    "requirements": "90 Farming, 90 Woodcutting, 90 Fletching",
+    "points": 150
+  },
+  {
+    "id": 1042,
+    "taskId": 560,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Catch a Crystal impling.",
+    "information": "Catch a crystal impling.",
+    "requirements": "80 Hunter",
+    "points": 150
+  },
+  {
+    "id": 1043,
+    "taskId": 561,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Craft an Attuned crystal teleport seed.",
+    "information": "Craft an attuned crystal teleport seed.",
+    "requirements": "85 Crafting, 85 Smithing",
+    "points": 150
+  },
+  {
+    "id": 1044,
+    "taskId": 562,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Mine 50 Light animica in Isafdar.",
+    "information": "Mine 50 light animica in Isafdar.",
+    "requirements": "90 Mining",
+    "points": 150
+  },
+  {
+    "id": 1045,
+    "taskId": 563,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Chop 25 Elder logs in Tirannwn.",
+    "information": "Chop 25 elder logs in Tirannwn.",
+    "requirements": "90 Woodcutting",
+    "points": 150
+  },
+  {
+    "id": 1046,
+    "taskId": 564,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Catch 75 Crystal skillchompas in Isafdar.",
+    "information": "Catch 75 crystal skillchompas in Isafdar.",
+    "requirements": "97 Hunter",
+    "points": 150
+  },
+  {
+    "id": 1047,
+    "taskId": 565,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Complete the task set: Elite Tirannwn.",
+    "information": "Complete the Elite Tirannwn achievements.",
+    "requirements": "See Elite Tirannwn achievements page",
+    "points": 150
+  },
+  {
+    "id": 1048,
+    "taskId": 566,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Complete a Seren symbol.",
+    "information": "Create a Seren's symbol.",
+    "requirements": "75 Farming, 75 Prayer",
+    "points": 150
+  },
+  {
+    "id": 1049,
+    "taskId": 567,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Obtain the titles of the elven clans.",
+    "information": "Obtain the titles of the elven clans.",
+    "requirements": "Various",
+    "points": 150
+  },
+  {
+    "id": 1050,
+    "taskId": 568,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Perform well enough in Rush of Blood to impress Morvran.",
+    "information": "Complete the Make Them Bleed achievement.",
+    "requirements": "N/A",
+    "points": 150
+  },
+  {
+    "id": 1051,
+    "taskId": 569,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Reach inside the Motherlode Maw 5 times.",
+    "information": "Reach inside the Motherlode Maw 5 times.",
+    "requirements": "115 Dungeoneering",
+    "points": 150
+  },
+  {
+    "id": 1052,
+    "taskId": 570,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Obtain 'the Elven' title by purchasing each of the elven clan capes.",
+    "information": "Obtain the Elven title by purchasing each of the elven clan capes.",
+    "requirements": "Various",
+    "points": 150
+  },
+  {
+    "id": 1053,
+    "taskId": 571,
+    "locality": "Elven Lands: Tirranwn",
+    "task": "Obtain the 'Dark Lord' title by unlocking a selection of titles from Prifddinas.",
+    "information": "Obtain the Dark Lord title by completing the Sort of Crystally achievement.",
+    "requirements": "Various",
+    "points": 150
+  },
+  {
+    "id": 1054,
+    "taskId": 630,
+    "locality": "Wilderness: General",
+    "task": "Use the bank at the Mage Arena.",
+    "information": "Use the Mage Arena bank.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1055,
+    "taskId": 631,
+    "locality": "Wilderness: General",
+    "task": "Defeat the Chaos Elemental.",
+    "information": "Defeat the Chaos Elemental once.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1056,
+    "taskId": 632,
+    "locality": "Wilderness: General",
+    "task": "Defeat the Chaos Elemental. (100 times)",
+    "information": "Defeat the Chaos Elemental 100 times.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1057,
+    "taskId": 633,
+    "locality": "Wilderness: General",
+    "task": "Reach a score of 10 using the strange switches in the Wilderness.",
+    "information": "Reach a score of 10 using the strange switches in the Wilderness.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1058,
+    "taskId": 634,
+    "locality": "Wilderness: General",
+    "task": "Jump over the Wilderness wall.",
+    "information": "Jump over the Wilderness wall.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1059,
+    "taskId": 635,
+    "locality": "Wilderness: General",
+    "task": "Activate the lodestone near the Wilderness Crater.",
+    "information": "Activate the Wilderness Crater lodestone.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1060,
+    "taskId": 636,
+    "locality": "Wilderness: Daemonheim",
+    "task": "Complete a Frozen floor in Daemonheim.",
+    "information": "Complete a Frozen floor in Daemonheim.",
+    "requirements": "1 Dungeoneering",
+    "points": 10
+  },
+  {
+    "id": 1061,
+    "taskId": 637,
+    "locality": "Wilderness: Daemonheim",
+    "task": "Make use of either an autoheater, gem bag, herbicide, bonecrusher or charming imp.",
+    "information": "Make use of either an autoheater, gem bag, herbicide, bonecrusher or charming imp.",
+    "requirements": "2000 dungeoneering token",
+    "points": 10
+  },
+  {
+    "id": 1062,
+    "taskId": 638,
+    "locality": "Wilderness: General",
+    "task": "Enter the chaos tunnels from an entrance in the Wilderness.",
+    "information": "Enter the Chaos Tunnels from an entrance in the Wilderness.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1063,
+    "taskId": 639,
+    "locality": "Wilderness: General",
+    "task": "Defeat a Black Unicorn in the Wilderness.",
+    "information": "Defeat a black unicorn in the Wilderness.",
+    "requirements": "N/A",
+    "points": 10
+  },
+  {
+    "id": 1064,
+    "taskId": 640,
     "locality": "Wilderness: General",
     "task": "Complete the task set: Easy Wilderness.",
     "information": "Complete the Easy Wilderness achievements.",
@@ -3948,7 +9585,8 @@
     "points": 30
   },
   {
-    "id": 493,
+    "id": 1065,
+    "taskId": 641,
     "locality": "Wilderness: General",
     "task": "Defeat the King Black Dragon.",
     "information": "Defeat the King Black Dragon once.",
@@ -3956,7 +9594,8 @@
     "points": 30
   },
   {
-    "id": 494,
+    "id": 1066,
+    "taskId": 642,
     "locality": "Wilderness: General",
     "task": "Defeat the King Black Dragon. (100 times)",
     "information": "Defeat the King Black Dragon 100 times.",
@@ -3964,7 +9603,8 @@
     "points": 30
   },
   {
-    "id": 495,
+    "id": 1067,
+    "taskId": 643,
     "locality": "Wilderness: General",
     "task": "Sacrifice Dragon bones on the Chaos Altar.",
     "information": "Sacrifice dragon bones on the chaos altar in the Wilderness.",
@@ -3972,15 +9612,17 @@
     "points": 30
   },
   {
-    "id": 496,
+    "id": 1068,
+    "taskId": 644,
     "locality": "Wilderness: General",
     "task": "Cast the Claws of Guthix special attack.",
     "information": "Cast the Claws of Guthix special attack.",
-    "requirements": "60 Magic, Completion of Mage Arena, Guthix staff",
+    "requirements": "60 Magic",
     "points": 30
   },
   {
-    "id": 497,
+    "id": 1069,
+    "taskId": 645,
     "locality": "Wilderness: General",
     "task": "Defeat 5 Green dragons.",
     "information": "Defeat 5 green dragons.",
@@ -3988,7 +9630,8 @@
     "points": 30
   },
   {
-    "id": 498,
+    "id": 1070,
+    "taskId": 646,
     "locality": "Wilderness: General",
     "task": "Complete 10 laps of the Wilderness agility course.",
     "information": "Complete 10 laps of the Wilderness agility course.",
@@ -3996,16 +9639,17 @@
     "points": 30
   },
   {
-    "id": 499,
+    "id": 1071,
+    "taskId": 647,
     "locality": "Wilderness: General",
     "task": "Equip a Saradomin, Zamorak, or Guthix cape.",
     "information": "Equip a Saradomin, Zamorak, or Guthix cape.",
-    "requirements": "60 Magic, Completion of Mage Arena",
+    "requirements": "60 Magic",
     "points": 30
-  }
-,
+  },
   {
-    "id": 500,
+    "id": 1072,
+    "taskId": 648,
     "locality": "Wilderness: General",
     "task": "Visit any Runecrafting altar through the Abyss.",
     "information": "Visit any Runecrafting altar through the Abyss.",
@@ -4013,7 +9657,8 @@
     "points": 30
   },
   {
-    "id": 501,
+    "id": 1073,
+    "taskId": 649,
     "locality": "Wilderness: General",
     "task": "Defeat 10 Fetid Zombies.",
     "information": "Defeat 10 fetid zombies.",
@@ -4021,7 +9666,8 @@
     "points": 30
   },
   {
-    "id": 502,
+    "id": 1074,
+    "taskId": 650,
     "locality": "Wilderness: General",
     "task": "Defeat 20 Bound Skeletons.",
     "information": "Defeat 20 bound skeletons.",
@@ -4029,7 +9675,8 @@
     "points": 30
   },
   {
-    "id": 503,
+    "id": 1075,
+    "taskId": 651,
     "locality": "Wilderness: Daemonheim",
     "task": "Defeat the Rammernaut.",
     "information": "Defeat the Rammernaut.",
@@ -4037,7 +9684,8 @@
     "points": 30
   },
   {
-    "id": 504,
+    "id": 1076,
+    "taskId": 652,
     "locality": "Wilderness: General",
     "task": "Defeat Bossy McBoss Face.",
     "information": "Defeat Bossy McBoss Face.",
@@ -4045,7 +9693,8 @@
     "points": 30
   },
   {
-    "id": 505,
+    "id": 1077,
+    "taskId": 653,
     "locality": "Wilderness: General",
     "task": "Activate and teleport from each of the Wilderness teleport obelisks.",
     "information": "Activate and teleport from each of the Wilderness teleport obelisks.",
@@ -4053,7 +9702,8 @@
     "points": 30
   },
   {
-    "id": 506,
+    "id": 1078,
+    "taskId": 654,
     "locality": "Wilderness: General",
     "task": "Defeat Bossy McBossface's first mate.",
     "information": "Defeat Bossy McBossface's first mate.",
@@ -4061,7 +9711,8 @@
     "points": 30
   },
   {
-    "id": 507,
+    "id": 1079,
+    "taskId": 655,
     "locality": "Wilderness: General",
     "task": "Complete the task set: Medium Wilderness.",
     "information": "Complete the Medium Wilderness achievements.",
@@ -4069,4881 +9720,336 @@
     "points": 30
   },
   {
-    "id": 508,
-    "locality": "Anachronia",
-    "task": "Harvest produce from 25 animals on Anachronia farm.",
-    "information": "Harvest produce from 25 animals on Anachronia farm.",
-    "requirements": "42 Farming, 45 Construction",
-    "points": 80
-  },
-  {
-    "id": 509,
-    "locality": "Anachronia",
-    "task": "Complete the ritual to activate a totem on Anachronia.",
-    "information": "Complete the ritual to activate a totem on Anachronia.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 510,
-    "locality": "Anachronia",
-    "task": "Complete the Anachronia agility course in under 7 minutes.",
-    "information": "Complete the Anachronia agility course in under 7 minutes.",
-    "requirements": "85 Agility",
-    "points": 80
-  },
-  {
-    "id": 511,
-    "locality": "Anachronia",
-    "task": "Complete all frog breeds.",
-    "information": "Complete all frog breeds.",
-    "requirements": "42 Farming, 45 Construction",
-    "points": 80
-  },
-  {
-    "id": 512,
-    "locality": "Anachronia",
-    "task": "Purchase the Quick Traps upgrade from Irwinsson's Hunter Mark shop.",
-    "information": "Purchase the quick traps upgrade from the Hunter Mark Shop.",
-    "requirements": "50 hunter marks",
-    "points": 80
-  },
-  {
-    "id": 513,
-    "locality": "Anachronia",
-    "task": "Complete the quest: Osseous Rex.",
-    "information": "Complete the Osseous Rex quest.",
-    "requirements": "See quest page",
-    "points": 80
-  },
-  {
-    "id": 514,
-    "locality": "Anachronia",
-    "task": "Clear an Overgrown idol on Anachronia.",
-    "information": "Clear an overgrown idol on Anachronia.",
-    "requirements": "81 Woodcutting",
-    "points": 80
-  },
-  {
-    "id": 515,
-    "locality": "Anachronia",
-    "task": "Defeat any of the Rex Matriarchs.",
-    "information": "Defeat any of the Rex Matriarchs once.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 516,
-    "locality": "Anachronia",
-    "task": "Defeat any of the Rex Matriarchs. (100 times)",
-    "information": "Defeat any of the Rex Matriarchs 100 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 517,
-    "locality": "Anachronia",
-    "task": "Complete the quest: Desperate Times.",
-    "information": "Complete the Desperate Times quest.",
-    "requirements": "See quest page",
-    "points": 80
-  },
-  {
-    "id": 518,
-    "locality": "Anachronia",
-    "task": "Find all the hidden Zygomites on Anachronia.",
-    "information": "Find all of the ancient zygomites on Anachronia. See the page for a route.",
-    "requirements": "85 Agility",
-    "points": 80
-  },
-  {
-    "id": 519,
-    "locality": "Anachronia",
-    "task": "Equip Laniakea's spear.",
-    "information": "Equip Laniakea's spear.",
-    "requirements": "82 Attack",
-    "points": 80
-  },
-  {
-    "id": 520,
-    "locality": "Anachronia",
-    "task": "Harvest an Arbuck herb.",
-    "information": "Harvest an arbuck herb.",
-    "requirements": "77 Farming",
-    "points": 80
-  },
-  {
-    "id": 521,
-    "locality": "Anachronia",
-    "task": "Complete the advanced sections of the Anachronia agility course.",
-    "information": "Complete the advanced sections of the Anachronia agility course.",
-    "requirements": "70 Agility",
-    "points": 80
-  },
-  {
-    "id": 522,
-    "locality": "Anachronia",
-    "task": "Equip a Dragon Mattock.",
-    "information": "Equip a dragon mattock.",
-    "requirements": "60 Archaeology, (optional) 75 Hunter",
-    "points": 80
-  },
-  {
-    "id": 523,
-    "locality": "Anachronia",
-    "task": "Take down each dinosaur in Big Game Hunter.",
-    "information": "Take down each dinosaur in Big Game Hunter.",
-    "requirements": "96 Hunter, 76 Slayer",
-    "points": 80
-  },
-  {
-    "id": 524,
-    "locality": "Anachronia",
-    "task": "Get caught by each of the big game creatures once.",
-    "information": "Get caught by each of the Big Game Hunter creatures once.",
-    "requirements": "96 Hunter, 76 Slayer",
-    "points": 80
-  },
-  {
-    "id": 525,
-    "locality": "Anachronia",
-    "task": "Complete a big game encounter without using movement abilities.",
-    "information": "Complete a Big Game Hunter encounter without using movement abilities.",
-    "requirements": "75 Hunter, 55 Slayer",
-    "points": 80
-  },
-  {
-    "id": 526,
-    "locality": "Anachronia",
-    "task": "Defeat Raksha, the Shadow Colossus.",
-    "information": "Defeat Raksha, the Shadow Colossus once.",
-    "requirements": "Completion of Raksha, the Shadow Colossus",
-    "points": 80
-  },
-  {
-    "id": 527,
-    "locality": "Asgarnia: Falador",
-    "task": "Reach 100% respect at the Artisans' Workshop.",
-    "information": "Reach 100% respect at the Artisans' Workshop.",
-    "requirements": "1 Smithing",
-    "points": 80
-  },
-  {
-    "id": 528,
-    "locality": "Asgarnia: Falador",
-    "task": "Complete the task set: Hard Falador.",
-    "information": "Complete the Hard Falador achievements.",
-    "requirements": "See Hard Falador achievements page",
-    "points": 80
-  },
-  {
-    "id": 529,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat any God Wars Dungeon boss 100 times.",
-    "information": "Defeat any God Wars Dungeon boss 100 times.",
-    "requirements": "Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 530,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat any God Wars Dungeon boss 250 times.",
-    "information": "Defeat any God Wars Dungeon boss 250 times.",
-    "requirements": "Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 531,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Commander Zilyana.",
-    "information": "Defeat Commander Zilyana",
-    "requirements": "70 Agility, Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 532,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat General Graardor.",
-    "information": "Defeat General Graardor",
-    "requirements": "70 Strength, Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 533,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat K'ril Tsutsaroth.",
-    "information": "Defeat K'ril Tsutsaroth",
-    "requirements": "70 Constitution, Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 534,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Kree'arra.",
-    "information": "Defeat Kree'arra",
-    "requirements": "70 Ranged, Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 535,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Nex.",
-    "information": "Defeat Nex",
-    "requirements": "70 Agility, 70 Strength, 70 Constitution, 70 Ranged, Partial completion of Troll Stronghold, completion of The Dig Site, frozen key",
-    "points": 80
-  },
-  {
-    "id": 536,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Kree'arra. (100 times)",
-    "information": "Defeat Kree'arra 100 times.",
-    "requirements": "70 Ranged, Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 537,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Assemble any godsword from the God Wars Dungeon.",
-    "information": "Assemble any godsword from the God Wars Dungeon.",
-    "requirements": "80 Smithing and one of 70 Agility, 70 Strength, 70 Constitution, or 70 Ranged",
-    "points": 80
-  },
-  {
-    "id": 538,
-    "locality": "Asgarnia: Port Sarim",
-    "task": "Defeat the Queen Black Dragon.",
-    "information": "Defeat the Queen Black Dragon.",
-    "requirements": "60 Summoning",
-    "points": 80
-  },
-  {
-    "id": 539,
-    "locality": "Asgarnia: Port Sarim",
-    "task": "Defeat the Queen Black Dragon. (100 times)",
-    "information": "Defeat the Queen Black Dragon 100 times.",
-    "requirements": "60 Summoning",
-    "points": 80
-  },
-  {
-    "id": 540,
-    "locality": "Asgarnia: Port Sarim",
-    "task": "Bury some frost dragon bones.",
-    "information": "Bury some frost dragon bones.",
-    "requirements": "85 Dungeoneering",
-    "points": 80
-  },
-  {
-    "id": 541,
-    "locality": "Desert: General",
-    "task": "Defeat the Kalphite King.",
-    "information": "Defeat the Kalphite King.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 542,
-    "locality": "Desert: General",
-    "task": "Defeat the Kalphite King. (100 times)",
-    "information": "Defeat the Kalphite King 100 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 543,
-    "locality": "Desert: General",
-    "task": "Equip a drygore weapon.",
-    "information": "Equip a drygore weapon.",
-    "requirements": "90 Attack",
-    "points": 80
-  },
-  {
-    "id": 544,
-    "locality": "Desert: General",
-    "task": "Become an honorary druid at the Garden of Kharid.",
-    "information": "Purchase the Druid/Druidess title for 50,000 Crux Eqal favour",
-    "requirements": "50 Farming",
-    "points": 80
-  },
-  {
-    "id": 545,
-    "locality": "Desert: General",
-    "task": "Deploy a dreadnip.",
-    "information": "Deploy a dreadnip.",
-    "requirements": "20 of a collection of quests (see Dominion Tower#Requirements), 450 Dominion Tower kills",
-    "points": 80
-  },
-  {
-    "id": 546,
-    "locality": "Desert: General",
-    "task": "Complete the task set: Hard Desert.",
-    "information": "Complete the Hard Desert achievements.",
-    "requirements": "See Hard Desert achievements page",
-    "points": 80
-  },
-  {
-    "id": 547,
-    "locality": "Desert: General",
-    "task": "Defeat Avaryss and Nymora.",
-    "information": "Defeat the Twin Furies.",
-    "requirements": "80 Ranged",
-    "points": 80
-  },
-  {
-    "id": 548,
-    "locality": "Desert: General",
-    "task": "Defeat Gregorovic.",
-    "information": "Defeat Gregorivic.",
-    "requirements": "80 Prayer",
-    "points": 80
-  },
-  {
-    "id": 549,
-    "locality": "Desert: General",
-    "task": "Defeat Vindicta and Gorvek.",
-    "information": "Defeat Vindicta.",
-    "requirements": "80 Attack",
-    "points": 80
-  },
-  {
-    "id": 550,
-    "locality": "Desert: General",
-    "task": "Defeat Helwyr.",
-    "information": "Defeat Helwyr.",
-    "requirements": "80 Magic",
-    "points": 80
-  },
-  {
-    "id": 551,
-    "locality": "Desert: General",
-    "task": "Defeat Avaryss and Nymora. (100 times)",
-    "information": "Defeat the Twin Furies 100 times.",
-    "requirements": "80 Ranged",
-    "points": 80
-  },
-  {
-    "id": 552,
-    "locality": "Desert: General",
-    "task": "Defeat Gregorovic. (100 times)",
-    "information": "Defeat Gregorivic 100 times.",
-    "requirements": "80 Prayer",
-    "points": 80
-  },
-  {
-    "id": 553,
-    "locality": "Desert: General",
-    "task": "Defeat Vindicta and Gorvek. (100 times)",
-    "information": "Defeat Vindicta 100 times.",
-    "requirements": "80 Attack",
-    "points": 80
-  },
-  {
-    "id": 554,
-    "locality": "Desert: General",
-    "task": "Defeat Helwyr. (100 times)",
-    "information": "Defeat Helwyr 100 times.",
-    "requirements": "80 Magic",
-    "points": 80
-  },
-  {
-    "id": 555,
-    "locality": "Desert: General",
-    "task": "Equip a Dragon Rider lance.",
-    "information": "Equip a Dragon Rider lance.",
-    "requirements": "85 Attack",
-    "points": 80
-  },
-  {
-    "id": 556,
-    "locality": "Desert: General",
-    "task": "Equip a wand or orb of the Cywir elders.",
-    "information": "Equip a wand or orb of the Cywir elders.",
-    "requirements": "85 Magic",
-    "points": 80
-  },
-  {
-    "id": 557,
-    "locality": "Desert: General",
-    "task": "Equip a shadow glaive.",
-    "information": "Equip a shadow glaive.",
-    "requirements": "85 Ranged",
-    "points": 80
-  },
-  {
-    "id": 558,
-    "locality": "Desert: General",
-    "task": "Equip a blade of Nymora or Avaryss.",
-    "information": "Equip a blade of Nymora or Avaryss.",
-    "requirements": "85 Attack",
-    "points": 80
-  },
-  {
-    "id": 559,
-    "locality": "Desert: Menaphos",
-    "task": "Slay a combination of 500 corrupted or devourer creatures.",
-    "information": "Slay a combination of 500 corrupted creatures or soul devourers.",
-    "requirements": "88 Slayer, Completion of Icthlarin's Little Helper",
-    "points": 80
-  },
-  {
-    "id": 560,
-    "locality": "Desert: General",
-    "task": "Defeat the Magister.",
-    "information": "Defeat the Magister.",
-    "requirements": "115 Slayer, Key to the Crossing",
-    "points": 80
-  },
-  {
-    "id": 561,
-    "locality": "Desert: General",
-    "task": "Defeat the Magister. (50 times)",
-    "information": "Defeat the Magister 50 times.",
-    "requirements": "115 Slayer, Key to the Crossing",
-    "points": 80
-  },
-  {
-    "id": 562,
-    "locality": "Desert: Menaphos",
-    "task": "Find an Off-hand khopesh of the Kharidian in Shifting Tombs.",
-    "information": "Find an off-hand khopesh of the Kharidian in Shifting Tombs.",
-    "requirements": "At least one of 50 Dungeoneering, 50 Agility, 50 Thieving, or 50 Construction",
-    "points": 80
-  },
-  {
-    "id": 563,
-    "locality": "Desert: General",
-    "task": "Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.",
-    "information": "Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.",
-    "requirements": "81 Thieving, Partial completion of Icthlarin's Little Helper",
-    "points": 80
-  },
-  {
-    "id": 564,
-    "locality": "Desert: General",
-    "task": "Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.",
-    "information": "Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.",
-    "requirements": "91 Thieving, Partial completion of Icthlarin's Little Helper",
-    "points": 80
-  },
-  {
-    "id": 565,
-    "locality": "Desert: Menaphos",
-    "task": "Complete the quest: Beneath Scabaras' Sands.",
-    "information": "Complete Beneath Scabaras' Sands.",
-    "requirements": "See quest page",
-    "points": 80
-  },
-  {
-    "id": 566,
-    "locality": "Desert: General",
-    "task": "Kill a desert strykewyrm wearing a Full Slayer Helm and wielding an ancient staff.",
-    "information": "Kill a desert strykewyrm wearing a full Slayer helm and wielding an ancient staff.",
-    "requirements": "77 Slayer, 50 Magic, 20 Defence, 55 Crafting, Completion of Desert Treasure and Smoking Kills, 400 slayer points to unlock crafting slayer helmets. See also Staff on Stryke.",
-    "points": 80
-  },
-  {
-    "id": 567,
-    "locality": "Desert: General",
-    "task": "Defeat Telos, the Warden.",
-    "information": "Defeat Telos, the Warden.",
-    "requirements": "80 Attack, 80 Prayer, 80 Magic, 80 Ranged",
-    "points": 80
-  },
-  {
-    "id": 568,
-    "locality": "Fremennik: Lunar Isles",
-    "task": "Cast Fertile Soil.",
-    "information": "Cast Fertile Soil.",
-    "requirements": "83 Magic, Completion of Lunar Diplomacy unless tier 6 reached",
-    "points": 80
-  },
-  {
-    "id": 569,
-    "locality": "Fremennik: Mainland",
-    "task": "Build a Gilded Altar.",
-    "information": "Build a gilded altar in your player-owned house's chapel.",
-    "requirements": "75 Construction",
-    "points": 80
-  },
-  {
-    "id": 570,
-    "locality": "Fremennik: Mainland",
-    "task": "Trap a Sabre-Toothed Kyatt.",
-    "information": "Trap a sabre-toothed kyatt.",
-    "requirements": "55 Hunter",
-    "points": 80
-  },
-  {
-    "id": 571,
-    "locality": "Fremennik: Mainland",
-    "task": "Defeat all the Dagannoth Kings without leaving a solo boss instance.",
-    "information": "Defeat all the Dagannoth Kings without leaving a solo boss instance.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 572,
-    "locality": "Fremennik: Mainland",
-    "task": "Equip a Berserker, Warrior, Seers, or Archers Ring.",
-    "information": "Equip a Berserker, Warrior, Seers, or Archers Ring.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 573,
-    "locality": "Fremennik: Mainland",
-    "task": "Use the Special Attack of a Dragon Axe.",
-    "information": "Use the special attack of a dragon hatchet.",
-    "requirements": "60 Attack",
-    "points": 80
-  },
-  {
-    "id": 574,
-    "locality": "Fremennik: Mainland",
-    "task": "Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.",
-    "information": "Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.",
-    "requirements": "25 Defence, Partial completion of The Fremennik Isles",
-    "points": 80
-  },
-  {
-    "id": 575,
-    "locality": "Fremennik: Mainland",
-    "task": "Equip a full set of Skeletal, Spined, or Rockshell armour.",
-    "information": "Equip a full skeletal, spined, or rock-shell armour set.",
-    "requirements": "50 Defence, Completion of The Fremennik Trials",
-    "points": 80
-  },
-  {
-    "id": 576,
-    "locality": "Fremennik: Mainland",
-    "task": "Collect Miscellania Resources at Full Approval.",
-    "information": "Collect from Managing Miscellania with a 100% approval rating.",
-    "requirements": "Completion of Throne of Miscellania",
-    "points": 80
-  },
-  {
-    "id": 577,
-    "locality": "Fremennik: Mainland",
-    "task": "Travel to the island of Ungael.",
-    "information": "Travel to the island of Ungael.",
-    "requirements": "Partial completion of Ancient Awakening",
-    "points": 80
-  },
-  {
-    "id": 578,
-    "locality": "Fremennik: Mainland",
-    "task": "Adopt a baby yak.",
-    "information": "Obtain an unchecked/baby Fremennik yak.",
-    "requirements": "71 Farming, Partial completion of The Fremennik Isles",
-    "points": 80
-  },
-  {
-    "id": 579,
-    "locality": "Fremennik: Mainland",
-    "task": "Catch 50 Azure Skillchompas.",
-    "information": "Catch 50 Azure Skillchompas.",
-    "requirements": "68 Hunter",
-    "points": 80
-  },
-  {
-    "id": 580,
-    "locality": "Fremennik: Mainland",
-    "task": "Mine 10 Banite Ore north of Rellekka.",
-    "information": "Mine 10 Banite ore in the arctic (azure) habitat mine.",
-    "requirements": "80 Mining",
-    "points": 80
-  },
-  {
-    "id": 581,
-    "locality": "Fremennik: Mainland",
-    "task": "Smith a piece of Bane equipment to +4 in Rellekka.",
-    "information": "Upgrade a piece of Bane equipment to +4 in Rellekka.",
-    "requirements": "80 Smithing, Completion of The Fremennik Trials",
-    "points": 80
-  },
-  {
-    "id": 582,
-    "locality": "Fremennik: Mainland",
-    "task": "Use a Crystal triskelion key to obtain some treasures.",
-    "information": "Use a Crystal triskelion to obtain some treasures.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 583,
-    "locality": "Fremennik: Mainland",
-    "task": "Create a Catherby Teleport Tablet.",
-    "information": "Create a Catherby Teleport Tablet.",
-    "requirements": "87 Magic, 67 Construction, Completion of Lunar Diplomacy unless tier 6 reached",
-    "points": 80
-  },
-  {
-    "id": 584,
-    "locality": "Fremennik: Mainland",
-    "task": "Gather a seed from an Aquanite using Seedicide.",
-    "information": "Gather a seed from an aquanite using Seedicide.",
-    "requirements": "78 Slayer, 2,200 renown, 10,000 beans, 360 thaler, or tier 4 reached",
-    "points": 80
-  },
-  {
-    "id": 585,
-    "locality": "Fremennik: Mainland",
-    "task": "Complete the task set: Hard Fremennik.",
-    "information": "Complete the Hard Fremennik achievements.",
-    "requirements": "See Hard Fremennik achievements page",
-    "points": 80
-  },
-  {
-    "id": 586,
-    "locality": "Global",
-    "task": "Reach at least level 50 in all non-elite skills.",
-    "information": "Reach at least level 50 in all non-elite skills.",
-    "requirements": "All skills except Invention at level 50",
-    "points": 80
-  },
-  {
-    "id": 587,
-    "locality": "Global",
-    "task": "Reach combat level 100.",
-    "information": "Reach combat level 100.",
-    "requirements": "100 Combat",
-    "points": 80
-  },
-  {
-    "id": 588,
-    "locality": "Global",
-    "task": "Reach total level 1000.",
-    "information": "Reach total level 1000. This task is currently bugged and may complete before you have reached 1000 total levels",
-    "requirements": "1000 Skills Total level",
-    "points": 80
-  },
-  {
-    "id": 589,
-    "locality": "Global",
-    "task": "Mine any ore 1000 times.",
-    "information": "Mine any ore 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 590,
-    "locality": "Global",
-    "task": "Chop any tree 1000 times.",
-    "information": "Chop any tree 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 591,
-    "locality": "Global",
-    "task": "Burn any logs 1000 times.",
-    "information": "Burn any logs 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 592,
-    "locality": "Global",
-    "task": "Catch any fish 1000 times.",
-    "information": "Catch any fish 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 593,
-    "locality": "Global",
-    "task": "Harvest any memory from a wisp 1000 times.",
-    "information": "Harvest any memory from a wisp 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 594,
-    "locality": "Global",
-    "task": "Pickpocket anyone 1000 times.",
-    "information": "Pickpocket anyone 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 595,
-    "locality": "Global",
-    "task": "Unlock all of the Lodestones.",
-    "information": "Unlock all of the Lodestones.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 596,
-    "locality": "Global",
-    "task": "Make 1,000 potions of any kind.",
-    "information": "Make 1,000 potions of any kind.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 597,
-    "locality": "Global",
-    "task": "Clean 1,000 of any herb.",
-    "information": "Clean 1,000 of any herb.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 598,
-    "locality": "Global",
-    "task": "Complete 50 laps of any Agility course.",
-    "information": "Complete 50 laps of any Agility course.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 599,
-    "locality": "Global",
-    "task": "Complete 100 laps of any Agility course.",
-    "information": "Complete 100 laps of any Agility course.",
-    "requirements": "N/A",
-    "points": 80
-  }
-,
-  {
-    "id": 600,
-    "locality": "Global",
-    "task": "Smith 50 of any metal weapon or armour piece.",
-    "information": "Smith 50 of any metal weapon or armour piece.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 601,
-    "locality": "Global",
-    "task": "Smith 100 of any metal weapon or armour piece.",
-    "information": "Smith 100 of any metal weapon or armour piece.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 602,
-    "locality": "Global",
-    "task": "Cook 1,000 fish.",
-    "information": "Cook 1,000 fish.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 603,
-    "locality": "Global",
-    "task": "Catch 1,000 Hunter creatures.",
-    "information": "Catch 1,000 Hunter creatures.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 604,
-    "locality": "Global",
-    "task": "Complete 15 Slayer tasks.",
-    "information": "Complete 15 Slayer tasks.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 605,
-    "locality": "Global",
-    "task": "Complete 150 Easy clue scrolls.",
-    "information": "Complete 150 Easy clue scrolls.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 606,
-    "locality": "Global",
-    "task": "Collect 50 unique items for the General clue rewards collection log.",
-    "information": "Collect 50 unique items for the General clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 607,
-    "locality": "Global",
-    "task": "Craft 10,000 runes.",
-    "information": "Craft 10,000 runes.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 608,
-    "locality": "Global",
-    "task": "Craft 20,000 runes.",
-    "information": "Craft 20,000 runes.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 609,
-    "locality": "Global",
-    "task": "Obtain 75 Quest Points.",
-    "information": "Obtain 75 quest points.",
-    "requirements": "75 Quest points",
-    "points": 80
-  },
-  {
-    "id": 610,
-    "locality": "Global",
-    "task": "Obtain 100 Quest Points.",
-    "information": "Obtain 100 quest points.",
-    "requirements": "100 Quest points",
-    "points": 80
-  },
-  {
-    "id": 611,
-    "locality": "Global",
-    "task": "Complete 150 Medium clue scrolls.",
-    "information": "Complete 150 Medium clue scrolls.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 612,
-    "locality": "Global",
-    "task": "Complete 75 Hard clue scrolls.",
-    "information": "Complete 75 Hard clue scrolls.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 613,
-    "locality": "Global",
-    "task": "Complete 150 Hard clue scrolls.",
-    "information": "Complete 150 Hard clue scrolls.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 614,
-    "locality": "Global",
-    "task": "Collect 25 unique items for the Easy clue rewards collection log.",
-    "information": "Collect 25 unique items for the Easy clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 615,
-    "locality": "Global",
-    "task": "Collect 50 unique items for the Easy clue rewards collection log.",
-    "information": "Collect 50 unique items for the Easy clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 616,
-    "locality": "Global",
-    "task": "Collect 25 unique items for the Medium clue rewards collection log.",
-    "information": "Collect 25 unique items for the Medium clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 617,
-    "locality": "Global",
-    "task": "Collect 50 unique items for the Medium clue rewards collection log.",
-    "information": "Collect 50 unique items for the Medium clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 618,
-    "locality": "Global",
-    "task": "Collect 10 unique items for the Hard clue rewards collection log.",
-    "information": "Collect 10 unique items for the Hard clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 619,
-    "locality": "Global",
-    "task": "Collect 25 unique items for the Hard clue rewards collection log.",
-    "information": "Collect 25 unique items for the Hard clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 620,
-    "locality": "Global",
-    "task": "Equip any Dragon mask.",
-    "information": "Equip any Dragon mask.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 621,
-    "locality": "Global",
-    "task": "Make any Perfect Juju Potion.",
-    "information": "Make any Perfect Juju Potion.",
-    "requirements": "75 Herblore",
-    "points": 80
-  },
-  {
-    "id": 622,
-    "locality": "Global",
-    "task": "Make 15 Antifire Potions.",
-    "information": "Make 15 Antifire Potions.",
-    "requirements": "69 Herblore",
-    "points": 80
-  },
-  {
-    "id": 623,
-    "locality": "Global",
-    "task": "Clean 50 Grimy Cadantine.",
-    "information": "Clean 50 Grimy Cadantine.",
-    "requirements": "65 Herblore",
-    "points": 80
-  },
-  {
-    "id": 624,
-    "locality": "Global",
-    "task": "Clean 100 Grimy Lantadyme.",
-    "information": "Clean 100 Grimy Lantadyme.",
-    "requirements": "67 Herblore",
-    "points": 80
-  },
-  {
-    "id": 625,
-    "locality": "Global",
-    "task": "Clean 100 Dwarf Weed.",
-    "information": "Clean 100 Dwarf Weed.",
-    "requirements": "70 Herblore",
-    "points": 80
-  },
-  {
-    "id": 626,
-    "locality": "Global",
-    "task": "Clean 100 Arbuck.",
-    "information": "Clean 100 Arbuck.",
-    "requirements": "77 Herblore, 77 Farming",
-    "points": 80
-  },
-  {
-    "id": 627,
-    "locality": "Global",
-    "task": "Equip a Yew shortbow.",
-    "information": "Equip a Yew shortbow.",
-    "requirements": "40 Ranged",
-    "points": 80
-  },
-  {
-    "id": 628,
-    "locality": "Global",
-    "task": "Equip a Magic shortbow.",
-    "information": "Equip a Magic shortbow.",
-    "requirements": "50 Ranged",
-    "points": 80
-  },
-  {
-    "id": 629,
-    "locality": "Global",
-    "task": "Fletch some Broad Arrows or Bolts.",
-    "information": "Fletch some Broad Arrows or Bolts.",
-    "requirements": "52 Fletching, Completion of Smoking Kills, 300 slayer points",
-    "points": 80
-  },
-  {
-    "id": 630,
-    "locality": "Global",
-    "task": "Fletch 100 Yew shortbows (unstrung).",
-    "information": "Fletch 100 Yew shortbows (unstrung).",
-    "requirements": "65 Fletching",
-    "points": 80
-  },
-  {
-    "id": 631,
-    "locality": "Global",
-    "task": "Fletch 100 Yew stocks.",
-    "information": "Fletch 100 Yew stocks.",
-    "requirements": "69 Fletching",
-    "points": 80
-  },
-  {
-    "id": 632,
-    "locality": "Global",
-    "task": "Fletch a Rune Crossbow.",
-    "information": "Fletch a Rune Crossbow.",
-    "requirements": "69 Fletching",
-    "points": 80
-  },
-  {
-    "id": 633,
-    "locality": "Global",
-    "task": "Fletch 35 or more arrow shafts from a single log.",
-    "information": "Fletch 35 or more Arrow shafts from a single log.",
-    "requirements": "60 Fletching, Yew logs or higher",
-    "points": 80
-  },
-  {
-    "id": 634,
-    "locality": "Global",
-    "task": "Fletch 500 Adamant arrows.",
-    "information": "Fletch 500 Adamant arrows.",
-    "requirements": "60 Fletching",
-    "points": 80
-  },
-  {
-    "id": 635,
-    "locality": "Global",
-    "task": "Fletch 750 Rune arrows.",
-    "information": "Fletch 750 Rune arrows.",
-    "requirements": "75 Fletching",
-    "points": 80
-  },
-  {
-    "id": 636,
-    "locality": "Global",
-    "task": "Fletch 75 Onyx bolts.",
-    "information": "Fletch 75 Onyx bolts.",
-    "requirements": "73 Fletching",
-    "points": 80
-  },
-  {
-    "id": 637,
-    "locality": "Global",
-    "task": "Equip a Rune Ceremonial Sword.",
-    "information": "Equip a Rune ceremonial sword.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 638,
-    "locality": "Global",
-    "task": "Equip a full set of the Blacksmith's outfit.",
-    "information": "Equip a full set of the Blacksmith's outfit.",
-    "requirements": "Total of 250% Artisans' Workshop respect, unless gained from ceremonial swords",
-    "points": 80
-  },
-  {
-    "id": 639,
-    "locality": "Global",
-    "task": "Power up the Artisan's Workshop with a Luminite Injector.",
-    "information": "Power up the Artisan's Workshop with a Luminite Injector.",
-    "requirements": "100% Artisans' Workshop respect",
-    "points": 80
-  },
-  {
-    "id": 640,
-    "locality": "Global",
-    "task": "Mine 50 Orichalcite Ore.",
-    "information": "Mine 50 Orichalcite Ore.",
-    "requirements": "60 Mining",
-    "points": 80
-  },
-  {
-    "id": 641,
-    "locality": "Global",
-    "task": "Mine 50 Drakolith.",
-    "information": "Mine 50 Drakolith.",
-    "requirements": "60 Mining",
-    "points": 80
-  },
-  {
-    "id": 642,
-    "locality": "Global",
-    "task": "Mine 60 Necrite Ore.",
-    "information": "Mine 60 Necrite Ore.",
-    "requirements": "70 Mining",
-    "points": 80
-  },
-  {
-    "id": 643,
-    "locality": "Global",
-    "task": "Mine 60 Phasmatite.",
-    "information": "Mine 60 Phasmatite.",
-    "requirements": "70 Mining",
-    "points": 80
-  },
-  {
-    "id": 644,
-    "locality": "Global",
-    "task": "Harvest 20 Grimy Kwuarm.",
-    "information": "Harvest 20 Grimy Kwuarm.",
-    "requirements": "56 Farming",
-    "points": 80
-  },
-  {
-    "id": 645,
-    "locality": "Global",
-    "task": "Catch 100 Shark.",
-    "information": "Catch 100 Shark.",
-    "requirements": "76 Fishing",
-    "points": 80
-  },
-  {
-    "id": 646,
-    "locality": "Global",
-    "task": "Catch 100 Green Blubber Jellyfish.",
-    "information": "Catch 100 Green Blubber Jellyfish.",
-    "requirements": "68 Fishing",
-    "points": 80
-  },
-  {
-    "id": 647,
-    "locality": "Global",
-    "task": "Catch a Spirit Impling.",
-    "information": "Catch a Spirit Impling.",
-    "requirements": "54 Hunter",
-    "points": 80
-  },
-  {
-    "id": 648,
-    "locality": "Global",
-    "task": "Equip a Slayer helmet.",
-    "information": "Equip a Slayer helmet.",
-    "requirements": "55 Crafting, 35 Slayer, Completion of Smoking Kills, 400 slayer points Note: While it does not say it explicitly, this task requires the Full slayer helmet and therefore has an implicit requirement of 77 Slayer for Desert Strykewyrms",
-    "points": 80
-  },
-  {
-    "id": 649,
-    "locality": "Global",
-    "task": "Complete a Soul Reaper task.",
-    "information": "Complete a Soul Reaper task.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 650,
-    "locality": "Global",
-    "task": "Complete 5 Soul Reaper tasks.",
-    "information": "Complete 5 Soul Reaper tasks.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 651,
-    "locality": "Global",
-    "task": "Equip a full set of Orikalkum armour.",
-    "information": "Equip a full set of Orikalkum armour.",
-    "requirements": "60 Smithing, 60 Defence",
-    "points": 80
-  },
-  {
-    "id": 652,
-    "locality": "Global",
-    "task": "Equip a full set of Necronium armour.",
-    "information": "Equip a full set of Necronium armour.",
-    "requirements": "70 Smithing, 70 Defence",
-    "points": 80
-  },
-  {
-    "id": 653,
-    "locality": "Global",
-    "task": "Equip a full set of Black Dragonhide armour.",
-    "information": "Equip a full set of Black Dragonhide armour.",
-    "requirements": "60 Defence, 60 Crafting unless getting the pieces as a drop",
-    "points": 80
-  },
-  {
-    "id": 654,
-    "locality": "Global",
-    "task": "Equip a full set of Royal Dragonhide armour.",
-    "information": "Equip a full set of Royal Dragonhide armour.",
-    "requirements": "65 Defence, 65 Crafting",
-    "points": 80
-  },
-  {
-    "id": 655,
-    "locality": "Global",
-    "task": "Cast a Wave spell.",
-    "information": "Cast a Wave spell.",
-    "requirements": "62 Magic",
-    "points": 80
-  },
-  {
-    "id": 656,
-    "locality": "Global",
-    "task": "Burn 75 Yew logs.",
-    "information": "Burn 75 Yew logs.",
-    "requirements": "60 Firemaking",
-    "points": 80
-  },
-  {
-    "id": 657,
-    "locality": "Global",
-    "task": "Unlock the Ring of Quests from May's Quest Caravan.",
-    "information": "Unlock the Ring of Quests from May's Quest Caravan.",
-    "requirements": "75 Quest points",
-    "points": 80
-  },
-  {
-    "id": 658,
-    "locality": "Global",
-    "task": "Complete 250 clues of any tier.",
-    "information": "Complete 250 clues of any tier.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 659,
-    "locality": "Global",
-    "task": "Complete 500 clues of any tier.",
-    "information": "Complete 500 clues of any tier.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 660,
-    "locality": "Global",
-    "task": "Complete an Elite clue scroll.",
-    "information": "Complete an Elite clue scroll.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 661,
-    "locality": "Global",
-    "task": "Complete 25 Elite clue scrolls.",
-    "information": "Complete 25 Elite clue scrolls.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 662,
-    "locality": "Global",
-    "task": "Complete a Master clue scroll.",
-    "information": "Complete a Master clue scroll.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 663,
-    "locality": "Global",
-    "task": "Collect 5 unique items for the Elite clue rewards collection log.",
-    "information": "Collect 5 unique items for the Elite clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 664,
-    "locality": "Global",
-    "task": "Collect 10 unique items for the Elite clue rewards collection log.",
-    "information": "Collect 10 unique items for the Elite clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 665,
-    "locality": "Global",
-    "task": "Collect 20 unique items for the Elite clue rewards collection log.",
-    "information": "Collect 20 unique items for the Elite clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 666,
-    "locality": "Global",
-    "task": "Collect 5 unique items for the Master clue rewards collection log.",
-    "information": "Collect 5 unique items for the Master clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 667,
-    "locality": "Global",
-    "task": "Catch a Manta ray.",
-    "information": "Catch a raw manta ray.",
-    "requirements": "81 Fishing (or 68 Fishing via swarm fishing)",
-    "points": 80
-  },
-  {
-    "id": 668,
-    "locality": "Global",
-    "task": "Reach level 70 in any skill.",
-    "information": "Reach level 70 in any skill.",
-    "requirements": "Any skill at level 70",
-    "points": 80
-  },
-  {
-    "id": 669,
-    "locality": "Global",
-    "task": "Reach level 80 in any skill.",
-    "information": "Reach level 80 in any skill.",
-    "requirements": "Any skill at level 80",
-    "points": 80
-  },
-  {
-    "id": 670,
-    "locality": "Global",
-    "task": "Reach at least level 40 in all non-elite skills.",
-    "information": "Reach at least level 40 in all non-elite skills.",
-    "requirements": "All skills except Invention at level 40",
-    "points": 80
-  },
-  {
-    "id": 671,
-    "locality": "Global",
-    "task": "Reach at least level 60 in all non-elite skills.",
-    "information": "Reach at least level 60 in all non-elite skills.",
-    "requirements": "All skills except Invention at level 60",
-    "points": 80
-  },
-  {
-    "id": 672,
-    "locality": "Global",
-    "task": "Reach at least level 70 in all non-elite skills.",
-    "information": "Reach at least level 70 in all non-elite skills.",
-    "requirements": "All skills except Invention at level 70",
-    "points": 80
-  },
-  {
-    "id": 673,
-    "locality": "Kandarin: Ardougne",
-    "task": "Throw coins into the deep sea whirlpool.",
-    "information": "Throw some gold coins into the Whirlpool at the Deep Sea Fishing platform.",
-    "requirements": "68 Fishing",
-    "points": 80
-  },
-  {
-    "id": 674,
-    "locality": "Kandarin: Ardougne",
-    "task": "Solve the Archaeology mystery: Leap of Faith.",
-    "information": "Solve the Leap of Faith Archaeology mystery.",
-    "requirements": "70 Archaeology",
-    "points": 80
-  },
-  {
-    "id": 675,
-    "locality": "Kandarin: Ardougne",
-    "task": "Collect all breeds of chinchompa at the Player Owned Farm.",
-    "information": "Breed all types of Chinchompas.",
-    "requirements": "54 Farming, 20 Construction, 97 Hunter to catch crystal chinchompas.",
-    "points": 80
-  },
-  {
-    "id": 676,
-    "locality": "Kandarin: Ardougne",
-    "task": "Equip one piece of the Fishing outfit.",
-    "information": "Equip one piece of the Fishing outfit.",
-    "requirements": "140 fishing tokens",
-    "points": 80
-  },
-  {
-    "id": 677,
-    "locality": "Kandarin: Ardougne",
-    "task": "Defeat the Penance Queen.",
-    "information": "Defeat the Penance Queen.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 678,
-    "locality": "Kandarin: Ardougne",
-    "task": "Pickpocket a Hero.",
-    "information": "Pickpocket a Hero.",
-    "requirements": "80 Thieving",
-    "points": 80
-  },
-  {
-    "id": 679,
-    "locality": "Kandarin: Ardougne",
-    "task": "Catch 50 Red Chinchompas in Kandarin.",
-    "information": "Catch 50 carnivorous chinchompas in Kandarin.",
-    "requirements": "63 Hunter",
-    "points": 80
-  },
-  {
-    "id": 680,
-    "locality": "Kandarin: Feldip Hills",
-    "task": "Equip an Ogre Expert hat.",
-    "information": "Equip an Ogre Expert hat.",
-    "requirements": "1,000 chompy bird kills",
-    "points": 80
-  },
-  {
-    "id": 681,
-    "locality": "Global",
-    "task": "Catch a Monkfish.",
-    "information": "Catch a raw monkfish.",
-    "requirements": "62 Fishing, Completion of Swan Song or from swarm fishing",
-    "points": 80
-  },
-  {
-    "id": 682,
-    "locality": "Global",
-    "task": "Recover all data for one memory-storage bot in the Hall of Memories.",
-    "information": "Recover all data for memory-storage bot (Aagi) in the Hall of Memories.",
-    "requirements": "70 Divination",
-    "points": 80
-  },
-  {
-    "id": 683,
-    "locality": "Kandarin: Seers Village",
-    "task": "Use the Piety Prayer.",
-    "information": "Use the Piety Prayer.",
-    "requirements": "70 Prayer, 70 Defence, Completion of Knight Waves training ground",
-    "points": 80
-  },
-  {
-    "id": 684,
-    "locality": "Kandarin: Ardougne",
-    "task": "Complete the task set: Hard Ardougne.",
-    "information": "Complete the Hard Ardougne Diary.",
-    "requirements": "See Hard Ardougne achievements page",
-    "points": 80
-  },
-  {
-    "id": 685,
-    "locality": "Karamja",
-    "task": "Use the stepping stone across the river in Shilo village.",
-    "information": "Use the Stepping Stones Agility Shortcut in Shilo Village.",
-    "requirements": "74 Agility, Completion of Shilo Village",
-    "points": 80
-  },
-  {
-    "id": 686,
-    "locality": "Karamja",
-    "task": "Equip a full set of Obsidian armour.",
-    "information": "Equip a full set of Obsidian armour.",
-    "requirements": "60 Defence, Completion of The Brink of Extinction, 80 Smithing",
-    "points": 80
-  },
-  {
-    "id": 687,
-    "locality": "Karamja",
-    "task": "Equip a Red Topaz Machete.",
-    "information": "Equip a Red Topaz Machete.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 688,
-    "locality": "Karamja",
-    "task": "Find a Gout Tuber.",
-    "information": "Find a Gout Tuber.",
-    "requirements": "10 Woodcutting, Completion of Jungle Potion",
-    "points": 80
-  },
-  {
-    "id": 689,
-    "locality": "Karamja",
-    "task": "Defeat TzTok-Jad.",
-    "information": "Defeat TzTok-Jad once.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 690,
-    "locality": "Karamja",
-    "task": "Defeat TzTok-Jad.",
-    "information": "Defeat TzTok-Jad 25 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 691,
-    "locality": "Karamja",
-    "task": "Use your fire cape on TzTok-Jad before defeating them.",
-    "information": "Use your fire cape on TzTok-Jad before defeating them.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 692,
-    "locality": "Karamja",
-    "task": "Equip a Fire Cape.",
-    "information": "Equip a Fire Cape.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 693,
-    "locality": "Karamja",
-    "task": "Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.",
-    "information": "Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.",
-    "requirements": "60 Defence and one of 60 Attack, 60 Strength, 60 Magic, or 60 Ranged, Completion of The Brink of Extinction",
-    "points": 80
-  },
-  {
-    "id": 694,
-    "locality": "Karamja",
-    "task": "Repair the fairy ring inside the Kharazi jungle.",
-    "information": "Repair the fairy ring inside the Kharazi jungle.",
-    "requirements": "Partial completion of Legends' Quest, 5 bittercap mushrooms",
-    "points": 80
-  },
-  {
-    "id": 695,
-    "locality": "Karamja",
-    "task": "Access the Gemstone cavern.",
-    "information": "Access the Gemstone cavern.",
-    "requirements": "Hard Karamja achievements and either an uncut dragonstone or a gemstone dragon Slayer task (requires 95 Slayer)",
-    "points": 80
-  },
-  {
-    "id": 696,
-    "locality": "Karamja",
-    "task": "Catch a Draconic jadinko at Herblore Habitat.",
-    "information": "Catch a Draconic jadinko at Herblore Habitat.",
-    "requirements": "80 Hunter",
-    "points": 80
-  },
-  {
-    "id": 697,
-    "locality": "Karamja",
-    "task": "Craft a Bolas.",
-    "information": "Craft a Bolas.",
-    "requirements": "87 Fletching, 80 Slayer",
-    "points": 80
-  },
-  {
-    "id": 698,
-    "locality": "Karamja",
-    "task": "Complete the task set: Hard Karamja.",
-    "information": "Complete the hard Karamja Diary.",
-    "requirements": "See Hard Karamja achievements page",
-    "points": 80
-  },
-  {
-    "id": 699,
-    "locality": "Karamja",
-    "task": "Collect 60 Agility Arena tickets from the Brimhaven Agility Arena.",
-    "information": "Receive 60 Agility Arena Tickets With No Mistakes.",
-    "requirements": "N/A",
-    "points": 80
-  }
-,
-  {
-    "id": 700,
-    "locality": "Karamja",
-    "task": "Defeat TzTok-Jad in less than 45:00.",
-    "information": "Defeat TzTok-Jad in less than 45:00.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 701,
-    "locality": "Karamja",
-    "task": "Complete the Fight Kiln.",
-    "information": "Complete the Fight Kiln.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape",
-    "points": 80
-  },
-  {
-    "id": 702,
-    "locality": "Karamja",
-    "task": "Equip a TokHaar-Kal-Ket.",
-    "information": "Equip a TokHaar-Kal-Ket.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape (once)",
-    "points": 80
-  },
-  {
-    "id": 703,
-    "locality": "Karamja",
-    "task": "Equip a TokHaar-Kal-Xil.",
-    "information": "Equip a TokHaar-Kal-Xil.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape (once)",
-    "points": 80
-  },
-  {
-    "id": 704,
-    "locality": "Karamja",
-    "task": "Equip a TokHaar-Kal-Mej.",
-    "information": "Equip a TokHaar-Kal-Mej.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape (once)",
-    "points": 80
-  },
-  {
-    "id": 705,
-    "locality": "Karamja",
-    "task": "Equip a TokHaar-Kal-Mor.",
-    "information": "Equip a TokHaar-Kal-Mor.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape (once)",
-    "points": 80
-  },
-  {
-    "id": 706,
-    "locality": "Karamja",
-    "task": "Complete the Fight Kiln and collect an uncut onyx.",
-    "information": "Complete the Fight Kiln and collect an uncut onyx.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape (once)",
-    "points": 80
-  },
-  {
-    "id": 707,
-    "locality": "Karamja",
-    "task": "Complete all TzTok-Jad combat achievements.",
-    "information": "Complete all TzTok-Jad combat achievements.",
-    "requirements": "See TzTok-Jad achievements page",
-    "points": 80
-  },
-  {
-    "id": 708,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Siphon from a death esswraith in the RuneSpan.",
-    "information": "Siphon from a death esswraith in the RuneSpan.",
-    "requirements": "66 Runecrafting",
-    "points": 80
-  },
-  {
-    "id": 709,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Obtain the Massive Pouch from the RuneSpan.",
-    "information": "Obtain the massive pouch from the RuneSpan.",
-    "requirements": "90 Runecrafting, 1,000 Runespan points",
-    "points": 80
-  },
-  {
-    "id": 710,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Equip the full Master Runecrafter skilling outfit.",
-    "information": "Equip the full master runecrafter robes set.",
-    "requirements": "50 Runecrafting, 60,000 Runecrafting guild tokens, 16,000 Runespan points, or 2,000 thaler",
-    "points": 80
-  },
-  {
-    "id": 711,
-    "locality": "Misthalin: Edgeville",
-    "task": "Complete the task set: Hard Varrock.",
-    "information": "Complete all of the Hard Varrock achievements and claim rewards from Vannaka in Edgeville.",
-    "requirements": "See Hard Varrock achievements page",
-    "points": 80
-  },
-  {
-    "id": 712,
-    "locality": "Misthalin: Edgeville",
-    "task": "Make a waka canoe near Edgeville.",
-    "information": "Make a waka canoe near Edgeville.",
-    "requirements": "57 Woodcutting",
-    "points": 80
-  },
-  {
-    "id": 713,
-    "locality": "Misthalin: Edgeville",
-    "task": "Chop down the Edgeville elder tree.",
-    "information": "Chop down the Edgeville elder tree.",
-    "requirements": "90 Woodcutting",
-    "points": 80
-  },
-  {
-    "id": 714,
-    "locality": "Misthalin: Fort Forinthry",
-    "task": "Upgrade the workshop in Fort Forinthry to Tier 3.",
-    "information": "Upgrade the workshop in Fort Forinthry to tier 3.",
-    "requirements": "75 Construction, Completion of New Foundations",
-    "points": 80
-  },
-  {
-    "id": 715,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Enter Zanaris via Lumbridge Swamp.",
-    "information": "Enter Zanaris via Lumbridge Swamp.",
-    "requirements": "Partial completion of Lost City",
-    "points": 80
-  },
-  {
-    "id": 716,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Complete the task set: Hard Lumbridge.",
-    "information": "Complete all Hard Tasks in Lumbridge and claim rewards from Ned in Draynor Village.",
-    "requirements": "See Hard Lumbridge achievements page",
-    "points": 80
-  },
-  {
-    "id": 717,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Unlock the Bladed Dive ability from Shattered Worlds.",
-    "information": "Unlock the Bladed Dive ability from Shattered Worlds.",
-    "requirements": "63,000,000 shattered anima",
-    "points": 80
-  },
-  {
-    "id": 718,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Smith a mithril platebody on the anvil in the jailhouse sewers.",
-    "information": "Smith a mithril platebody on the anvil in the jailhouse sewers.",
-    "requirements": "30 Smithing",
-    "points": 80
-  },
-  {
-    "id": 719,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Fully grow a magic tree in Lumbridge.",
-    "information": "Fully grow a magic tree in Lumbridge.",
-    "requirements": "75 Farming",
-    "points": 80
-  },
-  {
-    "id": 720,
-    "locality": "Misthalin: City of Um",
-    "task": "Defeat Hermod, the Spirit of War.",
-    "information": "Defeat Hermod, the Spirit of War once.",
-    "requirements": "Completion of The Spirit of War",
-    "points": 80
-  },
-  {
-    "id": 721,
-    "locality": "Misthalin: City of Um",
-    "task": "Defeat Hermod, the Spirit of War.",
-    "information": "Defeat Hermod, the Spirit of War 100 times.",
-    "requirements": "Completion of The Spirit of War",
-    "points": 80
-  },
-  {
-    "id": 722,
-    "locality": "Misthalin: City of Um",
-    "task": "Rest whilst listening to the Dead Beats in the City of Um.",
-    "information": "Rest whilst listening to the Dead Beats in the City of Um.",
-    "requirements": "Completion of That Old Black Magic",
-    "points": 80
-  },
-  {
-    "id": 723,
-    "locality": "Misthalin: City of Um",
-    "task": "Smelt a necronium bar at the smithy in the City of Um.",
-    "information": "Smelt a necronium bar at the smithy in the City of Um.",
-    "requirements": "70 Smithing, Partial completion of Necromancy!",
-    "points": 80
-  },
-  {
-    "id": 724,
-    "locality": "Misthalin: City of Um",
-    "task": "Create a passing bracelet, performing each step in the City of Um.",
-    "information": "Create a passing bracelet, performing each step in the City of Um.",
-    "requirements": "60 Necromancy for bar, 79 Crafting, 68 Magic, Ensouled bar, moonstone, runes for Lvl-5 Enchant. The moonstone is most easily obtained from completing Housing of Parliament, which requires 54 Necromancy.",
-    "points": 80
-  },
-  {
-    "id": 725,
-    "locality": "Misthalin: City of Um",
-    "task": "Catch a ghostly impling while wearing a full set of ghostly robes.",
-    "information": "Catch a ghostly impling while wearing a full set of ghostly robes.",
-    "requirements": "68 Hunter, Completion of The Curse of Zaros (miniquest)",
-    "points": 80
-  },
-  {
-    "id": 726,
-    "locality": "Misthalin: City of Um",
-    "task": "Upgrade a set of Death Skull equipment to tier 70.",
-    "information": "Upgrade a set of Death Skull equipment to tier 70.",
-    "requirements": "70 Necromancy, Completion of The Spirit of War. See also Kili's Knowledge V.",
-    "points": 80
-  },
-  {
-    "id": 727,
-    "locality": "Misthalin: City of Um",
-    "task": "Complete a Powerful Communion ritual.",
-    "information": "Complete a powerful communion ritual.",
-    "requirements": "90 Necromancy",
-    "points": 80
-  },
-  {
-    "id": 728,
-    "locality": "Misthalin: City of Um",
-    "task": "Conjure an undead army at the City of Um ritual site.",
-    "information": "Conjure an undead army at the City of Um ritual site.",
-    "requirements": "99 Necromancy, Conjure Undead Army unlocked in the Well of Souls",
-    "points": 80
-  },
-  {
-    "id": 729,
-    "locality": "Misthalin: Varrock",
-    "task": "Obtain a new set of Family Crest gauntlets from Dimintheis.",
-    "information": "Obtain a new set of Family Crest gauntlets from Dimintheis.",
-    "requirements": "Completion of Family Crest",
-    "points": 80
-  },
-  {
-    "id": 730,
-    "locality": "Misthalin: Varrock",
-    "task": "Talk to Romily Weaklax and give him a wild pie.",
-    "information": "Talk to Romily Weaklax and give him a wild pie.",
-    "requirements": "85 Cooking to make it from scratch, or 50 Hunter to get it as a rare drop from eclectic implings",
-    "points": 80
-  },
-  {
-    "id": 731,
-    "locality": "Misthalin: Varrock",
-    "task": "Harness the power of three relics at once.",
-    "information": "Activate 3 Archaeology relics at once",
-    "requirements": "25 Archaeology, A Ring of Luck to unlock the Hand of Glory relic.",
-    "points": 80
-  },
-  {
-    "id": 732,
-    "locality": "Misthalin: Varrock",
-    "task": "Mine 50 Dark Animica from the Empty Throne Room.",
-    "information": "Mine 50 dark animica from the Empty Throne Room mine.",
-    "requirements": "90 Mining",
-    "points": 80
-  },
-  {
-    "id": 733,
-    "locality": "Misthalin: Varrock",
-    "task": "Defeat Kerapac, the bound.",
-    "information": "Defeat Kerapac, the bound once.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 734,
-    "locality": "Misthalin: Varrock",
-    "task": "Defeat the Arch-Glacor.",
-    "information": "Defeat the Arch-Glacor.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 735,
-    "locality": "Misthalin: City of Um",
-    "task": "Defeat Nakatra, Devourer Eternal.",
-    "information": "Defeat Nakatra, Devourer Eternal.",
-    "requirements": "Completion of Necromancy!, completion of Soul Searching",
-    "points": 80
-  },
-  {
-    "id": 736,
-    "locality": "Misthalin: City of Um",
-    "task": "Cleanse the Gate of Elidinis.",
-    "information": "Cleanse the Gate of Elidinis.",
-    "requirements": "Completion of Ode of the Devourer (or Soul Searching if tier 4 reached)",
-    "points": 80
-  },
-  {
-    "id": 737,
-    "locality": "Misthalin: City of Um",
-    "task": "Complete the task set: Hard Underworld.",
-    "information": "Complete the Hard Underworld achievements.",
-    "requirements": "See Hard Underworld achievements page",
-    "points": 80
-  },
-  {
-    "id": 738,
-    "locality": "Morytania",
-    "task": "Take a hard companion through a hard route of Temple Trekking.",
-    "information": "Take a hard companion through a hard route of Temple Trekking.",
-    "requirements": "Completion of In Aid of the Myreque",
-    "points": 80
-  },
-  {
-    "id": 739,
-    "locality": "Morytania",
-    "task": "Mine 30 Phasmatite.",
-    "information": "Mine 30 phasmatite near Port Phasmatys.",
-    "requirements": "70 Mining",
-    "points": 80
-  },
-  {
-    "id": 740,
-    "locality": "Morytania",
-    "task": "Defeat 25 Gargoyles.",
-    "information": "Defeat 25 Gargoyles.",
-    "requirements": "75 Slayer",
-    "points": 80
-  },
-  {
-    "id": 741,
-    "locality": "Morytania",
-    "task": "Defeat 35 Aberrant Spectres.",
-    "information": "Defeat 35 Aberrant Spectres.",
-    "requirements": "60 Slayer",
-    "points": 80
-  },
-  {
-    "id": 742,
-    "locality": "Morytania",
-    "task": "Equip a full set of Ahrim's equipment, including the staff.",
-    "information": "Equip a full set of Ahrim's equipment, including the staff.",
-    "requirements": "70 Defence, 70 Magic",
-    "points": 80
-  },
-  {
-    "id": 743,
-    "locality": "Morytania",
-    "task": "Equip a full set of Dharok's equipment, including the greataxe.",
-    "information": "Equip a full set of Dharok's equipment, including the greataxe.",
-    "requirements": "70 Defence, 70 Attack",
-    "points": 80
-  },
-  {
-    "id": 744,
-    "locality": "Morytania",
-    "task": "Equip a full set of Guthan's equipment, including the warspear.",
-    "information": "Equip a full set of Guthan's equipment, including the Guthan's warspear.",
-    "requirements": "70 Defence, 70 Attack",
-    "points": 80
-  },
-  {
-    "id": 745,
-    "locality": "Morytania",
-    "task": "Equip a full set of Torag's equipment, including the hammer.",
-    "information": "Equip a full set of Torag's equipment, including the hammer.",
-    "requirements": "70 Defence, 70 Attack",
-    "points": 80
-  },
-  {
-    "id": 746,
-    "locality": "Morytania",
-    "task": "Equip a full set of Verac's equipment, including the flail.",
-    "information": "Equip a full set of Verac's equipment, including the flail.",
-    "requirements": "70 Defence, 70 Attack",
-    "points": 80
-  },
-  {
-    "id": 747,
-    "locality": "Morytania",
-    "task": "Equip a full set of Karil's equipment, including the 2h crossbow.",
-    "information": "Equip a full set of Karil's equipment, including the 2h crossbow.",
-    "requirements": "70 Defence, 70 Ranged",
-    "points": 80
-  },
-  {
-    "id": 748,
-    "locality": "Morytania",
-    "task": "Complete the quest: The Branches of Darkmeyer.",
-    "information": "Complete The Branches of Darkmeyer.",
-    "requirements": "See quest page",
-    "points": 80
-  },
-  {
-    "id": 749,
-    "locality": "Morytania",
-    "task": "Burn 20 Blisterwood logs.",
-    "information": "Burn 20 Blisterwood logs.",
-    "requirements": "76 Woodcutting, 76 Firemaking, Partial completion of The Branches of Darkmeyer",
-    "points": 80
-  },
-  {
-    "id": 750,
-    "locality": "Morytania",
-    "task": "Fully level up all Temple Trekking companions.",
-    "information": "Fully level up all Temple Trekking companions.",
-    "requirements": "Completion of In Aid of the Myreque",
-    "points": 80
-  },
-  {
-    "id": 751,
-    "locality": "Morytania",
-    "task": "Catch 5 sharks in Burgh de Rott.",
-    "information": "Catch 5 sharks in Burgh de Rott.",
-    "requirements": "76 Fishing, Partial completion of In Aid of the Myreque",
-    "points": 80
-  },
-  {
-    "id": 752,
-    "locality": "Morytania",
-    "task": "Complete the task set: Hard Morytania.",
-    "information": "Complete the hard Morytania Diary.",
-    "requirements": "See Hard Morytania achievements page",
-    "points": 80
-  },
-  {
-    "id": 753,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Plant a mushroom seed in the mushroom patch in Isafdar.",
-    "information": "Plant a mushroom seed in the mushroom patch in Isafdar.",
-    "requirements": "53 Farming, Completion of the medium Tirannwn achievements.",
-    "points": 80
-  },
-  {
-    "id": 754,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Defeat 30 Cadarn warriors in Prifddinas.",
-    "information": "Defeat 30 Cadarn warriors in Prifddinas.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 755,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Harvest some harmony moss from a harmony pillar.",
-    "information": "Harvest some harmony moss from a harmony pillar.",
-    "requirements": "75 Farming",
-    "points": 80
-  },
-  {
-    "id": 756,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Complete the Hefin Agility course with a light creature familiar summoned.",
-    "information": "Complete the Hefin Agility course with a light creature familiar summoned.",
-    "requirements": "77 Agility, 88 Summoning, 71 Divination",
-    "points": 80
-  },
-  {
-    "id": 757,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Cleanse the Corrupted Seren stone with 5 cleansing crystals.",
-    "information": "Cleanse the Corrupted Seren stone with 5 cleansing crystals.",
-    "requirements": "75 Prayer",
-    "points": 80
-  },
-  {
-    "id": 758,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Complete 10 laps of the Hefin agility course.",
-    "information": "Complete 10 laps of the Hefin agility course.",
-    "requirements": "77 Agility",
-    "points": 80
-  },
-  {
-    "id": 759,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Harvest 100 Incandescent energy from Incandescent Wisps.",
-    "information": "Harvest 100 Incandescent energy from Incandescent Wisps.",
-    "requirements": "95 Divination",
-    "points": 80
-  },
-  {
-    "id": 760,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Equip a Dark bow.",
-    "information": "Equip a Dark bow.",
-    "requirements": "90 Slayer, 70 Ranged, 70 Defence",
-    "points": 80
-  },
-  {
-    "id": 761,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Defeat 30 Dark beasts in Tirannwn.",
-    "information": "Defeat 30 Dark beasts in Tirannwn.",
-    "requirements": "90 Slayer",
-    "points": 80
-  },
-  {
-    "id": 762,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Equip a Crystal halberd.",
-    "information": "Equip a Crystal halberd.",
-    "requirements": "50 Agility, 70 Attack",
-    "points": 80
-  },
-  {
-    "id": 763,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Equip a Crystal shield.",
-    "information": "Equip a Crystal shield.",
-    "requirements": "50 Agility, 70 Defence",
-    "points": 80
-  },
-  {
-    "id": 764,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Equip a Crystal bow.",
-    "information": "Equip a Crystal bow.",
-    "requirements": "50 Agility, 70 Ranged",
-    "points": 80
-  },
-  {
-    "id": 765,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Catch 25 Grenwalls in Isafdar.",
-    "information": "Catch 25 Grenwalls in Isafdar.",
-    "requirements": "77 Hunter",
-    "points": 80
-  },
-  {
-    "id": 766,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Defeat 10 Elf warriors in Lletya.",
-    "information": "Defeat 10 Elf warriors in Lletya.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 767,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Chop 50 Magic logs in Tirannwn.",
-    "information": "Chop 50 Magic logs in Tirannwn.",
-    "requirements": "80 Woodcutting",
-    "points": 80
-  },
-  {
-    "id": 768,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Open the crystal chest in Prifddinas 10 times.",
-    "information": "Open the crystal chest in Prifddinas 10 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 769,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Charge a piece of Dragonstone jewellery using the Tears of Seren.",
-    "information": "Charge a piece of Dragonstone jewellery using the Tears of Seren.",
-    "requirements": "Completion of Legends' Quest",
-    "points": 80
-  },
-  {
-    "id": 770,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Complete the task set: Hard Tirannwn.",
-    "information": "Complete the hard Tirannwn Diary.",
-    "requirements": "See Hard Tirannwn achievements page",
-    "points": 80
-  },
-  {
-    "id": 771,
-    "locality": "Wilderness: General",
-    "task": "Defeat the King Black Dragon while wearing black dragonhide in six equipment slots. Can only be completed in a solo instance.",
-    "information": "Defeat the King Black Dragon while wearing black dragonhide in six equipment slots.",
-    "requirements": "60 Defence",
-    "points": 80
-  },
-  {
-    "id": 772,
-    "locality": "Wilderness: General",
-    "task": "Defeat one of each revenant creature in the Forinthry dungeon.",
-    "information": "Defeat one of each revenant creature in the Forinthry dungeon.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 773,
-    "locality": "Wilderness: General",
-    "task": "Equip a Statius's warhammer.",
-    "information": "Equip a Statius's warhammer.",
-    "requirements": "78 Attack",
-    "points": 80
-  },
-  {
-    "id": 774,
-    "locality": "Wilderness: General",
-    "task": "Catch 25 Black Salamanders.",
-    "information": "Catch 25 Black Salamanders.",
-    "requirements": "67 Hunter",
-    "points": 80
-  },
-  {
-    "id": 775,
-    "locality": "Wilderness: Daemonheim",
-    "task": "Restore an artefact from the Daemonheim digsite.",
-    "information": "Restore an artefact from the Daemonheim digsite.",
-    "requirements": "73 Archaeology",
-    "points": 80
-  },
-  {
-    "id": 776,
-    "locality": "Wilderness: General",
-    "task": "Defeat the Corporeal Beast.",
-    "information": "Defeat the Corporeal Beast once.",
-    "requirements": "Completion of Summer's End",
-    "points": 80
-  },
-  {
-    "id": 777,
-    "locality": "Wilderness: General",
-    "task": "Defeat the Corporeal Beast.",
-    "information": "Defeat the Corporeal Beast 100 times.",
-    "requirements": "Completion of Summer's End",
-    "points": 80
-  },
-  {
-    "id": 778,
-    "locality": "Wilderness: Daemonheim",
-    "task": "Defeat the Skeletal Trio.",
-    "information": "Defeat the Skeletal Trio.",
-    "requirements": "71 Dungeoneering",
-    "points": 80
-  },
-  {
-    "id": 779,
-    "locality": "Wilderness: Daemonheim",
-    "task": "Upgrade your Gem bag.",
-    "information": "Upgrade your Gem bag.",
-    "requirements": "40 Dungeoneering, 45 Crafting, 20,000 dungeoneering tokens",
-    "points": 80
-  },
-  {
-    "id": 780,
-    "locality": "Wilderness: General",
-    "task": "Equip a pair of Steadfast boots.",
-    "information": "Equip a pair of Steadfast boots.",
-    "requirements": "85 Defence",
-    "points": 80
-  },
-  {
-    "id": 781,
-    "locality": "Wilderness: General",
-    "task": "Equip a pair of Glaiven boots.",
-    "information": "Equip a pair of Glaiven boots.",
-    "requirements": "85 Defence",
-    "points": 80
-  },
-  {
-    "id": 782,
-    "locality": "Wilderness: General",
-    "task": "Equip a pair of Ragefire boots.",
-    "information": "Equip a pair of Ragefire boots.",
-    "requirements": "85 Defence",
-    "points": 80
-  },
-  {
-    "id": 783,
-    "locality": "Wilderness: General",
-    "task": "Complete the task set: Hard Wilderness.",
-    "information": "Complete the hard Wilderness Diary.",
-    "requirements": "See Hard Wilderness achievements page",
-    "points": 80
-  },
-  {
-    "id": 784,
-    "locality": "Wilderness: Daemonheim",
-    "task": "Equip a Chaotic weapon or kiteshield.",
-    "information": "Equip a Chaotic weapon or kiteshield.",
-    "requirements": "80 Dungeoneering, 80 Attack OR 80 Ranged OR 80 Magic OR 80 Defence",
-    "points": 80
-  },
-  {
-    "id": 785,
-    "locality": "Anachronia",
-    "task": "Harvest produce from 25 animals on Anachronia farm.",
-    "information": "Harvest produce from 25 animals on Anachronia farm.",
-    "requirements": "42 Farming, 45 Construction",
-    "points": 80
-  },
-  {
-    "id": 786,
-    "locality": "Anachronia",
-    "task": "Complete the ritual to activate a totem on Anachronia.",
-    "information": "Complete the ritual to activate a totem on Anachronia.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 787,
-    "locality": "Anachronia",
-    "task": "Complete the Anachronia agility course in under 7 minutes.",
-    "information": "Complete the Anachronia agility course in under 7 minutes.",
-    "requirements": "85 Agility",
-    "points": 80
-  },
-  {
-    "id": 788,
-    "locality": "Anachronia",
-    "task": "Complete all frog breeds.",
-    "information": "Complete all frog breeds.",
-    "requirements": "42 Farming, 45 Construction",
-    "points": 80
-  },
-  {
-    "id": 789,
-    "locality": "Anachronia",
-    "task": "Purchase the Quick Traps upgrade from Irwinsson's Hunter Mark shop.",
-    "information": "Purchase the quick traps upgrade from the Hunter Mark Shop.",
-    "requirements": "50 hunter marks",
-    "points": 80
-  },
-  {
-    "id": 790,
-    "locality": "Anachronia",
-    "task": "Complete the quest: Osseous Rex.",
-    "information": "Complete the Osseous Rex quest.",
-    "requirements": "See quest page",
-    "points": 80
-  },
-  {
-    "id": 791,
-    "locality": "Anachronia",
-    "task": "Clear an Overgrown idol on Anachronia.",
-    "information": "Clear an overgrown idol on Anachronia.",
-    "requirements": "81 Woodcutting",
-    "points": 80
-  },
-  {
-    "id": 792,
-    "locality": "Anachronia",
-    "task": "Defeat any of the Rex Matriarchs.",
-    "information": "Defeat any of the Rex Matriarchs once.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 793,
-    "locality": "Anachronia",
-    "task": "Defeat any of the Rex Matriarchs. (100 times)",
-    "information": "Defeat any of the Rex Matriarchs 100 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 794,
-    "locality": "Anachronia",
-    "task": "Complete the quest: Desperate Times.",
-    "information": "Complete the Desperate Times quest.",
-    "requirements": "See quest page",
-    "points": 80
-  },
-  {
-    "id": 795,
-    "locality": "Anachronia",
-    "task": "Find all the hidden Zygomites on Anachronia.",
-    "information": "Find all of the ancient zygomites on Anachronia. See the page for a route.",
-    "requirements": "85 Agility",
-    "points": 80
-  },
-  {
-    "id": 796,
-    "locality": "Anachronia",
-    "task": "Equip Laniakea's spear.",
-    "information": "Equip Laniakea's spear.",
-    "requirements": "82 Attack",
-    "points": 80
-  },
-  {
-    "id": 797,
-    "locality": "Anachronia",
-    "task": "Harvest an Arbuck herb.",
-    "information": "Harvest an arbuck herb.",
-    "requirements": "77 Farming",
-    "points": 80
-  },
-  {
-    "id": 798,
-    "locality": "Anachronia",
-    "task": "Complete the advanced sections of the Anachronia agility course.",
-    "information": "Complete the advanced sections of the Anachronia agility course.",
-    "requirements": "70 Agility",
-    "points": 80
-  },
-  {
-    "id": 799,
-    "locality": "Anachronia",
-    "task": "Equip a Dragon Mattock.",
-    "information": "Equip a dragon mattock.",
-    "requirements": "60 Archaeology, (optional) 75 Hunter",
-    "points": 80
-  }
-,
-  {
-    "id": 800,
-    "locality": "Anachronia",
-    "task": "Take down each dinosaur in Big Game Hunter.",
-    "information": "Take down each dinosaur in Big Game Hunter.",
-    "requirements": "96 Hunter, 76 Slayer",
-    "points": 80
-  },
-  {
-    "id": 801,
-    "locality": "Anachronia",
-    "task": "Get caught by each of the big game creatures once.",
-    "information": "Get caught by each of the Big Game Hunter creatures once.",
-    "requirements": "96 Hunter, 76 Slayer",
-    "points": 80
-  },
-  {
-    "id": 802,
-    "locality": "Anachronia",
-    "task": "Complete a big game encounter without using movement abilities.",
-    "information": "Complete a Big Game Hunter encounter without using movement abilities.",
-    "requirements": "75 Hunter, 55 Slayer",
-    "points": 80
-  },
-  {
-    "id": 803,
-    "locality": "Anachronia",
-    "task": "Defeat Raksha, the Shadow Colossus.",
-    "information": "Defeat Raksha, the Shadow Colossus once.",
-    "requirements": "Completion of Raksha, the Shadow Colossus",
-    "points": 80
-  },
-  {
-    "id": 804,
-    "locality": "Asgarnia: Falador",
-    "task": "Reach 100% respect at the Artisans' Workshop.",
-    "information": "Reach 100% respect at the Artisans' Workshop.",
-    "requirements": "1 Smithing",
-    "points": 80
-  },
-  {
-    "id": 805,
-    "locality": "Asgarnia: Falador",
-    "task": "Complete the task set: Hard Falador.",
-    "information": "Complete the Hard Falador achievements.",
-    "requirements": "See Hard Falador achievements page",
-    "points": 80
-  },
-  {
-    "id": 806,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat any God Wars Dungeon boss 100 times.",
-    "information": "Defeat any God Wars Dungeon boss 100 times.",
-    "requirements": "Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 807,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat any God Wars Dungeon boss 250 times.",
-    "information": "Defeat any God Wars Dungeon boss 250 times.",
-    "requirements": "Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 808,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Commander Zilyana.",
-    "information": "Defeat Commander Zilyana",
-    "requirements": "70 Agility, Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 809,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat General Graardor.",
-    "information": "Defeat General Graardor",
-    "requirements": "70 Strength, Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 810,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat K'ril Tsutsaroth.",
-    "information": "Defeat K'ril Tsutsaroth",
-    "requirements": "70 Constitution, Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 811,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Kree'arra.",
-    "information": "Defeat Kree'arra",
-    "requirements": "70 Ranged, Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 812,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Nex.",
-    "information": "Defeat Nex",
-    "requirements": "70 Agility, 70 Strength, 70 Constitution, 70 Ranged, Partial completion of Troll Stronghold, completion of The Dig Site, frozen key",
-    "points": 80
-  },
-  {
-    "id": 813,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Kree'arra. (100 times)",
-    "information": "Defeat Kree'arra 100 times.",
-    "requirements": "70 Ranged, Partial completion of Troll Stronghold",
-    "points": 80
-  },
-  {
-    "id": 814,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Assemble any godsword from the God Wars Dungeon.",
-    "information": "Assemble any godsword from the God Wars Dungeon.",
-    "requirements": "80 Smithing and one of 70 Agility, 70 Strength, 70 Constitution, or 70 Ranged",
-    "points": 80
-  },
-  {
-    "id": 815,
-    "locality": "Asgarnia: Port Sarim",
-    "task": "Defeat the Queen Black Dragon.",
-    "information": "Defeat the Queen Black Dragon.",
-    "requirements": "60 Summoning",
-    "points": 80
-  },
-  {
-    "id": 816,
-    "locality": "Asgarnia: Port Sarim",
-    "task": "Defeat the Queen Black Dragon. (100 times)",
-    "information": "Defeat the Queen Black Dragon 100 times.",
-    "requirements": "60 Summoning",
-    "points": 80
-  },
-  {
-    "id": 817,
-    "locality": "Asgarnia: Port Sarim",
-    "task": "Bury some frost dragon bones.",
-    "information": "Bury some frost dragon bones.",
-    "requirements": "85 Dungeoneering",
-    "points": 80
-  },
-  {
-    "id": 818,
-    "locality": "Desert: General",
-    "task": "Defeat the Kalphite King.",
-    "information": "Defeat the Kalphite King.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 819,
-    "locality": "Desert: General",
-    "task": "Defeat the Kalphite King. (100 times)",
-    "information": "Defeat the Kalphite King 100 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 820,
-    "locality": "Desert: General",
-    "task": "Equip a drygore weapon.",
-    "information": "Equip a drygore weapon.",
-    "requirements": "90 Attack",
-    "points": 80
-  },
-  {
-    "id": 821,
-    "locality": "Desert: General",
-    "task": "Become an honorary druid at the Garden of Kharid.",
-    "information": "Purchase the Druid/Druidess title for 50,000 Crux Eqal favour",
-    "requirements": "50 Farming",
-    "points": 80
-  },
-  {
-    "id": 822,
-    "locality": "Desert: General",
-    "task": "Deploy a dreadnip.",
-    "information": "Deploy a dreadnip.",
-    "requirements": "20 of a collection of quests (see Dominion Tower#Requirements), 450 Dominion Tower kills",
-    "points": 80
-  },
-  {
-    "id": 823,
-    "locality": "Desert: General",
-    "task": "Complete the task set: Hard Desert.",
-    "information": "Complete the Hard Desert achievements.",
-    "requirements": "See Hard Desert achievements page",
-    "points": 80
-  },
-  {
-    "id": 824,
-    "locality": "Desert: General",
-    "task": "Defeat Avaryss and Nymora.",
-    "information": "Defeat the Twin Furies.",
-    "requirements": "80 Ranged",
-    "points": 80
-  },
-  {
-    "id": 825,
-    "locality": "Desert: General",
-    "task": "Defeat Gregorovic.",
-    "information": "Defeat Gregorivic.",
-    "requirements": "80 Prayer",
-    "points": 80
-  },
-  {
-    "id": 826,
-    "locality": "Desert: General",
-    "task": "Defeat Vindicta and Gorvek.",
-    "information": "Defeat Vindicta.",
-    "requirements": "80 Attack",
-    "points": 80
-  },
-  {
-    "id": 827,
-    "locality": "Desert: General",
-    "task": "Defeat Helwyr.",
-    "information": "Defeat Helwyr.",
-    "requirements": "80 Magic",
-    "points": 80
-  },
-  {
-    "id": 828,
-    "locality": "Desert: General",
-    "task": "Defeat Avaryss and Nymora. (100 times)",
-    "information": "Defeat the Twin Furies 100 times.",
-    "requirements": "80 Ranged",
-    "points": 80
-  },
-  {
-    "id": 829,
-    "locality": "Desert: General",
-    "task": "Defeat Gregorovic. (100 times)",
-    "information": "Defeat Gregorivic 100 times.",
-    "requirements": "80 Prayer",
-    "points": 80
-  },
-  {
-    "id": 830,
-    "locality": "Desert: General",
-    "task": "Defeat Vindicta and Gorvek. (100 times)",
-    "information": "Defeat Vindicta 100 times.",
-    "requirements": "80 Attack",
-    "points": 80
-  },
-  {
-    "id": 831,
-    "locality": "Desert: General",
-    "task": "Defeat Helwyr. (100 times)",
-    "information": "Defeat Helwyr 100 times.",
-    "requirements": "80 Magic",
-    "points": 80
-  },
-  {
-    "id": 832,
-    "locality": "Desert: General",
-    "task": "Equip a Dragon Rider lance.",
-    "information": "Equip a Dragon Rider lance.",
-    "requirements": "85 Attack",
-    "points": 80
-  },
-  {
-    "id": 833,
-    "locality": "Desert: General",
-    "task": "Equip a wand or orb of the Cywir elders.",
-    "information": "Equip a wand or orb of the Cywir elders.",
-    "requirements": "85 Magic",
-    "points": 80
-  },
-  {
-    "id": 834,
-    "locality": "Desert: General",
-    "task": "Equip a shadow glaive.",
-    "information": "Equip a shadow glaive.",
-    "requirements": "85 Ranged",
-    "points": 80
-  },
-  {
-    "id": 835,
-    "locality": "Desert: General",
-    "task": "Equip a blade of Nymora or Avaryss.",
-    "information": "Equip a blade of Nymora or Avaryss.",
-    "requirements": "85 Attack",
-    "points": 80
-  },
-  {
-    "id": 836,
-    "locality": "Desert: Menaphos",
-    "task": "Slay a combination of 500 corrupted or devourer creatures.",
-    "information": "Slay a combination of 500 corrupted creatures or soul devourers.",
-    "requirements": "88 Slayer, Completion of Icthlarin's Little Helper",
-    "points": 80
-  },
-  {
-    "id": 837,
-    "locality": "Desert: General",
-    "task": "Defeat the Magister.",
-    "information": "Defeat the Magister.",
-    "requirements": "115 Slayer, Key to the Crossing",
-    "points": 80
-  },
-  {
-    "id": 838,
-    "locality": "Desert: General",
-    "task": "Defeat the Magister. (50 times)",
-    "information": "Defeat the Magister 50 times.",
-    "requirements": "115 Slayer, Key to the Crossing",
-    "points": 80
-  },
-  {
-    "id": 839,
-    "locality": "Desert: Menaphos",
-    "task": "Find an Off-hand khopesh of the Kharidian in Shifting Tombs.",
-    "information": "Find an off-hand khopesh of the Kharidian in Shifting Tombs.",
-    "requirements": "At least one of 50 Dungeoneering, 50 Agility, 50 Thieving, or 50 Construction",
-    "points": 80
-  },
-  {
-    "id": 840,
-    "locality": "Desert: General",
-    "task": "Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.",
-    "information": "Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.",
-    "requirements": "81 Thieving, Partial completion of Icthlarin's Little Helper",
-    "points": 80
-  },
-  {
-    "id": 841,
-    "locality": "Desert: General",
-    "task": "Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.",
-    "information": "Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.",
-    "requirements": "91 Thieving, Partial completion of Icthlarin's Little Helper",
-    "points": 80
-  },
-  {
-    "id": 842,
-    "locality": "Desert: Menaphos",
-    "task": "Complete the quest: Beneath Scabaras' Sands.",
-    "information": "Complete Beneath Scabaras' Sands.",
-    "requirements": "See quest page",
-    "points": 80
-  },
-  {
-    "id": 843,
-    "locality": "Desert: General",
-    "task": "Kill a desert strykewyrm wearing a Full Slayer Helm and wielding an ancient staff.",
-    "information": "Kill a desert strykewyrm wearing a full Slayer helm and wielding an ancient staff.",
-    "requirements": "77 Slayer, 50 Magic, 20 Defence, 55 Crafting, Completion of Desert Treasure and Smoking Kills, 400 slayer points to unlock crafting slayer helmets. See also Staff on Stryke.",
-    "points": 80
-  },
-  {
-    "id": 844,
-    "locality": "Desert: General",
-    "task": "Defeat Telos, the Warden.",
-    "information": "Defeat Telos, the Warden.",
-    "requirements": "80 Attack, 80 Prayer, 80 Magic, 80 Ranged",
-    "points": 80
-  },
-  {
-    "id": 845,
-    "locality": "Fremennik: Lunar Isles",
-    "task": "Cast Fertile Soil.",
-    "information": "Cast Fertile Soil.",
-    "requirements": "83 Magic, Completion of Lunar Diplomacy unless tier 6 reached",
-    "points": 80
-  },
-  {
-    "id": 846,
-    "locality": "Fremennik: Mainland",
-    "task": "Build a Gilded Altar.",
-    "information": "Build a gilded altar in your player-owned house's chapel.",
-    "requirements": "75 Construction",
-    "points": 80
-  },
-  {
-    "id": 847,
-    "locality": "Fremennik: Mainland",
-    "task": "Trap a Sabre-Toothed Kyatt.",
-    "information": "Trap a sabre-toothed kyatt.",
-    "requirements": "55 Hunter",
-    "points": 80
-  },
-  {
-    "id": 848,
-    "locality": "Fremennik: Mainland",
-    "task": "Defeat all the Dagannoth Kings without leaving a solo boss instance.",
-    "information": "Defeat all the Dagannoth Kings without leaving a solo boss instance.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 849,
-    "locality": "Fremennik: Mainland",
-    "task": "Equip a Berserker, Warrior, Seers, or Archers Ring.",
-    "information": "Equip a Berserker, Warrior, Seers, or Archers Ring.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 850,
-    "locality": "Fremennik: Mainland",
-    "task": "Use the Special Attack of a Dragon Axe.",
-    "information": "Use the special attack of a dragon hatchet.",
-    "requirements": "60 Attack",
-    "points": 80
-  },
-  {
-    "id": 851,
-    "locality": "Fremennik: Mainland",
-    "task": "Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.",
-    "information": "Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.",
-    "requirements": "25 Defence, Partial completion of The Fremennik Isles",
-    "points": 80
-  },
-  {
-    "id": 852,
-    "locality": "Fremennik: Mainland",
-    "task": "Equip a full set of Skeletal, Spined, or Rockshell armour.",
-    "information": "Equip a full skeletal, spined, or rock-shell armour set.",
-    "requirements": "50 Defence, Completion of The Fremennik Trials",
-    "points": 80
-  },
-  {
-    "id": 853,
-    "locality": "Fremennik: Mainland",
-    "task": "Collect Miscellania Resources at Full Approval.",
-    "information": "Collect from Managing Miscellania with a 100% approval rating.",
-    "requirements": "Completion of Throne of Miscellania",
-    "points": 80
-  },
-  {
-    "id": 854,
-    "locality": "Fremennik: Mainland",
-    "task": "Travel to the island of Ungael.",
-    "information": "Travel to the island of Ungael.",
-    "requirements": "Partial completion of Ancient Awakening",
-    "points": 80
-  },
-  {
-    "id": 855,
-    "locality": "Fremennik: Mainland",
-    "task": "Adopt a baby yak.",
-    "information": "Obtain an unchecked/baby Fremennik yak.",
-    "requirements": "71 Farming, Partial completion of The Fremennik Isles",
-    "points": 80
-  },
-  {
-    "id": 856,
-    "locality": "Fremennik: Mainland",
-    "task": "Catch 50 Azure Skillchompas.",
-    "information": "Catch 50 Azure Skillchompas.",
-    "requirements": "68 Hunter",
-    "points": 80
-  },
-  {
-    "id": 857,
-    "locality": "Fremennik: Mainland",
-    "task": "Mine 10 Banite Ore north of Rellekka.",
-    "information": "Mine 10 Banite ore in the arctic (azure) habitat mine.",
-    "requirements": "80 Mining",
-    "points": 80
-  },
-  {
-    "id": 858,
-    "locality": "Fremennik: Mainland",
-    "task": "Smith a piece of Bane equipment to +4 in Rellekka.",
-    "information": "Upgrade a piece of Bane equipment to +4 in Rellekka.",
-    "requirements": "80 Smithing, Completion of The Fremennik Trials",
-    "points": 80
-  },
-  {
-    "id": 859,
-    "locality": "Fremennik: Mainland",
-    "task": "Use a Crystal triskelion key to obtain some treasures.",
-    "information": "Use a Crystal triskelion to obtain some treasures.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 860,
-    "locality": "Fremennik: Mainland",
-    "task": "Create a Catherby Teleport Tablet.",
-    "information": "Create a Catherby Teleport Tablet.",
-    "requirements": "87 Magic, 67 Construction, Completion of Lunar Diplomacy unless tier 6 reached",
-    "points": 80
-  },
-  {
-    "id": 861,
-    "locality": "Fremennik: Mainland",
-    "task": "Gather a seed from an Aquanite using Seedicide.",
-    "information": "Gather a seed from an aquanite using Seedicide.",
-    "requirements": "78 Slayer, 2,200 renown, 10,000 beans, 360 thaler, or tier 4 reached",
-    "points": 80
-  },
-  {
-    "id": 862,
-    "locality": "Fremennik: Mainland",
-    "task": "Complete the task set: Hard Fremennik.",
-    "information": "Complete the Hard Fremennik achievements.",
-    "requirements": "See Hard Fremennik achievements page",
-    "points": 80
-  },
-  {
-    "id": 863,
-    "locality": "Global",
-    "task": "Reach at least level 50 in all non-elite skills.",
-    "information": "Reach at least level 50 in all non-elite skills.",
-    "requirements": "All skills except Invention at level 50",
-    "points": 80
-  },
-  {
-    "id": 864,
-    "locality": "Global",
-    "task": "Reach combat level 100.",
-    "information": "Reach combat level 100.",
-    "requirements": "100 Combat",
-    "points": 80
-  },
-  {
-    "id": 865,
-    "locality": "Global",
-    "task": "Reach total level 1000.",
-    "information": "Reach total level 1000. This task is currently bugged and may complete before you have reached 1000 total levels",
-    "requirements": "1000 Skills Total level",
-    "points": 80
-  },
-  {
-    "id": 866,
-    "locality": "Global",
-    "task": "Mine any ore 1000 times.",
-    "information": "Mine any ore 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 867,
-    "locality": "Global",
-    "task": "Chop any tree 1000 times.",
-    "information": "Chop any tree 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 868,
-    "locality": "Global",
-    "task": "Burn any logs 1000 times.",
-    "information": "Burn any logs 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 869,
-    "locality": "Global",
-    "task": "Catch any fish 1000 times.",
-    "information": "Catch any fish 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 870,
-    "locality": "Global",
-    "task": "Harvest any memory from a wisp 1000 times.",
-    "information": "Harvest any memory from a wisp 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 871,
-    "locality": "Global",
-    "task": "Pickpocket anyone 1000 times.",
-    "information": "Pickpocket anyone 1000 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 872,
-    "locality": "Global",
-    "task": "Unlock all of the Lodestones.",
-    "information": "Unlock all of the Lodestones.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 873,
-    "locality": "Global",
-    "task": "Make 1,000 potions of any kind.",
-    "information": "Make 1,000 potions of any kind.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 874,
-    "locality": "Global",
-    "task": "Clean 1,000 of any herb.",
-    "information": "Clean 1,000 of any herb.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 875,
-    "locality": "Global",
-    "task": "Complete 50 laps of any Agility course.",
-    "information": "Complete 50 laps of any Agility course.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 876,
-    "locality": "Global",
-    "task": "Complete 100 laps of any Agility course.",
-    "information": "Complete 100 laps of any Agility course.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 877,
-    "locality": "Global",
-    "task": "Smith 50 of any metal weapon or armour piece.",
-    "information": "Smith 50 of any metal weapon or armour piece.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 878,
-    "locality": "Global",
-    "task": "Smith 100 of any metal weapon or armour piece.",
-    "information": "Smith 100 of any metal weapon or armour piece.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 879,
-    "locality": "Global",
-    "task": "Cook 1,000 fish.",
-    "information": "Cook 1,000 fish.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 880,
-    "locality": "Global",
-    "task": "Catch 1,000 Hunter creatures.",
-    "information": "Catch 1,000 Hunter creatures.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 881,
-    "locality": "Global",
-    "task": "Complete 15 Slayer tasks.",
-    "information": "Complete 15 Slayer tasks.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 882,
-    "locality": "Global",
-    "task": "Complete 150 Easy clue scrolls.",
-    "information": "Complete 150 Easy clue scrolls.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 883,
-    "locality": "Global",
-    "task": "Collect 50 unique items for the General clue rewards collection log.",
-    "information": "Collect 50 unique items for the General clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 884,
-    "locality": "Global",
-    "task": "Craft 10,000 runes.",
-    "information": "Craft 10,000 runes.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 885,
-    "locality": "Global",
-    "task": "Craft 20,000 runes.",
-    "information": "Craft 20,000 runes.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 886,
-    "locality": "Global",
-    "task": "Obtain 75 Quest Points.",
-    "information": "Obtain 75 quest points.",
-    "requirements": "75 Quest points",
-    "points": 80
-  },
-  {
-    "id": 887,
-    "locality": "Global",
-    "task": "Obtain 100 Quest Points.",
-    "information": "Obtain 100 quest points.",
-    "requirements": "100 Quest points",
-    "points": 80
-  },
-  {
-    "id": 888,
-    "locality": "Global",
-    "task": "Complete 150 Medium clue scrolls.",
-    "information": "Complete 150 Medium clue scrolls.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 889,
-    "locality": "Global",
-    "task": "Complete 75 Hard clue scrolls.",
-    "information": "Complete 75 Hard clue scrolls.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 890,
-    "locality": "Global",
-    "task": "Complete 150 Hard clue scrolls.",
-    "information": "Complete 150 Hard clue scrolls.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 891,
-    "locality": "Global",
-    "task": "Collect 25 unique items for the Easy clue rewards collection log.",
-    "information": "Collect 25 unique items for the Easy clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 892,
-    "locality": "Global",
-    "task": "Collect 50 unique items for the Easy clue rewards collection log.",
-    "information": "Collect 50 unique items for the Easy clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 893,
-    "locality": "Global",
-    "task": "Collect 25 unique items for the Medium clue rewards collection log.",
-    "information": "Collect 25 unique items for the Medium clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 894,
-    "locality": "Global",
-    "task": "Collect 50 unique items for the Medium clue rewards collection log.",
-    "information": "Collect 50 unique items for the Medium clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 895,
-    "locality": "Global",
-    "task": "Collect 10 unique items for the Hard clue rewards collection log.",
-    "information": "Collect 10 unique items for the Hard clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 896,
-    "locality": "Global",
-    "task": "Collect 25 unique items for the Hard clue rewards collection log.",
-    "information": "Collect 25 unique items for the Hard clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 897,
-    "locality": "Global",
-    "task": "Equip any Dragon mask.",
-    "information": "Equip any Dragon mask.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 898,
-    "locality": "Global",
-    "task": "Make any Perfect Juju Potion.",
-    "information": "Make any Perfect Juju Potion.",
-    "requirements": "75 Herblore",
-    "points": 80
-  },
-  {
-    "id": 899,
-    "locality": "Global",
-    "task": "Make 15 Antifire Potions.",
-    "information": "Make 15 Antifire Potions.",
-    "requirements": "69 Herblore",
-    "points": 80
-  }
-,
-  {
-    "id": 900,
-    "locality": "Global",
-    "task": "Clean 50 Grimy Cadantine.",
-    "information": "Clean 50 Grimy Cadantine.",
-    "requirements": "65 Herblore",
-    "points": 80
-  },
-  {
-    "id": 901,
-    "locality": "Global",
-    "task": "Clean 100 Grimy Lantadyme.",
-    "information": "Clean 100 Grimy Lantadyme.",
-    "requirements": "67 Herblore",
-    "points": 80
-  },
-  {
-    "id": 902,
-    "locality": "Global",
-    "task": "Clean 100 Dwarf Weed.",
-    "information": "Clean 100 Dwarf Weed.",
-    "requirements": "70 Herblore",
-    "points": 80
-  },
-  {
-    "id": 903,
-    "locality": "Global",
-    "task": "Clean 100 Arbuck.",
-    "information": "Clean 100 Arbuck.",
-    "requirements": "77 Herblore, 77 Farming",
-    "points": 80
-  },
-  {
-    "id": 904,
-    "locality": "Global",
-    "task": "Equip a Yew shortbow.",
-    "information": "Equip a Yew shortbow.",
-    "requirements": "40 Ranged",
-    "points": 80
-  },
-  {
-    "id": 905,
-    "locality": "Global",
-    "task": "Equip a Magic shortbow.",
-    "information": "Equip a Magic shortbow.",
-    "requirements": "50 Ranged",
-    "points": 80
-  },
-  {
-    "id": 906,
-    "locality": "Global",
-    "task": "Fletch some Broad Arrows or Bolts.",
-    "information": "Fletch some Broad Arrows or Bolts.",
-    "requirements": "52 Fletching, Completion of Smoking Kills, 300 slayer points",
-    "points": 80
-  },
-  {
-    "id": 907,
-    "locality": "Global",
-    "task": "Fletch 100 Yew shortbows (unstrung).",
-    "information": "Fletch 100 Yew shortbows (unstrung).",
-    "requirements": "65 Fletching",
-    "points": 80
-  },
-  {
-    "id": 908,
-    "locality": "Global",
-    "task": "Fletch 100 Yew stocks.",
-    "information": "Fletch 100 Yew stocks.",
-    "requirements": "69 Fletching",
-    "points": 80
-  },
-  {
-    "id": 909,
-    "locality": "Global",
-    "task": "Fletch a Rune Crossbow.",
-    "information": "Fletch a Rune Crossbow.",
-    "requirements": "69 Fletching",
-    "points": 80
-  },
-  {
-    "id": 910,
-    "locality": "Global",
-    "task": "Fletch 35 or more arrow shafts from a single log.",
-    "information": "Fletch 35 or more Arrow shafts from a single log.",
-    "requirements": "60 Fletching, Yew logs or higher",
-    "points": 80
-  },
-  {
-    "id": 911,
-    "locality": "Global",
-    "task": "Fletch 500 Adamant arrows.",
-    "information": "Fletch 500 Adamant arrows.",
-    "requirements": "60 Fletching",
-    "points": 80
-  },
-  {
-    "id": 912,
-    "locality": "Global",
-    "task": "Fletch 750 Rune arrows.",
-    "information": "Fletch 750 Rune arrows.",
-    "requirements": "75 Fletching",
-    "points": 80
-  },
-  {
-    "id": 913,
-    "locality": "Global",
-    "task": "Fletch 75 Onyx bolts.",
-    "information": "Fletch 75 Onyx bolts.",
-    "requirements": "73 Fletching",
-    "points": 80
-  },
-  {
-    "id": 914,
-    "locality": "Global",
-    "task": "Equip a Rune Ceremonial Sword.",
-    "information": "Equip a Rune ceremonial sword.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 915,
-    "locality": "Global",
-    "task": "Equip a full set of the Blacksmith's outfit.",
-    "information": "Equip a full set of the Blacksmith's outfit.",
-    "requirements": "Total of 250% Artisans' Workshop respect, unless gained from ceremonial swords",
-    "points": 80
-  },
-  {
-    "id": 916,
-    "locality": "Global",
-    "task": "Power up the Artisan's Workshop with a Luminite Injector.",
-    "information": "Power up the Artisan's Workshop with a Luminite Injector.",
-    "requirements": "100% Artisans' Workshop respect",
-    "points": 80
-  },
-  {
-    "id": 917,
-    "locality": "Global",
-    "task": "Mine 50 Orichalcite Ore.",
-    "information": "Mine 50 Orichalcite Ore.",
-    "requirements": "60 Mining",
-    "points": 80
-  },
-  {
-    "id": 918,
-    "locality": "Global",
-    "task": "Mine 50 Drakolith.",
-    "information": "Mine 50 Drakolith.",
-    "requirements": "60 Mining",
-    "points": 80
-  },
-  {
-    "id": 919,
-    "locality": "Global",
-    "task": "Mine 60 Necrite Ore.",
-    "information": "Mine 60 Necrite Ore.",
-    "requirements": "70 Mining",
-    "points": 80
-  },
-  {
-    "id": 920,
-    "locality": "Global",
-    "task": "Mine 60 Phasmatite.",
-    "information": "Mine 60 Phasmatite.",
-    "requirements": "70 Mining",
-    "points": 80
-  },
-  {
-    "id": 921,
-    "locality": "Global",
-    "task": "Harvest 20 Grimy Kwuarm.",
-    "information": "Harvest 20 Grimy Kwuarm.",
-    "requirements": "56 Farming",
-    "points": 80
-  },
-  {
-    "id": 922,
-    "locality": "Global",
-    "task": "Catch 100 Shark.",
-    "information": "Catch 100 Shark.",
-    "requirements": "76 Fishing",
-    "points": 80
-  },
-  {
-    "id": 923,
-    "locality": "Global",
-    "task": "Catch 100 Green Blubber Jellyfish.",
-    "information": "Catch 100 Green Blubber Jellyfish.",
-    "requirements": "68 Fishing",
-    "points": 80
-  },
-  {
-    "id": 924,
-    "locality": "Global",
-    "task": "Catch a Spirit Impling.",
-    "information": "Catch a Spirit Impling.",
-    "requirements": "54 Hunter",
-    "points": 80
-  },
-  {
-    "id": 925,
-    "locality": "Global",
-    "task": "Equip a Slayer helmet.",
-    "information": "Equip a Slayer helmet.",
-    "requirements": "55 Crafting, 35 Slayer, Completion of Smoking Kills, 400 slayer points Note: While it does not say it explicitly, this task requires the Full slayer helmet and therefore has an implicit requirement of 77 Slayer for Desert Strykewyrms",
-    "points": 80
-  },
-  {
-    "id": 926,
-    "locality": "Global",
-    "task": "Complete a Soul Reaper task.",
-    "information": "Complete a Soul Reaper task.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 927,
-    "locality": "Global",
-    "task": "Complete 5 Soul Reaper tasks.",
-    "information": "Complete 5 Soul Reaper tasks.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 928,
-    "locality": "Global",
-    "task": "Equip a full set of Orikalkum armour.",
-    "information": "Equip a full set of Orikalkum armour.",
-    "requirements": "60 Smithing, 60 Defence",
-    "points": 80
-  },
-  {
-    "id": 929,
-    "locality": "Global",
-    "task": "Equip a full set of Necronium armour.",
-    "information": "Equip a full set of Necronium armour.",
-    "requirements": "70 Smithing, 70 Defence",
-    "points": 80
-  },
-  {
-    "id": 930,
-    "locality": "Global",
-    "task": "Equip a full set of Black Dragonhide armour.",
-    "information": "Equip a full set of Black Dragonhide armour.",
-    "requirements": "60 Defence, 60 Crafting unless getting the pieces as a drop",
-    "points": 80
-  },
-  {
-    "id": 931,
-    "locality": "Global",
-    "task": "Equip a full set of Royal Dragonhide armour.",
-    "information": "Equip a full set of Royal Dragonhide armour.",
-    "requirements": "65 Defence, 65 Crafting",
-    "points": 80
-  },
-  {
-    "id": 932,
-    "locality": "Global",
-    "task": "Cast a Wave spell.",
-    "information": "Cast a Wave spell.",
-    "requirements": "62 Magic",
-    "points": 80
-  },
-  {
-    "id": 933,
-    "locality": "Global",
-    "task": "Burn 75 Yew logs.",
-    "information": "Burn 75 Yew logs.",
-    "requirements": "60 Firemaking",
-    "points": 80
-  },
-  {
-    "id": 934,
-    "locality": "Global",
-    "task": "Unlock the Ring of Quests from May's Quest Caravan.",
-    "information": "Unlock the Ring of Quests from May's Quest Caravan.",
-    "requirements": "75 Quest points",
-    "points": 80
-  },
-  {
-    "id": 935,
-    "locality": "Global",
-    "task": "Complete 250 clues of any tier.",
-    "information": "Complete 250 clues of any tier.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 936,
-    "locality": "Global",
-    "task": "Complete 500 clues of any tier.",
-    "information": "Complete 500 clues of any tier.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 937,
-    "locality": "Global",
-    "task": "Complete an Elite clue scroll.",
-    "information": "Complete an Elite clue scroll.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 938,
-    "locality": "Global",
-    "task": "Complete 25 Elite clue scrolls.",
-    "information": "Complete 25 Elite clue scrolls.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 939,
-    "locality": "Global",
-    "task": "Complete a Master clue scroll.",
-    "information": "Complete a Master clue scroll.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 940,
-    "locality": "Global",
-    "task": "Collect 5 unique items for the Elite clue rewards collection log.",
-    "information": "Collect 5 unique items for the Elite clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 941,
-    "locality": "Global",
-    "task": "Collect 10 unique items for the Elite clue rewards collection log.",
-    "information": "Collect 10 unique items for the Elite clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 942,
-    "locality": "Global",
-    "task": "Collect 20 unique items for the Elite clue rewards collection log.",
-    "information": "Collect 20 unique items for the Elite clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 943,
-    "locality": "Global",
-    "task": "Collect 5 unique items for the Master clue rewards collection log.",
-    "information": "Collect 5 unique items for the Master clue rewards collection log.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 944,
-    "locality": "Global",
-    "task": "Catch a Manta ray.",
-    "information": "Catch a raw manta ray.",
-    "requirements": "81 Fishing (or 68 Fishing via swarm fishing)",
-    "points": 80
-  },
-  {
-    "id": 945,
-    "locality": "Global",
-    "task": "Reach level 70 in any skill.",
-    "information": "Reach level 70 in any skill.",
-    "requirements": "Any skill at level 70",
-    "points": 80
-  },
-  {
-    "id": 946,
-    "locality": "Global",
-    "task": "Reach level 80 in any skill.",
-    "information": "Reach level 80 in any skill.",
-    "requirements": "Any skill at level 80",
-    "points": 80
-  },
-  {
-    "id": 947,
-    "locality": "Global",
-    "task": "Reach at least level 40 in all non-elite skills.",
-    "information": "Reach at least level 40 in all non-elite skills.",
-    "requirements": "All skills except Invention at level 40",
-    "points": 80
-  },
-  {
-    "id": 948,
-    "locality": "Global",
-    "task": "Reach at least level 60 in all non-elite skills.",
-    "information": "Reach at least level 60 in all non-elite skills.",
-    "requirements": "All skills except Invention at level 60",
-    "points": 80
-  },
-  {
-    "id": 949,
-    "locality": "Global",
-    "task": "Reach at least level 70 in all non-elite skills.",
-    "information": "Reach at least level 70 in all non-elite skills.",
-    "requirements": "All skills except Invention at level 70",
-    "points": 80
-  },
-  {
-    "id": 950,
-    "locality": "Kandarin: Ardougne",
-    "task": "Throw coins into the deep sea whirlpool.",
-    "information": "Throw some gold coins into the Whirlpool at the Deep Sea Fishing platform.",
-    "requirements": "68 Fishing",
-    "points": 80
-  },
-  {
-    "id": 951,
-    "locality": "Kandarin: Ardougne",
-    "task": "Solve the Archaeology mystery: Leap of Faith.",
-    "information": "Solve the Leap of Faith Archaeology mystery.",
-    "requirements": "70 Archaeology",
-    "points": 80
-  },
-  {
-    "id": 952,
-    "locality": "Kandarin: Ardougne",
-    "task": "Collect all breeds of chinchompa at the Player Owned Farm.",
-    "information": "Breed all types of Chinchompas.",
-    "requirements": "54 Farming, 20 Construction, 97 Hunter to catch crystal chinchompas.",
-    "points": 80
-  },
-  {
-    "id": 953,
-    "locality": "Kandarin: Ardougne",
-    "task": "Equip one piece of the Fishing outfit.",
-    "information": "Equip one piece of the Fishing outfit.",
-    "requirements": "140 fishing tokens",
-    "points": 80
-  },
-  {
-    "id": 954,
-    "locality": "Kandarin: Ardougne",
-    "task": "Defeat the Penance Queen.",
-    "information": "Defeat the Penance Queen.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 955,
-    "locality": "Kandarin: Ardougne",
-    "task": "Pickpocket a Hero.",
-    "information": "Pickpocket a Hero.",
-    "requirements": "80 Thieving",
-    "points": 80
-  },
-  {
-    "id": 956,
-    "locality": "Kandarin: Ardougne",
-    "task": "Catch 50 Red Chinchompas in Kandarin.",
-    "information": "Catch 50 carnivorous chinchompas in Kandarin.",
-    "requirements": "63 Hunter",
-    "points": 80
-  },
-  {
-    "id": 957,
-    "locality": "Kandarin: Feldip Hills",
-    "task": "Equip an Ogre Expert hat.",
-    "information": "Equip an Ogre Expert hat.",
-    "requirements": "1,000 chompy bird kills",
-    "points": 80
-  },
-  {
-    "id": 958,
-    "locality": "Global",
-    "task": "Catch a Monkfish.",
-    "information": "Catch a raw monkfish.",
-    "requirements": "62 Fishing, Completion of Swan Song or from swarm fishing",
-    "points": 80
-  },
-  {
-    "id": 959,
-    "locality": "Global",
-    "task": "Recover all data for one memory-storage bot in the Hall of Memories.",
-    "information": "Recover all data for memory-storage bot (Aagi) in the Hall of Memories.",
-    "requirements": "70 Divination",
-    "points": 80
-  },
-  {
-    "id": 960,
-    "locality": "Kandarin: Seers Village",
-    "task": "Use the Piety Prayer.",
-    "information": "Use the Piety Prayer.",
-    "requirements": "70 Prayer, 70 Defence, Completion of Knight Waves training ground",
-    "points": 80
-  },
-  {
-    "id": 961,
-    "locality": "Kandarin: Ardougne",
-    "task": "Complete the task set: Hard Ardougne.",
-    "information": "Complete the Hard Ardougne Diary.",
-    "requirements": "See Hard Ardougne achievements page",
-    "points": 80
-  },
-  {
-    "id": 962,
-    "locality": "Karamja",
-    "task": "Use the stepping stone across the river in Shilo village.",
-    "information": "Use the Stepping Stones Agility Shortcut in Shilo Village.",
-    "requirements": "74 Agility, Completion of Shilo Village",
-    "points": 80
-  },
-  {
-    "id": 963,
-    "locality": "Karamja",
-    "task": "Equip a full set of Obsidian armour.",
-    "information": "Equip a full set of Obsidian armour.",
-    "requirements": "60 Defence, Completion of The Brink of Extinction, 80 Smithing",
-    "points": 80
-  },
-  {
-    "id": 964,
-    "locality": "Karamja",
-    "task": "Equip a Red Topaz Machete.",
-    "information": "Equip a Red Topaz Machete.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 965,
-    "locality": "Karamja",
-    "task": "Find a Gout Tuber.",
-    "information": "Find a Gout Tuber.",
-    "requirements": "10 Woodcutting, Completion of Jungle Potion",
-    "points": 80
-  },
-  {
-    "id": 966,
-    "locality": "Karamja",
-    "task": "Defeat TzTok-Jad.",
-    "information": "Defeat TzTok-Jad once.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 967,
-    "locality": "Karamja",
-    "task": "Defeat TzTok-Jad.",
-    "information": "Defeat TzTok-Jad 25 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 968,
-    "locality": "Karamja",
-    "task": "Use your fire cape on TzTok-Jad before defeating them.",
-    "information": "Use your fire cape on TzTok-Jad before defeating them.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 969,
-    "locality": "Karamja",
-    "task": "Equip a Fire Cape.",
-    "information": "Equip a Fire Cape.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 970,
-    "locality": "Karamja",
-    "task": "Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.",
-    "information": "Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.",
-    "requirements": "60 Defence and one of 60 Attack, 60 Strength, 60 Magic, or 60 Ranged, Completion of The Brink of Extinction",
-    "points": 80
-  },
-  {
-    "id": 971,
-    "locality": "Karamja",
-    "task": "Repair the fairy ring inside the Kharazi jungle.",
-    "information": "Repair the fairy ring inside the Kharazi jungle.",
-    "requirements": "Partial completion of Legends' Quest, 5 bittercap mushrooms",
-    "points": 80
-  },
-  {
-    "id": 972,
-    "locality": "Karamja",
-    "task": "Access the Gemstone cavern.",
-    "information": "Access the Gemstone cavern.",
-    "requirements": "Hard Karamja achievements and either an uncut dragonstone or a gemstone dragon Slayer task (requires 95 Slayer)",
-    "points": 80
-  },
-  {
-    "id": 973,
-    "locality": "Karamja",
-    "task": "Catch a Draconic jadinko at Herblore Habitat.",
-    "information": "Catch a Draconic jadinko at Herblore Habitat.",
-    "requirements": "80 Hunter",
-    "points": 80
-  },
-  {
-    "id": 974,
-    "locality": "Karamja",
-    "task": "Craft a Bolas.",
-    "information": "Craft a Bolas.",
-    "requirements": "87 Fletching, 80 Slayer",
-    "points": 80
-  },
-  {
-    "id": 975,
-    "locality": "Karamja",
-    "task": "Complete the task set: Hard Karamja.",
-    "information": "Complete the hard Karamja Diary.",
-    "requirements": "See Hard Karamja achievements page",
-    "points": 80
-  },
-  {
-    "id": 976,
-    "locality": "Karamja",
-    "task": "Collect 60 Agility Arena tickets from the Brimhaven Agility Arena.",
-    "information": "Receive 60 Agility Arena Tickets With No Mistakes.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 977,
-    "locality": "Karamja",
-    "task": "Defeat TzTok-Jad in less than 45:00.",
-    "information": "Defeat TzTok-Jad in less than 45:00.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 978,
-    "locality": "Karamja",
-    "task": "Complete the Fight Kiln.",
-    "information": "Complete the Fight Kiln.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape",
-    "points": 80
-  },
-  {
-    "id": 979,
-    "locality": "Karamja",
-    "task": "Equip a TokHaar-Kal-Ket.",
-    "information": "Equip a TokHaar-Kal-Ket.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape (once)",
-    "points": 80
-  },
-  {
-    "id": 980,
-    "locality": "Karamja",
-    "task": "Equip a TokHaar-Kal-Xil.",
-    "information": "Equip a TokHaar-Kal-Xil.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape (once)",
-    "points": 80
-  },
-  {
-    "id": 981,
-    "locality": "Karamja",
-    "task": "Equip a TokHaar-Kal-Mej.",
-    "information": "Equip a TokHaar-Kal-Mej.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape (once)",
-    "points": 80
-  },
-  {
-    "id": 982,
-    "locality": "Karamja",
-    "task": "Equip a TokHaar-Kal-Mor.",
-    "information": "Equip a TokHaar-Kal-Mor.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape (once)",
-    "points": 80
-  },
-  {
-    "id": 983,
-    "locality": "Karamja",
-    "task": "Complete the Fight Kiln and collect an uncut onyx.",
-    "information": "Complete the Fight Kiln and collect an uncut onyx.",
-    "requirements": "Completion of The Elder Kiln, hand in a fire cape (once)",
-    "points": 80
-  },
-  {
-    "id": 984,
-    "locality": "Karamja",
-    "task": "Complete all TzTok-Jad combat achievements.",
-    "information": "Complete all TzTok-Jad combat achievements.",
-    "requirements": "See TzTok-Jad achievements page",
-    "points": 80
-  },
-  {
-    "id": 985,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Siphon from a death esswraith in the RuneSpan.",
-    "information": "Siphon from a death esswraith in the RuneSpan.",
-    "requirements": "66 Runecrafting",
-    "points": 80
-  },
-  {
-    "id": 986,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Obtain the Massive Pouch from the RuneSpan.",
-    "information": "Obtain the massive pouch from the RuneSpan.",
-    "requirements": "90 Runecrafting, 1,000 Runespan points",
-    "points": 80
-  },
-  {
-    "id": 987,
-    "locality": "Misthalin: Draynor Village",
-    "task": "Equip the full Master Runecrafter skilling outfit.",
-    "information": "Equip the full master runecrafter robes set.",
-    "requirements": "50 Runecrafting, 60,000 Runecrafting guild tokens, 16,000 Runespan points, or 2,000 thaler",
-    "points": 80
-  },
-  {
-    "id": 988,
-    "locality": "Misthalin: Edgeville",
-    "task": "Complete the task set: Hard Varrock.",
-    "information": "Complete all of the Hard Varrock achievements and claim rewards from Vannaka in Edgeville.",
-    "requirements": "See Hard Varrock achievements page",
-    "points": 80
-  },
-  {
-    "id": 989,
-    "locality": "Misthalin: Edgeville",
-    "task": "Make a waka canoe near Edgeville.",
-    "information": "Make a waka canoe near Edgeville.",
-    "requirements": "57 Woodcutting",
-    "points": 80
-  },
-  {
-    "id": 990,
-    "locality": "Misthalin: Edgeville",
-    "task": "Chop down the Edgeville elder tree.",
-    "information": "Chop down the Edgeville elder tree.",
-    "requirements": "90 Woodcutting",
-    "points": 80
-  },
-  {
-    "id": 991,
-    "locality": "Misthalin: Fort Forinthry",
-    "task": "Upgrade the workshop in Fort Forinthry to Tier 3.",
-    "information": "Upgrade the workshop in Fort Forinthry to tier 3.",
-    "requirements": "75 Construction, Completion of New Foundations",
-    "points": 80
-  },
-  {
-    "id": 992,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Enter Zanaris via Lumbridge Swamp.",
-    "information": "Enter Zanaris via Lumbridge Swamp.",
-    "requirements": "Partial completion of Lost City",
-    "points": 80
-  },
-  {
-    "id": 993,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Complete the task set: Hard Lumbridge.",
-    "information": "Complete all Hard Tasks in Lumbridge and claim rewards from Ned in Draynor Village.",
-    "requirements": "See Hard Lumbridge achievements page",
-    "points": 80
-  },
-  {
-    "id": 994,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Unlock the Bladed Dive ability from Shattered Worlds.",
-    "information": "Unlock the Bladed Dive ability from Shattered Worlds.",
-    "requirements": "63,000,000 shattered anima",
-    "points": 80
-  },
-  {
-    "id": 995,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Smith a mithril platebody on the anvil in the jailhouse sewers.",
-    "information": "Smith a mithril platebody on the anvil in the jailhouse sewers.",
-    "requirements": "30 Smithing",
-    "points": 80
-  },
-  {
-    "id": 996,
-    "locality": "Misthalin: Lumbridge",
-    "task": "Fully grow a magic tree in Lumbridge.",
-    "information": "Fully grow a magic tree in Lumbridge.",
-    "requirements": "75 Farming",
-    "points": 80
-  },
-  {
-    "id": 997,
-    "locality": "Misthalin: City of Um",
-    "task": "Defeat Hermod, the Spirit of War.",
-    "information": "Defeat Hermod, the Spirit of War once.",
-    "requirements": "Completion of The Spirit of War",
-    "points": 80
-  },
-  {
-    "id": 998,
-    "locality": "Misthalin: City of Um",
-    "task": "Defeat Hermod, the Spirit of War.",
-    "information": "Defeat Hermod, the Spirit of War 100 times.",
-    "requirements": "Completion of The Spirit of War",
-    "points": 80
-  },
-  {
-    "id": 999,
-    "locality": "Misthalin: City of Um",
-    "task": "Rest whilst listening to the Dead Beats in the City of Um.",
-    "information": "Rest whilst listening to the Dead Beats in the City of Um.",
-    "requirements": "Completion of That Old Black Magic",
-    "points": 80
-  }
-,
-  {
-    "id": 1000,
-    "locality": "Misthalin: City of Um",
-    "task": "Smelt a necronium bar at the smithy in the City of Um.",
-    "information": "Smelt a necronium bar at the smithy in the City of Um.",
-    "requirements": "70 Smithing, Partial completion of Necromancy!",
-    "points": 80
-  },
-  {
-    "id": 1001,
-    "locality": "Misthalin: City of Um",
-    "task": "Create a passing bracelet, performing each step in the City of Um.",
-    "information": "Create a passing bracelet, performing each step in the City of Um.",
-    "requirements": "60 Necromancy for bar, 79 Crafting, 68 Magic, Ensouled bar, moonstone, runes for Lvl-5 Enchant. The moonstone is most easily obtained from completing Housing of Parliament, which requires 54 Necromancy.",
-    "points": 80
-  },
-  {
-    "id": 1002,
-    "locality": "Misthalin: City of Um",
-    "task": "Catch a ghostly impling while wearing a full set of ghostly robes.",
-    "information": "Catch a ghostly impling while wearing a full set of ghostly robes.",
-    "requirements": "68 Hunter, Completion of The Curse of Zaros (miniquest)",
-    "points": 80
-  },
-  {
-    "id": 1003,
-    "locality": "Misthalin: City of Um",
-    "task": "Upgrade a set of Death Skull equipment to tier 70.",
-    "information": "Upgrade a set of Death Skull equipment to tier 70.",
-    "requirements": "70 Necromancy, Completion of The Spirit of War. See also Kili's Knowledge V.",
-    "points": 80
-  },
-  {
-    "id": 1004,
-    "locality": "Misthalin: City of Um",
-    "task": "Complete a Powerful Communion ritual.",
-    "information": "Complete a powerful communion ritual.",
-    "requirements": "90 Necromancy",
-    "points": 80
-  },
-  {
-    "id": 1005,
-    "locality": "Misthalin: City of Um",
-    "task": "Conjure an undead army at the City of Um ritual site.",
-    "information": "Conjure an undead army at the City of Um ritual site.",
-    "requirements": "99 Necromancy, Conjure Undead Army unlocked in the Well of Souls",
-    "points": 80
-  },
-  {
-    "id": 1006,
-    "locality": "Misthalin: Varrock",
-    "task": "Obtain a new set of Family Crest gauntlets from Dimintheis.",
-    "information": "Obtain a new set of Family Crest gauntlets from Dimintheis.",
-    "requirements": "Completion of Family Crest",
-    "points": 80
-  },
-  {
-    "id": 1007,
-    "locality": "Misthalin: Varrock",
-    "task": "Talk to Romily Weaklax and give him a wild pie.",
-    "information": "Talk to Romily Weaklax and give him a wild pie.",
-    "requirements": "85 Cooking to make it from scratch, or 50 Hunter to get it as a rare drop from eclectic implings",
-    "points": 80
-  },
-  {
-    "id": 1008,
-    "locality": "Misthalin: Varrock",
-    "task": "Harness the power of three relics at once.",
-    "information": "Activate 3 Archaeology relics at once",
-    "requirements": "25 Archaeology, A Ring of Luck to unlock the Hand of Glory relic.",
-    "points": 80
-  },
-  {
-    "id": 1009,
-    "locality": "Misthalin: Varrock",
-    "task": "Mine 50 Dark Animica from the Empty Throne Room.",
-    "information": "Mine 50 dark animica from the Empty Throne Room mine.",
-    "requirements": "90 Mining",
-    "points": 80
-  },
-  {
-    "id": 1010,
-    "locality": "Misthalin: Varrock",
-    "task": "Defeat Kerapac, the bound.",
-    "information": "Defeat Kerapac, the bound once.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 1011,
-    "locality": "Misthalin: Varrock",
-    "task": "Defeat the Arch-Glacor.",
-    "information": "Defeat the Arch-Glacor.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 1012,
-    "locality": "Misthalin: City of Um",
-    "task": "Defeat Nakatra, Devourer Eternal.",
-    "information": "Defeat Nakatra, Devourer Eternal.",
-    "requirements": "Completion of Necromancy!, completion of Soul Searching",
-    "points": 80
-  },
-  {
-    "id": 1013,
-    "locality": "Misthalin: City of Um",
-    "task": "Cleanse the Gate of Elidinis.",
-    "information": "Cleanse the Gate of Elidinis.",
-    "requirements": "Completion of Ode of the Devourer (or Soul Searching if tier 4 reached)",
-    "points": 80
-  },
-  {
-    "id": 1014,
-    "locality": "Misthalin: City of Um",
-    "task": "Complete the task set: Hard Underworld.",
-    "information": "Complete the Hard Underworld achievements.",
-    "requirements": "See Hard Underworld achievements page",
-    "points": 80
-  },
-  {
-    "id": 1015,
-    "locality": "Morytania",
-    "task": "Take a hard companion through a hard route of Temple Trekking.",
-    "information": "Take a hard companion through a hard route of Temple Trekking.",
-    "requirements": "Completion of In Aid of the Myreque",
-    "points": 80
-  },
-  {
-    "id": 1016,
-    "locality": "Morytania",
-    "task": "Mine 30 Phasmatite.",
-    "information": "Mine 30 phasmatite near Port Phasmatys.",
-    "requirements": "70 Mining",
-    "points": 80
-  },
-  {
-    "id": 1017,
-    "locality": "Morytania",
-    "task": "Defeat 25 Gargoyles.",
-    "information": "Defeat 25 Gargoyles.",
-    "requirements": "75 Slayer",
-    "points": 80
-  },
-  {
-    "id": 1018,
-    "locality": "Morytania",
-    "task": "Defeat 35 Aberrant Spectres.",
-    "information": "Defeat 35 Aberrant Spectres.",
-    "requirements": "60 Slayer",
-    "points": 80
-  },
-  {
-    "id": 1019,
-    "locality": "Morytania",
-    "task": "Equip a full set of Ahrim's equipment, including the staff.",
-    "information": "Equip a full set of Ahrim's equipment, including the staff.",
-    "requirements": "70 Defence, 70 Magic",
-    "points": 80
-  },
-  {
-    "id": 1020,
-    "locality": "Morytania",
-    "task": "Equip a full set of Dharok's equipment, including the greataxe.",
-    "information": "Equip a full set of Dharok's equipment, including the greataxe.",
-    "requirements": "70 Defence, 70 Attack",
-    "points": 80
-  },
-  {
-    "id": 1021,
-    "locality": "Morytania",
-    "task": "Equip a full set of Guthan's equipment, including the warspear.",
-    "information": "Equip a full set of Guthan's equipment, including the Guthan's warspear.",
-    "requirements": "70 Defence, 70 Attack",
-    "points": 80
-  },
-  {
-    "id": 1022,
-    "locality": "Morytania",
-    "task": "Equip a full set of Torag's equipment, including the hammer.",
-    "information": "Equip a full set of Torag's equipment, including the hammer.",
-    "requirements": "70 Defence, 70 Attack",
-    "points": 80
-  },
-  {
-    "id": 1023,
-    "locality": "Morytania",
-    "task": "Equip a full set of Verac's equipment, including the flail.",
-    "information": "Equip a full set of Verac's equipment, including the flail.",
-    "requirements": "70 Defence, 70 Attack",
-    "points": 80
-  },
-  {
-    "id": 1024,
-    "locality": "Morytania",
-    "task": "Equip a full set of Karil's equipment, including the 2h crossbow.",
-    "information": "Equip a full set of Karil's equipment, including the 2h crossbow.",
-    "requirements": "70 Defence, 70 Ranged",
-    "points": 80
-  },
-  {
-    "id": 1025,
-    "locality": "Morytania",
-    "task": "Complete the quest: The Branches of Darkmeyer.",
-    "information": "Complete The Branches of Darkmeyer.",
-    "requirements": "See quest page",
-    "points": 80
-  },
-  {
-    "id": 1026,
-    "locality": "Morytania",
-    "task": "Burn 20 Blisterwood logs.",
-    "information": "Burn 20 Blisterwood logs.",
-    "requirements": "76 Woodcutting, 76 Firemaking, Partial completion of The Branches of Darkmeyer",
-    "points": 80
-  },
-  {
-    "id": 1027,
-    "locality": "Morytania",
-    "task": "Fully level up all Temple Trekking companions.",
-    "information": "Fully level up all Temple Trekking companions.",
-    "requirements": "Completion of In Aid of the Myreque",
-    "points": 80
-  },
-  {
-    "id": 1028,
-    "locality": "Morytania",
-    "task": "Catch 5 sharks in Burgh de Rott.",
-    "information": "Catch 5 sharks in Burgh de Rott.",
-    "requirements": "76 Fishing, Partial completion of In Aid of the Myreque",
-    "points": 80
-  },
-  {
-    "id": 1029,
-    "locality": "Morytania",
-    "task": "Complete the task set: Hard Morytania.",
-    "information": "Complete the hard Morytania Diary.",
-    "requirements": "See Hard Morytania achievements page",
-    "points": 80
-  },
-  {
-    "id": 1030,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Plant a mushroom seed in the mushroom patch in Isafdar.",
-    "information": "Plant a mushroom seed in the mushroom patch in Isafdar.",
-    "requirements": "53 Farming, Completion of the medium Tirannwn achievements.",
-    "points": 80
-  },
-  {
-    "id": 1031,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Defeat 30 Cadarn warriors in Prifddinas.",
-    "information": "Defeat 30 Cadarn warriors in Prifddinas.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 1032,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Harvest some harmony moss from a harmony pillar.",
-    "information": "Harvest some harmony moss from a harmony pillar.",
-    "requirements": "75 Farming",
-    "points": 80
-  },
-  {
-    "id": 1033,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Complete the Hefin Agility course with a light creature familiar summoned.",
-    "information": "Complete the Hefin Agility course with a light creature familiar summoned.",
-    "requirements": "77 Agility, 88 Summoning, 71 Divination",
-    "points": 80
-  },
-  {
-    "id": 1034,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Cleanse the Corrupted Seren stone with 5 cleansing crystals.",
-    "information": "Cleanse the Corrupted Seren stone with 5 cleansing crystals.",
-    "requirements": "75 Prayer",
-    "points": 80
-  },
-  {
-    "id": 1035,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Complete 10 laps of the Hefin agility course.",
-    "information": "Complete 10 laps of the Hefin agility course.",
-    "requirements": "77 Agility",
-    "points": 80
-  },
-  {
-    "id": 1036,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Harvest 100 Incandescent energy from Incandescent Wisps.",
-    "information": "Harvest 100 Incandescent energy from Incandescent Wisps.",
-    "requirements": "95 Divination",
-    "points": 80
-  },
-  {
-    "id": 1037,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Equip a Dark bow.",
-    "information": "Equip a Dark bow.",
-    "requirements": "90 Slayer, 70 Ranged, 70 Defence",
-    "points": 80
-  },
-  {
-    "id": 1038,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Defeat 30 Dark beasts in Tirannwn.",
-    "information": "Defeat 30 Dark beasts in Tirannwn.",
-    "requirements": "90 Slayer",
-    "points": 80
-  },
-  {
-    "id": 1039,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Equip a Crystal halberd.",
-    "information": "Equip a Crystal halberd.",
-    "requirements": "50 Agility, 70 Attack",
-    "points": 80
-  },
-  {
-    "id": 1040,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Equip a Crystal shield.",
-    "information": "Equip a Crystal shield.",
-    "requirements": "50 Agility, 70 Defence",
-    "points": 80
-  },
-  {
-    "id": 1041,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Equip a Crystal bow.",
-    "information": "Equip a Crystal bow.",
-    "requirements": "50 Agility, 70 Ranged",
-    "points": 80
-  },
-  {
-    "id": 1042,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Catch 25 Grenwalls in Isafdar.",
-    "information": "Catch 25 Grenwalls in Isafdar.",
-    "requirements": "77 Hunter",
-    "points": 80
-  },
-  {
-    "id": 1043,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Defeat 10 Elf warriors in Lletya.",
-    "information": "Defeat 10 Elf warriors in Lletya.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 1044,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Chop 50 Magic logs in Tirannwn.",
-    "information": "Chop 50 Magic logs in Tirannwn.",
-    "requirements": "80 Woodcutting",
-    "points": 80
-  },
-  {
-    "id": 1045,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Open the crystal chest in Prifddinas 10 times.",
-    "information": "Open the crystal chest in Prifddinas 10 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 1046,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Charge a piece of Dragonstone jewellery using the Tears of Seren.",
-    "information": "Charge a piece of Dragonstone jewellery using the Tears of Seren.",
-    "requirements": "Completion of Legends' Quest",
-    "points": 80
-  },
-  {
-    "id": 1047,
-    "locality": "Elven Lands: Tirranwn",
-    "task": "Complete the task set: Hard Tirannwn.",
-    "information": "Complete the hard Tirannwn Diary.",
-    "requirements": "See Hard Tirannwn achievements page",
-    "points": 80
-  },
-  {
-    "id": 1048,
-    "locality": "Wilderness: General",
-    "task": "Defeat the King Black Dragon while wearing black dragonhide in six equipment slots. Can only be completed in a solo instance.",
-    "information": "Defeat the King Black Dragon while wearing black dragonhide in six equipment slots.",
-    "requirements": "60 Defence",
-    "points": 80
-  },
-  {
-    "id": 1049,
-    "locality": "Wilderness: General",
-    "task": "Defeat one of each revenant creature in the Forinthry dungeon.",
-    "information": "Defeat one of each revenant creature in the Forinthry dungeon.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 1050,
-    "locality": "Wilderness: General",
-    "task": "Equip a Statius's warhammer.",
-    "information": "Equip a Statius's warhammer.",
-    "requirements": "78 Attack",
-    "points": 80
-  },
-  {
-    "id": 1051,
-    "locality": "Wilderness: General",
-    "task": "Catch 25 Black Salamanders.",
-    "information": "Catch 25 Black Salamanders.",
-    "requirements": "67 Hunter",
-    "points": 80
-  },
-  {
-    "id": 1052,
-    "locality": "Wilderness: Daemonheim",
-    "task": "Restore an artefact from the Daemonheim digsite.",
-    "information": "Restore an artefact from the Daemonheim digsite.",
-    "requirements": "73 Archaeology",
-    "points": 80
-  },
-  {
-    "id": 1053,
-    "locality": "Wilderness: General",
-    "task": "Defeat the Corporeal Beast.",
-    "information": "Defeat the Corporeal Beast once.",
-    "requirements": "Completion of Summer's End",
-    "points": 80
-  },
-  {
-    "id": 1054,
-    "locality": "Wilderness: General",
-    "task": "Defeat the Corporeal Beast.",
-    "information": "Defeat the Corporeal Beast 100 times.",
-    "requirements": "Completion of Summer's End",
-    "points": 80
-  },
-  {
-    "id": 1055,
-    "locality": "Wilderness: Daemonheim",
-    "task": "Defeat the Skeletal Trio.",
-    "information": "Defeat the Skeletal Trio.",
-    "requirements": "71 Dungeoneering",
-    "points": 80
-  },
-  {
-    "id": 1056,
-    "locality": "Wilderness: Daemonheim",
-    "task": "Upgrade your Gem bag.",
-    "information": "Upgrade your Gem bag.",
-    "requirements": "40 Dungeoneering, 45 Crafting, 20,000 dungeoneering tokens",
-    "points": 80
-  },
-  {
-    "id": 1057,
-    "locality": "Wilderness: General",
-    "task": "Equip a pair of Steadfast boots.",
-    "information": "Equip a pair of Steadfast boots.",
-    "requirements": "85 Defence",
-    "points": 80
-  },
-  {
-    "id": 1058,
-    "locality": "Wilderness: General",
-    "task": "Equip a pair of Glaiven boots.",
-    "information": "Equip a pair of Glaiven boots.",
-    "requirements": "85 Defence",
-    "points": 80
-  },
-  {
-    "id": 1059,
-    "locality": "Wilderness: General",
-    "task": "Equip a pair of Ragefire boots.",
-    "information": "Equip a pair of Ragefire boots.",
-    "requirements": "85 Defence",
-    "points": 80
-  },
-  {
-    "id": 1060,
-    "locality": "Wilderness: General",
-    "task": "Complete the task set: Hard Wilderness.",
-    "information": "Complete the hard Wilderness Diary.",
-    "requirements": "See Hard Wilderness achievements page",
-    "points": 80
-  },
-  {
-    "id": 1061,
-    "locality": "Wilderness: Daemonheim",
-    "task": "Equip a Chaotic weapon or kiteshield.",
-    "information": "Equip a Chaotic weapon or kiteshield.",
-    "requirements": "80 Dungeoneering, 80 Attack OR 80 Ranged OR 80 Magic OR 80 Defence",
-    "points": 80
-  },
-  {
-    "id": 1062,
-    "locality": "Anachronia",
-    "task": "Harvest produce from 25 animals on Anachronia farm.",
-    "information": "Harvest produce from 25 animals on Anachronia farm.",
-    "requirements": "42 Farming, 45 Construction",
-    "points": 80
-  },
-  {
-    "id": 1063,
-    "locality": "Anachronia",
-    "task": "Complete the ritual to activate a totem on Anachronia.",
-    "information": "Complete the ritual to activate a totem on Anachronia.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 1064,
-    "locality": "Anachronia",
-    "task": "Complete the Anachronia agility course in under 7 minutes.",
-    "information": "Complete the Anachronia agility course in under 7 minutes.",
-    "requirements": "85 Agility",
-    "points": 80
-  },
-  {
-    "id": 1065,
-    "locality": "Anachronia",
-    "task": "Complete all frog breeds.",
-    "information": "Complete all frog breeds.",
-    "requirements": "42 Farming, 45 Construction",
-    "points": 80
-  },
-  {
-    "id": 1066,
-    "locality": "Anachronia",
-    "task": "Purchase the Quick Traps upgrade from Irwinsson's Hunter Mark shop.",
-    "information": "Purchase the quick traps upgrade from the Hunter Mark Shop.",
-    "requirements": "50 hunter marks",
-    "points": 80
-  },
-  {
-    "id": 1067,
-    "locality": "Anachronia",
-    "task": "Complete the quest: Osseous Rex.",
-    "information": "Complete the Osseous Rex quest.",
-    "requirements": "See quest page",
-    "points": 80
-  },
-  {
-    "id": 1068,
-    "locality": "Anachronia",
-    "task": "Clear an Overgrown idol on Anachronia.",
-    "information": "Clear an overgrown idol on Anachronia.",
-    "requirements": "81 Woodcutting",
-    "points": 80
-  },
-  {
-    "id": 1069,
-    "locality": "Anachronia",
-    "task": "Defeat any of the Rex Matriarchs.",
-    "information": "Defeat any of the Rex Matriarchs once.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 1070,
-    "locality": "Anachronia",
-    "task": "Defeat any of the Rex Matriarchs. (100 times)",
-    "information": "Defeat any of the Rex Matriarchs 100 times.",
-    "requirements": "N/A",
-    "points": 80
-  },
-  {
-    "id": 1071,
-    "locality": "Anachronia",
-    "task": "Complete the quest: Desperate Times.",
-    "information": "Complete the Desperate Times quest.",
-    "requirements": "See quest page",
-    "points": 80
-  },
-  {
-    "id": 1072,
-    "locality": "Anachronia",
-    "task": "Find all the hidden Zygomites on Anachronia.",
-    "information": "Find all of the ancient zygomites on Anachronia. See the page for a route.",
-    "requirements": "85 Agility",
-    "points": 80
-  },
-  {
-    "id": 1073,
-    "locality": "Anachronia",
-    "task": "Equip Laniakea's spear.",
-    "information": "Equip Laniakea's spear.",
-    "requirements": "82 Attack",
-    "points": 80
-  },
-  {
-    "id": 1074,
-    "locality": "Anachronia",
-    "task": "Harvest an Arbuck herb.",
-    "information": "Harvest an arbuck herb.",
-    "requirements": "77 Farming",
-    "points": 80
-  },
-  {
-    "id": 1075,
-    "locality": "Anachronia",
-    "task": "Complete the advanced sections of the Anachronia agility course.",
-    "information": "Complete the advanced sections of the Anachronia agility course.",
-    "requirements": "70 Agility",
-    "points": 80
-  },
-  {
-    "id": 1076,
-    "locality": "Anachronia",
-    "task": "Equip a Dragon Mattock.",
-    "information": "Equip a dragon mattock.",
-    "requirements": "60 Archaeology, (optional) 75 Hunter",
-    "points": 80
-  },
-  {
-    "id": 1077,
-    "locality": "Anachronia",
-    "task": "Take down each dinosaur in Big Game Hunter.",
-    "information": "Take down each dinosaur in Big Game Hunter.",
-    "requirements": "96 Hunter, 76 Slayer",
-    "points": 80
-  },
-  {
-    "id": 1078,
-    "locality": "Anachronia",
-    "task": "Get caught by each of the big game creatures once.",
-    "information": "Get caught by each of the Big Game Hunter creatures once.",
-    "requirements": "96 Hunter, 76 Slayer",
-    "points": 80
-  },
-  {
-    "id": 1079,
-    "locality": "Anachronia",
-    "task": "Complete a big game encounter without using movement abilities.",
-    "information": "Complete a Big Game Hunter encounter without using movement abilities.",
-    "requirements": "75 Hunter, 55 Slayer",
-    "points": 80
-  },
-  {
     "id": 1080,
-    "locality": "Anachronia",
-    "task": "Defeat Raksha, the Shadow Colossus.",
-    "information": "Defeat Raksha, the Shadow Colossus once.",
-    "requirements": "Completion of Raksha, the Shadow Colossus",
+    "taskId": 656,
+    "locality": "Wilderness: General",
+    "task": "Defeat the King Black Dragon while wearing black dragonhide in six equipment slots. Can only be completed in a solo instance.",
+    "information": "Defeat the King Black Dragon while wearing black dragonhide in six equipment slots.",
+    "requirements": "60 Defence",
     "points": 80
   },
   {
     "id": 1081,
-    "locality": "Asgarnia: Falador",
-    "task": "Reach 100% respect at the Artisans' Workshop.",
-    "information": "Reach 100% respect at the Artisans' Workshop.",
-    "requirements": "1 Smithing",
+    "taskId": 657,
+    "locality": "Wilderness: General",
+    "task": "Defeat one of each revenant creature in the Forinthry dungeon.",
+    "information": "Defeat one of each revenant creature in the Forinthry dungeon.",
+    "requirements": "N/A",
     "points": 80
   },
   {
     "id": 1082,
-    "locality": "Asgarnia: Falador",
-    "task": "Complete the task set: Hard Falador.",
-    "information": "Complete the Hard Falador achievements.",
-    "requirements": "See Hard Falador achievements page",
+    "taskId": 658,
+    "locality": "Wilderness: General",
+    "task": "Equip a Statius's warhammer.",
+    "information": "Equip a Statius's warhammer.",
+    "requirements": "78 Attack",
     "points": 80
   },
   {
     "id": 1083,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat any God Wars Dungeon boss 100 times.",
-    "information": "Defeat any God Wars Dungeon boss 100 times.",
-    "requirements": "Partial completion of Troll Stronghold",
+    "taskId": 659,
+    "locality": "Wilderness: General",
+    "task": "Catch 25 Black Salamanders.",
+    "information": "Catch 25 black salamanders.",
+    "requirements": "67 Hunter",
     "points": 80
   },
   {
     "id": 1084,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat any God Wars Dungeon boss 250 times.",
-    "information": "Defeat any God Wars Dungeon boss 250 times.",
-    "requirements": "Partial completion of Troll Stronghold",
+    "taskId": 660,
+    "locality": "Wilderness: Daemonheim",
+    "task": "Restore an artefact from the Daemonheim digsite.",
+    "information": "Restore an artefact from the Daemonheim digsite.",
+    "requirements": "73 Archaeology",
     "points": 80
   },
   {
     "id": 1085,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Commander Zilyana.",
-    "information": "Defeat Commander Zilyana",
-    "requirements": "70 Agility, Partial completion of Troll Stronghold",
+    "taskId": 661,
+    "locality": "Wilderness: General",
+    "task": "Defeat the Corporeal Beast.",
+    "information": "Defeat the Corporeal Beast once.",
+    "requirements": "Completion of Summer's End",
     "points": 80
   },
   {
     "id": 1086,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat General Graardor.",
-    "information": "Defeat General Graardor",
-    "requirements": "70 Strength, Partial completion of Troll Stronghold",
+    "taskId": 662,
+    "locality": "Wilderness: General",
+    "task": "Defeat the Corporeal Beast. (100 times)",
+    "information": "Defeat the Corporeal Beast 100 times.",
+    "requirements": "Completion of Summer's End",
     "points": 80
   },
   {
     "id": 1087,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat K'ril Tsutsaroth.",
-    "information": "Defeat K'ril Tsutsaroth",
-    "requirements": "70 Constitution, Partial completion of Troll Stronghold",
+    "taskId": 663,
+    "locality": "Wilderness: Daemonheim",
+    "task": "Defeat the Skeletal Trio.",
+    "information": "Defeat the Skeletal Trio.",
+    "requirements": "71 Dungeoneering",
     "points": 80
   },
   {
     "id": 1088,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Kree'arra.",
-    "information": "Defeat Kree'arra",
-    "requirements": "70 Ranged, Partial completion of Troll Stronghold",
+    "taskId": 664,
+    "locality": "Wilderness: Daemonheim",
+    "task": "Upgrade your Gem bag.",
+    "information": "Upgrade your gem bag.",
+    "requirements": "40 Dungeoneering, 45 Crafting",
     "points": 80
   },
   {
     "id": 1089,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Nex.",
-    "information": "Defeat Nex",
-    "requirements": "70 Agility, 70 Strength, 70 Constitution, 70 Ranged, Partial completion of Troll Stronghold, completion of The Dig Site, frozen key",
+    "taskId": 665,
+    "locality": "Wilderness: General",
+    "task": "Equip a pair of Steadfast boots.",
+    "information": "Equip a pair of steadfast boots.",
+    "requirements": "85 Defence",
     "points": 80
   },
   {
     "id": 1090,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Defeat Kree'arra. (100 times)",
-    "information": "Defeat Kree'arra 100 times.",
-    "requirements": "70 Ranged, Partial completion of Troll Stronghold",
+    "taskId": 666,
+    "locality": "Wilderness: General",
+    "task": "Equip a pair of Glaiven boots.",
+    "information": "Equip a pair of glaiven boots.",
+    "requirements": "85 Defence",
     "points": 80
   },
   {
     "id": 1091,
-    "locality": "Asgarnia: Burthorpe",
-    "task": "Assemble any godsword from the God Wars Dungeon.",
-    "information": "Assemble any godsword from the God Wars Dungeon.",
-    "requirements": "80 Smithing and one of 70 Agility, 70 Strength, 70 Constitution, or 70 Ranged",
+    "taskId": 667,
+    "locality": "Wilderness: General",
+    "task": "Equip a pair of Ragefire boots.",
+    "information": "Equip a pair of ragefire boots.",
+    "requirements": "85 Defence",
     "points": 80
   },
   {
     "id": 1092,
-    "locality": "Asgarnia: Port Sarim",
-    "task": "Defeat the Queen Black Dragon.",
-    "information": "Defeat the Queen Black Dragon.",
-    "requirements": "60 Summoning",
+    "taskId": 668,
+    "locality": "Wilderness: General",
+    "task": "Complete the task set: Hard Wilderness.",
+    "information": "Complete the Hard Wilderness achievements.",
+    "requirements": "See Hard Wilderness achievements page",
     "points": 80
   },
   {
     "id": 1093,
-    "locality": "Asgarnia: Port Sarim",
-    "task": "Defeat the Queen Black Dragon. (100 times)",
-    "information": "Defeat the Queen Black Dragon 100 times.",
-    "requirements": "60 Summoning",
+    "taskId": 678,
+    "locality": "Wilderness: Daemonheim",
+    "task": "Equip a Chaotic weapon or kiteshield.",
+    "information": "Equip a chaotic weapon or kiteshield.",
+    "requirements": "80 Dungeoneering, 80 Attack OR 80 Ranged OR 80 Magic OR 80 Defence",
     "points": 80
   },
   {
     "id": 1094,
-    "locality": "Asgarnia: Port Sarim",
-    "task": "Bury some frost dragon bones.",
-    "information": "Bury some frost dragon bones.",
-    "requirements": "85 Dungeoneering",
-    "points": 80
+    "taskId": 669,
+    "locality": "Wilderness: General",
+    "task": "Equip the Hellfire bow.",
+    "information": "Equip the hellfire bow.",
+    "requirements": "N/A",
+    "points": 150
   },
   {
     "id": 1095,
-    "locality": "Desert: General",
-    "task": "Defeat the Kalphite King.",
-    "information": "Defeat the Kalphite King.",
+    "taskId": 670,
+    "locality": "Wilderness: General",
+    "task": "Complete a slayer task from Mandrith.",
+    "information": "Complete a slayer task from Mandrith.",
     "requirements": "N/A",
-    "points": 80
+    "points": 150
   },
   {
     "id": 1096,
-    "locality": "Desert: General",
-    "task": "Defeat the Kalphite King. (100 times)",
-    "information": "Defeat the Kalphite King 100 times.",
-    "requirements": "N/A",
-    "points": 80
+    "taskId": 671,
+    "locality": "Wilderness: General",
+    "task": "Chop 20 Bloodwood logs in the Wilderness.",
+    "information": "Chop 20 bloodwood logs in the Wilderness.",
+    "requirements": "85 Woodcutting",
+    "points": 150
   },
   {
     "id": 1097,
-    "locality": "Desert: General",
-    "task": "Equip a drygore weapon.",
-    "information": "Equip a drygore weapon.",
-    "requirements": "90 Attack",
-    "points": 80
+    "taskId": 672,
+    "locality": "Wilderness: General",
+    "task": "Unlock the Greater Flurry, Barge, and Fury abilities.",
+    "information": "Unlock the Greater Flurry, Barge, and Fury abilities.",
+    "requirements": "Various",
+    "points": 150
   },
   {
     "id": 1098,
-    "locality": "Desert: General",
-    "task": "Become an honorary druid at the Garden of Kharid.",
-    "information": "Purchase the Druid/Druidess title for 50,000 Crux Eqal favour",
-    "requirements": "50 Farming",
-    "points": 80
+    "taskId": 673,
+    "locality": "Wilderness: General",
+    "task": "Crack 6 safes inside the Rogues' Castle.",
+    "information": "Crack 6 safes inside the Rogues' Castle.",
+    "requirements": "62 Thieving",
+    "points": 150
   },
   {
     "id": 1099,
-    "locality": "Desert: General",
-    "task": "Deploy a dreadnip.",
-    "information": "Deploy a dreadnip.",
-    "requirements": "20 of a collection of quests (see Dominion Tower#Requirements), 450 Dominion Tower kills",
-    "points": 80
-  }
-,
+    "taskId": 674,
+    "locality": "Wilderness: General",
+    "task": "Defeat 5 Ripper Demons.",
+    "information": "Defeat 5 ripper demons.",
+    "requirements": "96 Slayer",
+    "points": 150
+  },
   {
     "id": 1100,
-    "locality": "Desert: General",
-    "task": "Complete the task set: Hard Desert.",
-    "information": "Complete the Hard Desert achievements.",
-    "requirements": "See Hard Desert achievements page",
-    "points": 80
+    "taskId": 675,
+    "locality": "Wilderness: General",
+    "task": "Defeat 10 Lava Strykewyrms in the Wilderness, south of the Lava Maze.",
+    "information": "Defeat 10 lava strykewyrms in the Wilderness, south of the Lava Maze.",
+    "requirements": "94 Slayer",
+    "points": 150
   },
   {
     "id": 1101,
-    "locality": "Desert: General",
-    "task": "Defeat Avaryss and Nymora.",
-    "information": "Defeat the Twin Furies.",
-    "requirements": "80 Ranged",
-    "points": 80
+    "taskId": 676,
+    "locality": "Wilderness: General",
+    "task": "Equip Annihilation, Decimation, or Obliteration.",
+    "information": "Equip Annihilation, Decimation, or Obliteration.",
+    "requirements": "87 Attack, 87 Ranged, 87 Magic",
+    "points": 150
   },
   {
     "id": 1102,
-    "locality": "Desert: General",
-    "task": "Defeat Gregorovic.",
-    "information": "Defeat Gregorivic.",
-    "requirements": "80 Prayer",
-    "points": 80
+    "taskId": 677,
+    "locality": "Wilderness: Daemonheim",
+    "task": "Kill Blink in a solo Dungeoneering instance, without dying.",
+    "information": "Kill Blink in a solo Dungeoneering instance without dying.",
+    "requirements": "117 Dungeoneering",
+    "points": 150
   },
   {
     "id": 1103,
-    "locality": "Desert: General",
-    "task": "Defeat Vindicta and Gorvek.",
-    "information": "Defeat Vindicta.",
-    "requirements": "80 Attack",
-    "points": 80
+    "taskId": 679,
+    "locality": "Wilderness: General",
+    "task": "Defeat every miniboss inside the Dragonkin Laboratory.",
+    "information": "Defeat every miniboss inside the Dragonkin Laboratory.",
+    "requirements": "95 Dungeoneering",
+    "points": 150
   },
   {
     "id": 1104,
-    "locality": "Desert: General",
-    "task": "Defeat Helwyr.",
-    "information": "Defeat Helwyr.",
-    "requirements": "80 Magic",
-    "points": 80
+    "taskId": 680,
+    "locality": "Wilderness: General",
+    "task": "Defeat the Black Stone Dragon.",
+    "information": "Defeat the black stone dragon once.",
+    "requirements": "N/A",
+    "points": 150
   },
   {
     "id": 1105,
-    "locality": "Desert: General",
-    "task": "Defeat Avaryss and Nymora. (100 times)",
-    "information": "Defeat the Twin Furies 100 times.",
-    "requirements": "80 Ranged",
-    "points": 80
+    "taskId": 681,
+    "locality": "Wilderness: General",
+    "task": "Defeat the Black Stone Dragon. (25 times)",
+    "information": "Defeat the black stone dragon 25 times.",
+    "requirements": "N/A",
+    "points": 150
   },
   {
     "id": 1106,
-    "locality": "Desert: General",
-    "task": "Defeat Gregorovic. (100 times)",
-    "information": "Defeat Gregorivic 100 times.",
-    "requirements": "80 Prayer",
-    "points": 80
+    "taskId": 682,
+    "locality": "Wilderness: General",
+    "task": "Complete the task set: Elite Wilderness.",
+    "information": "Complete the Elite Wilderness achievements.",
+    "requirements": "See Elite Wilderness achievements page",
+    "points": 150
   },
   {
     "id": 1107,
-    "locality": "Desert: General",
-    "task": "Defeat Vindicta and Gorvek. (100 times)",
-    "information": "Defeat Vindicta 100 times.",
-    "requirements": "80 Attack",
-    "points": 80
+    "taskId": 683,
+    "locality": "Wilderness: General",
+    "task": "Defeat 25 Hydrix dragons in the Wilderness.",
+    "information": "Defeat 25 hydrix dragons in the Wilderness.",
+    "requirements": "101 Slayer",
+    "points": 150
   },
   {
     "id": 1108,
-    "locality": "Desert: General",
-    "task": "Defeat Helwyr. (100 times)",
-    "information": "Defeat Helwyr 100 times.",
-    "requirements": "80 Magic",
-    "points": 80
+    "taskId": 684,
+    "locality": "Wilderness: General",
+    "task": "Defeat 10 Abyssal lords in the Wilderness.",
+    "information": "Defeat 10 abyssal lords in the Wilderness.",
+    "requirements": "115 Slayer",
+    "points": 150
   },
   {
     "id": 1109,
-    "locality": "Desert: General",
-    "task": "Equip a Dragon Rider lance.",
-    "information": "Equip a Dragon Rider lance.",
-    "requirements": "85 Attack",
-    "points": 80
+    "taskId": 685,
+    "locality": "Wilderness: Daemonheim",
+    "task": "Mine 30 Primal ores.",
+    "information": "Mine 30 primal ores.",
+    "requirements": "99 Mining",
+    "points": 150
   },
   {
     "id": 1110,
-    "locality": "Desert: General",
-    "task": "Equip a wand or orb of the Cywir elders.",
-    "information": "Equip a wand or orb of the Cywir elders.",
-    "requirements": "85 Magic",
-    "points": 80
+    "taskId": 686,
+    "locality": "Wilderness: Daemonheim",
+    "task": "Smelt 150 Primal bars.",
+    "information": "Smelt 150 primal bars.",
+    "requirements": "99 Smithing",
+    "points": 150
   },
   {
     "id": 1111,
-    "locality": "Desert: General",
-    "task": "Equip a shadow glaive.",
-    "information": "Equip a shadow glaive.",
-    "requirements": "85 Ranged",
-    "points": 80
+    "taskId": 687,
+    "locality": "Wilderness: Daemonheim",
+    "task": "Defeat Kal'Ger the Warmonger.",
+    "information": "Defeat Kal'Ger the Warmonger.",
+    "requirements": "90 Dungeoneering",
+    "points": 150
   },
   {
     "id": 1112,
-    "locality": "Desert: General",
-    "task": "Equip a blade of Nymora or Avaryss.",
-    "information": "Equip a blade of Nymora or Avaryss.",
-    "requirements": "85 Attack",
-    "points": 80
+    "taskId": 689,
+    "locality": "Wilderness: General",
+    "task": "Defeat the Ambassador.",
+    "information": "Defeat the Ambassador once.",
+    "requirements": "N/A",
+    "points": 150
   },
   {
     "id": 1113,
-    "locality": "Desert: Menaphos",
-    "task": "Slay a combination of 500 corrupted or devourer creatures.",
-    "information": "Slay a combination of 500 corrupted creatures or soul devourers.",
-    "requirements": "88 Slayer, Completion of Icthlarin's Little Helper",
-    "points": 80
+    "taskId": 690,
+    "locality": "Wilderness: General",
+    "task": "Defeat the Ambassador. (25 times)",
+    "information": "Defeat the Ambassador 25 times.",
+    "requirements": "N/A",
+    "points": 150
   },
   {
     "id": 1114,
-    "locality": "Desert: General",
-    "task": "Defeat the Magister.",
-    "information": "Defeat the Magister.",
-    "requirements": "115 Slayer, Key to the Crossing",
-    "points": 80
+    "taskId": 691,
+    "locality": "Wilderness: General",
+    "task": "Equip a Spectral, Arcane, Elysian, or Divine spirit shield.",
+    "information": "Equip a spectral, arcane, Elysian, or divine spirit shield.",
+    "requirements": "75 Defence, 75 Prayer",
+    "points": 150
   },
   {
     "id": 1115,
-    "locality": "Desert: General",
-    "task": "Defeat the Magister. (50 times)",
-    "information": "Defeat the Magister 50 times.",
-    "requirements": "115 Slayer, Key to the Crossing",
-    "points": 80
+    "taskId": 692,
+    "locality": "Wilderness: General",
+    "task": "Defeat the Ambassador after allowing 4 unstable black holes to explode.",
+    "information": "Defeat the Ambassador after allowing 4 unstable black holes to explode.",
+    "requirements": "N/A",
+    "points": 150
   },
   {
     "id": 1116,
-    "locality": "Desert: Menaphos",
-    "task": "Find an Off-hand khopesh of the Kharidian in Shifting Tombs.",
-    "information": "Find an off-hand khopesh of the Kharidian in Shifting Tombs.",
-    "requirements": "At least one of 50 Dungeoneering, 50 Agility, 50 Thieving, or 50 Construction",
-    "points": 80
+    "taskId": 688,
+    "locality": "Wilderness: General",
+    "task": "Equip an Eldritch Crossbow.",
+    "information": "Equip an eldritch crossbow.",
+    "requirements": "92 Ranged",
+    "points": 150
   }
 ]


### PR DESCRIPTION
This feature adds the ability to look up a player by their RuneScape name and automatically populate their completed tasks.

- Adds the official Task ID to each task in `raw_tasks.txt` and `tasks.json`.
- Modifies the `process_tasks.js` script to handle the new Task ID column.
- Updates the main application logic in `script.js` to:
  - Fetch completed task IDs from the RuneScape wiki API.
  - Create a mapping from the official Task ID to the internal application ID.
  - Update the "Completed Tasks" list based on the API response.
  - Filter the "Available Tasks" list to remove the completed tasks.