### PR TITLE
fix: Improve quest detection for wiki links

### DIFF
--- a/script.js
+++ b/script.js
@@ -204,7 +204,7 @@ function formatRequirements(requirements) {
     let skillMatches = [];
     let otherReqs = requirements;
 
-    const questRegex = /quest:\s*([^,]+)/gi;
+    const questRegex = /(?:completion of|quest:)\s*([^,]+)/gi;
     let match;
     while ((match = questRegex.exec(otherReqs)) !== null) {
         questMatches.push(match[1].trim());


### PR DESCRIPTION
This commit improves the logic for detecting quest requirements in task descriptions.

- The regular expression in the `formatRequirements` function has been updated to recognize quests prefixed with either "quest:" or "Completion of".
- This ensures that more quest requirements are correctly identified and automatically linked to their respective RuneScape Wiki pages, improving usability.