### PR TITLE
fix: Use correct property name for completed tasks

### DIFF
--- a/script.js
+++ b/script.js
@@ -84,9 +84,9 @@ async function fetchPlayerStats() {
         const data = await response.json();
 
         completedTasks.clear();
-        // The API returns completed tasks in a `tasks` property.
-        if (data.tasks && Array.isArray(data.tasks)) {
-            data.tasks.forEach(completedTaskId => {
+        // The API returns completed tasks in a `league_tasks` property.
+        if (data.league_tasks && Array.isArray(data.league_tasks)) {
+            data.league_tasks.forEach(completedTaskId => {
                 if (taskIdMap.has(completedTaskId)) {
                     const internalId = taskIdMap.get(completedTaskId);
                     completedTasks.add(internalId);


### PR DESCRIPTION
The player lookup feature was not working because it was looking for a `tasks` property in the API response, but the correct property name is `league_tasks`.

This commit updates the `fetchPlayerStats` function in `script.js` to use the correct `league_tasks` property, ensuring that completed tasks are correctly identified and displayed when a player is looked up.