### PR TITLE
fix: Correct progress visualizer tier counts

### DIFF
--- a/process_tasks.js
+++ b/process_tasks.js
@@ -46,6 +46,28 @@ function processRecord(recordLines, id) {
         return null;
     }
 
+    let tier;
+    if (columns[2].trim().toLowerCase().includes('master')) {
+        tier = 'Master';
+    } else {
+        switch (points) {
+            case 10:
+                tier = 'Easy';
+                break;
+            case 30:
+                tier = 'Medium';
+                break;
+            case 80:
+                tier = 'Hard';
+                break;
+            case 200:
+                tier = 'Elite';
+                break;
+            default:
+                tier = 'Unknown';
+        }
+    }
+
     return {
         id: id,
         taskId: taskId,
@@ -53,7 +75,8 @@ function processRecord(recordLines, id) {
         task: columns[2].trim(),
         information: columns[3].trim(),
         requirements: columns[4].trim(),
-        points: points
+        points: points,
+        tier: tier
     };
 }
 

--- a/script.js
+++ b/script.js
@@ -163,21 +163,22 @@ function populateFilters() {
         locationFilter.appendChild(option);
     });
 
-    // Use a hardcoded map for points to ensure correct tiers and labels
-    const pointsTiers = {
-        10: 'Easy',
-        30: 'Medium',
-        80: 'Hard',
-        200: 'Elite',
-        400: 'Master'
+    const tiers = [...new Set(allTasks.map(task => task.tier))];
+    const tierPointMap = {
+        'Easy': 10,
+        'Medium': 30,
+        'Hard': 80,
+        'Elite': 200,
+        'Master': 400
     };
     pointsFilter.innerHTML = '<option value="all">All Points</option>';
-    for (const [value, label] of Object.entries(pointsTiers)) {
+    tiers.sort((a, b) => tierPointMap[a] - tierPointMap[b]).forEach(tier => {
+        const points = Object.keys(tierPointMap).find(key => tierPointMap[key] === (allTasks.find(t => t.tier === tier)?.points || 0)) || 0;
         const option = document.createElement('option');
-        option.value = value;
-        option.textContent = `${label} (${value} pts)`;
+        option.value = points;
+        option.textContent = `${tier} (${points} pts)`;
         pointsFilter.appendChild(option);
-    }
+    });
 
     // Use a hardcoded list of official skills to prevent incorrect entries
     const officialSkills = [
@@ -370,21 +371,21 @@ function updateProgressVisualization() {
         .filter(task => completedTasks.has(task.id))
         .reduce((sum, task) => sum + task.points, 0);
 
-    const pointsTiers = {
-        10: 'Easy',
-        30: 'Medium',
-        80: 'Hard',
-        200: 'Elite',
-        400: 'Master'
+    const tierPointMap = {
+        'Easy': 10,
+        'Medium': 30,
+        'Hard': 80,
+        'Elite': 200,
+        'Master': 400
     };
-
+    const tiers = Object.keys(tierPointMap);
     const tierCounts = {};
     const completedTierCounts = {};
 
-    for (const points in pointsTiers) {
-        tierCounts[points] = allTasks.filter(task => task.points === parseInt(points)).length;
-        completedTierCounts[points] = allTasks.filter(task => task.points === parseInt(points) && completedTasks.has(task.id)).length;
-    }
+    tiers.forEach(tier => {
+        tierCounts[tier] = allTasks.filter(task => task.tier === tier).length;
+        completedTierCounts[tier] = allTasks.filter(task => task.tier === tier && completedTasks.has(task.id)).length;
+    });
 
     const totalProgressBar = document.getElementById('total-progress-bar');
     const totalProgressText = document.getElementById('total-progress-text');
@@ -397,16 +398,15 @@ function updateProgressVisualization() {
     totalPointsText.textContent = `Total Points: ${completedPoints.toLocaleString()} / ${totalPoints.toLocaleString()}`;
 
     tierProgressContainer.innerHTML = '';
-    for (const points in pointsTiers) {
-        const tierName = pointsTiers[points];
-        const total = tierCounts[points];
-        const completed = completedTierCounts[points];
+    for (const tier of tiers) {
+        const total = tierCounts[tier];
+        const completed = completedTierCounts[tier];
         const percentage = total > 0 ? (completed / total) * 100 : 0;
 
         const tierDiv = document.createElement('div');
         tierDiv.className = 'tier-progress';
         tierDiv.innerHTML = `
-            <div class="tier-name">${tierName}</div>
+            <div class="tier-name">${tier}</div>
             <div class="progress-bar-container">
                 <div class="progress-bar" style="width: ${percentage}%;"></div>
             </div>

--- a/tasks.json
+++ b/tasks.json
@@ -6,7 +6,8 @@
     "task": "Complete the base camp tutorial on Anachronia.",
     "information": "Complete the Anachronia base camp tutorial.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1,
@@ -15,7 +16,8 @@
     "task": "Observe all the large dragonkin statues around Anachronia.",
     "information": "Observe all the large dragonkin statues around Anachronia.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 2,
@@ -24,7 +26,8 @@
     "task": "Surge under the spine on Anachronia.",
     "information": "Complete Spinal Surgery.",
     "requirements": "5 Agility",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 3,
@@ -33,7 +36,8 @@
     "task": "Set sail for Anachronia.",
     "information": "Set sail for Anachronia on The Stormbreaker docked at Varrock Dig Site.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 4,
@@ -42,7 +46,8 @@
     "task": "Complete the quest: Helping Laniakea (miniquest).",
     "information": "Complete the Helping Laniakea miniquest.",
     "requirements": "Quest: Helping Laniakea (miniquest)",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 5,
@@ -51,7 +56,8 @@
     "task": "Complete the quest: Raksha, the Shadow Colossus.",
     "information": "Complete Raksha, the Shadow Colossus quest.",
     "requirements": "Quest: Raksha, the Shadow Colossus",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 6,
@@ -60,7 +66,8 @@
     "task": "Obtain 100 potent herbs from Herby Werby.",
     "information": "Obtain 100 potent herbs from Herby Werby.",
     "requirements": "1 Herblore",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 7,
@@ -69,7 +76,8 @@
     "task": "Build your Player Lodge on Anachronia.",
     "information": "Build your Player Lodge on Anachronia.",
     "requirements": "40 Construction",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 8,
@@ -78,7 +86,8 @@
     "task": "Purchase the herb bag and the herb bag upgrade from the Herby Werby reward shop.",
     "information": "Purchase the herb bag and the herb bag upgrade from the Herby Werby reward shop.",
     "requirements": "1 Herblore",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 9,
@@ -87,7 +96,8 @@
     "task": "Give Snoop some clean Dwarf weed.",
     "information": "Give Snoop some clean dwarf weed.",
     "requirements": "70 Herblore",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 10,
@@ -96,7 +106,8 @@
     "task": "Harvest produce from 5 animals on Anachronia farm.",
     "information": "Harvest produce from 5 animals on Anachronia farm.",
     "requirements": "42 Farming, 45 Construction",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 11,
@@ -105,7 +116,8 @@
     "task": "Complete the beginner sections of the Anachronia agility course.",
     "information": "Complete the beginner sections of the Anachronia agility course.",
     "requirements": "30 Agility",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 12,
@@ -114,7 +126,8 @@
     "task": "Complete the novice sections of the Anachronia agility course.",
     "information": "Complete the novice sections of the Anachronia agility course.",
     "requirements": "50 Agility",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 13,
@@ -123,7 +136,8 @@
     "task": "Harvest produce from 25 animals on Anachronia farm.",
     "information": "Harvest produce from 25 animals on Anachronia farm.",
     "requirements": "42 Farming, 45 Construction",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 14,
@@ -132,7 +146,8 @@
     "task": "Complete the ritual to activate a totem on Anachronia.",
     "information": "Complete the ritual to activate a totem on Anachronia.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 15,
@@ -141,7 +156,8 @@
     "task": "Complete the Anachronia agility course in under 7 minutes.",
     "information": "Complete the Anachronia agility course in under 7 minutes.",
     "requirements": "85 Agility",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 16,
@@ -150,7 +166,8 @@
     "task": "Complete all frog breeds.",
     "information": "Complete all frog breeds.",
     "requirements": "42 Farming, 45 Construction",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 17,
@@ -159,7 +176,8 @@
     "task": "Purchase the Quick Traps upgrade from Irwinsson's Hunter Mark shop.",
     "information": "Purchase the quick traps upgrade from the Hunter Mark Shop.",
     "requirements": "50 hunter marks",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 18,
@@ -168,7 +186,8 @@
     "task": "Complete the quest: Osseous Rex.",
     "information": "Complete the Osseous Rex quest.",
     "requirements": "Quest: Osseous Rex",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 19,
@@ -177,7 +196,8 @@
     "task": "Clear an Overgrown idol on Anachronia.",
     "information": "Clear an overgrown idol on Anachronia.",
     "requirements": "81 Woodcutting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 20,
@@ -186,7 +206,8 @@
     "task": "Defeat any of the Rex Matriarchs.",
     "information": "Defeat any of the Rex Matriarchs once.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 21,
@@ -195,7 +216,8 @@
     "task": "Defeat any of the Rex Matriarchs. (100 times)",
     "information": "Defeat any of the Rex Matriarchs 100 times.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 22,
@@ -204,7 +226,8 @@
     "task": "Complete the quest: Desperate Times.",
     "information": "Complete the Desperate Times quest.",
     "requirements": "Quest: Desperate Times",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 23,
@@ -213,7 +236,8 @@
     "task": "Find all the hidden Zygomites on Anachronia.",
     "information": "Find all of the ancient zygomites on Anachronia. See the page for a route.",
     "requirements": "85 Agility",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 24,
@@ -222,7 +246,8 @@
     "task": "Equip Laniakea's spear.",
     "information": "Equip Laniakea's spear.",
     "requirements": "82 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 25,
@@ -231,7 +256,8 @@
     "task": "Harvest an Arbuck herb.",
     "information": "Harvest an arbuck herb.",
     "requirements": "77 Farming",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 26,
@@ -240,7 +266,8 @@
     "task": "Complete the advanced sections of the Anachronia agility course.",
     "information": "Complete the advanced sections of the Anachronia agility course.",
     "requirements": "70 Agility",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 27,
@@ -249,7 +276,8 @@
     "task": "Equip a Dragon Mattock.",
     "information": "Equip a dragon mattock.",
     "requirements": "60 Archaeology",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 28,
@@ -258,7 +286,8 @@
     "task": "Take down each dinosaur in Big Game Hunter.",
     "information": "Take down each dinosaur in Big Game Hunter.",
     "requirements": "96 Hunter, 76 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 29,
@@ -267,7 +296,8 @@
     "task": "Get caught by each of the big game creatures once.",
     "information": "Get caught by each of the Big Game Hunter creatures once.",
     "requirements": "96 Hunter, 76 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 30,
@@ -276,7 +306,8 @@
     "task": "Complete a big game encounter without using movement abilities.",
     "information": "Complete a Big Game Hunter encounter without using movement abilities.",
     "requirements": "75 Hunter, 55 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 31,
@@ -285,7 +316,8 @@
     "task": "Defeat Raksha, the Shadow Colossus.",
     "information": "Defeat Raksha, the Shadow Colossus once.",
     "requirements": "Completion of Raksha, the Shadow Colossus",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 32,
@@ -294,7 +326,8 @@
     "task": "Discover all the totem pieces on Anachronia.",
     "information": "Discover all the totem pieces on Anachronia.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 33,
@@ -303,7 +336,8 @@
     "task": "Unlock the double Surge or double Escape ability upgrade.",
     "information": "Unlock the double Surge or double Escape ability upgrade.",
     "requirements": "85 Agility",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 34,
@@ -312,7 +346,8 @@
     "task": "Harvest a Dragonfruit plant in the cactus patch in the north of Anachronia.",
     "information": "Harvest a dragonfruit cactus in the cactus patch in the north of Anachronia.",
     "requirements": "81 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 35,
@@ -321,7 +356,8 @@
     "task": "Kill 50 Dinosaurs.",
     "information": "Kill 50 dinosaurs.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 36,
@@ -330,7 +366,8 @@
     "task": "Kill 50 Vile Blooms.",
     "information": "Kill 50 vile blooms.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 37,
@@ -339,7 +376,8 @@
     "task": "Solve the Archaeology mystery: Teleport Node On.",
     "information": "Activate all Orthen teleportation devices on Anachronia.",
     "requirements": "90 Archaeology",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 38,
@@ -348,7 +386,8 @@
     "task": "Use Potterington Blend #102 Fertiliser or dinosaur 'propellant' on Prehistoric Potterington.",
     "information": "Use Potterington blend 102 fertiliser or dinosaur 'propellant' on Prehistoric Potterington.",
     "requirements": "102 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 39,
@@ -357,7 +396,8 @@
     "task": "Find an unchecked egg in the pile of dinosaur eggs south of Anachronia dinosaur farm.",
     "information": "Find a dinosaur egg in the pile of dinosaur eggs on Anachronia Farm.",
     "requirements": "42 Farming, 45 Construction",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 40,
@@ -366,7 +406,8 @@
     "task": "Defeat Raksha, the Shadow Colossus. (100 times)",
     "information": "Defeat Raksha, the Shadow Colossus 100 times.",
     "requirements": "Completion of Raksha, the Shadow Colossus",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 41,
@@ -375,7 +416,8 @@
     "task": "Complete the quest: Desperate Measures.",
     "information": "Complete the Desperate Measures quest.",
     "requirements": "Quest: Desperate Measures",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 42,
@@ -384,7 +426,8 @@
     "task": "Equip a Terrasaur maul.",
     "information": "Equip a terrasaur maul.",
     "requirements": "90 Attack",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 43,
@@ -393,7 +436,8 @@
     "task": "Complete a big game encounter without stepping into the creature's vision ring.",
     "information": "Complete a Big Game Hunter encounter without stepping into the creature's vision ring.",
     "requirements": "75 Hunter, 55 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 44,
@@ -402,7 +446,8 @@
     "task": "Craft 500 Time Runes.",
     "information": "Craft 500 time runes.",
     "requirements": "102 Runecrafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 45,
@@ -411,7 +456,8 @@
     "task": "Solve the Archaeology mystery: Fragmented Memories.",
     "information": "Complete the Fragmented Memories Archaeology mystery.",
     "requirements": "99 Archaeology",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 46,
@@ -420,7 +466,8 @@
     "task": "Fletch any type of Elder God arrow.",
     "information": "Fletch any type of Elder God arrow.",
     "requirements": "95 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 47,
@@ -429,7 +476,8 @@
     "task": "Cast the Crumble Undead spell.",
     "information": "Cast the Crumble Undead spell.",
     "requirements": "39 Magic",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 48,
@@ -438,7 +486,8 @@
     "task": "Fully upgrade the Town Hall in the base camp on Anachronia.",
     "information": "Fully upgrade the town hall in the base camp on Anachronia.",
     "requirements": "90 Construction",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 49,
@@ -447,7 +496,8 @@
     "task": "Complete a big game encounter with 3 creatures active.",
     "information": "Complete a Big Game Hunter encounter with 3 creatures active.",
     "requirements": "75 Hunter, 55 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 50,
@@ -456,7 +506,8 @@
     "task": "Breed a shiny dinosaur.",
     "information": "Breed a shiny dinosaur.",
     "requirements": "42 Farming, 45 Construction",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 51,
@@ -465,7 +516,8 @@
     "task": "Equip Skeka's hypnowand.",
     "information": "Equip Skeka's hypnowand.",
     "requirements": "99 Archaeology",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 52,
@@ -474,7 +526,8 @@
     "task": "Complete the quest: Extinction.",
     "information": "Complete the Extinction quest.",
     "requirements": "Quest: Extinction",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 53,
@@ -483,7 +536,8 @@
     "task": "Complete a lap of the Burthorpe Agility course.",
     "information": "Complete a lap of the Burthorpe Agility Course.",
     "requirements": "1 Agility",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 54,
@@ -492,7 +546,8 @@
     "task": "Kill a goblin raider boss in the Goblin Village.",
     "information": "Kill 15 goblins in the Goblin Village to spawn a Goblin raider boss.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 55,
@@ -501,7 +556,8 @@
     "task": "Complete the quest: Witch's House.",
     "information": "Complete Witch's House",
     "requirements": "Quest: Witch's House",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 56,
@@ -510,7 +566,8 @@
     "task": "Sit down with Tiffy in Falador park.",
     "information": "Sit on the bench with Sir Tiffy Cashien in Falador Park.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 57,
@@ -519,7 +576,8 @@
     "task": "Pray to Bandos's remains.",
     "information": "Pray to Bandos's remains (just south-east of Goblin Village.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 58,
@@ -528,7 +586,8 @@
     "task": "Dance in the Falador party room.",
     "information": "Dance in the Falador party room.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 59,
@@ -537,7 +596,8 @@
     "task": "Give Thurgo a redberry pie.",
     "information": "Give Thurgo a redberry pie.",
     "requirements": "10 Cooking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 60,
@@ -546,7 +606,8 @@
     "task": "Build a God statue in Taverley.",
     "information": "Build a God statue in Taverley.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 61,
@@ -555,7 +616,8 @@
     "task": "Enter the Warriors Guild.",
     "information": "Enter the Warriors Guild.",
     "requirements": "Combined Attack and Strength level of 130",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 62,
@@ -564,7 +626,8 @@
     "task": "Equip a defender.",
     "information": "Equip a defender.",
     "requirements": "Combined Attack and Strength level of 130",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 63,
@@ -573,7 +636,8 @@
     "task": "Charge an Amulet of Glory in the Heroes' Guild.",
     "information": "Charge an amulet of glory in the Heroes' Guild.",
     "requirements": "80 Crafting, 68 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 64,
@@ -582,7 +646,8 @@
     "task": "Enter the Crafting Guild.",
     "information": "Enter the Crafting Guild.",
     "requirements": "40 Crafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 65,
@@ -591,7 +656,8 @@
     "task": "Complete the task set: Easy Falador.",
     "information": "Achievement: Easy Falador",
     "requirements": "Achievement: Easy Falador",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 66,
@@ -600,7 +666,8 @@
     "task": "Complete the task set: Medium Falador.",
     "information": "Achievement: Medium Falador",
     "requirements": "Achievement: Medium Falador",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 67,
@@ -609,7 +676,8 @@
     "task": "Defeat the Giant Mole.",
     "information": "Kill the giant mole.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 68,
@@ -618,7 +686,8 @@
     "task": "Defeat the Giant Mole. (50 times)",
     "information": "Kill the giant mole 50 times.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 69,
@@ -627,7 +696,8 @@
     "task": "Steal some Wine of Zamorak from the Captured Temple, south of Goblin Village.",
     "information": "Steal some wine of Zamorak from the Captured Temple, south of Goblin Village.",
     "requirements": "33 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 70,
@@ -636,7 +706,8 @@
     "task": "Set up a dwarf cannon.",
     "information": "Set up a dwarf multicannon.",
     "requirements": "Completion of Dwarf Cannon",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 71,
@@ -645,7 +716,8 @@
     "task": "Complete a ceremonial sword at the Artisans' Workshop.",
     "information": "Complete a ceremonial sword at the Artisans' Workshop.",
     "requirements": "1 Smithing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 72,
@@ -654,7 +726,8 @@
     "task": "Mine some orichalcite in the Mining Guild.",
     "information": "Mine some orichalcite ore in the Mining Guild.",
     "requirements": "60 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 73,
@@ -663,7 +736,8 @@
     "task": "Harvest a herb from the troll stronghold herb patch.",
     "information": "Harvest a herb from the troll stronghold herb patch.",
     "requirements": "9 Farming",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 74,
@@ -672,7 +746,8 @@
     "task": "Kill a blue dragon in Taverley dungeon.",
     "information": "Kill a blue dragon in Taverley dungeon.",
     "requirements": "70 Agility",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 75,
@@ -681,7 +756,8 @@
     "task": "Open the crystal chest in Taverley.",
     "information": "Open the crystal chest in Taverley.",
     "requirements": "A crystal key",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 76,
@@ -690,7 +766,8 @@
     "task": "Reach 100% respect at the Artisans' Workshop.",
     "information": "Reach 100% respect at the Artisans' Workshop.",
     "requirements": "1 Smithing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 77,
@@ -699,7 +776,8 @@
     "task": "Complete the task set: Hard Falador.",
     "information": "Complete the Hard Falador achievements.",
     "requirements": "Achievement: Hard Falador",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 78,
@@ -708,7 +786,8 @@
     "task": "Defeat any God Wars Dungeon boss 100 times.",
     "information": "Defeat any God Wars Dungeon boss 100 times.",
     "requirements": "Partial completion of Troll Stronghold",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 79,
@@ -717,7 +796,8 @@
     "task": "Defeat any God Wars Dungeon boss 250 times.",
     "information": "Defeat any God Wars Dungeon boss 250 times.",
     "requirements": "Partial completion of Troll Stronghold",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 80,
@@ -726,7 +806,8 @@
     "task": "Defeat Commander Zilyana.",
     "information": "Defeat Commander Zilyana",
     "requirements": "70 Agility",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 81,
@@ -735,7 +816,8 @@
     "task": "Defeat General Graardor.",
     "information": "Defeat General Graardor",
     "requirements": "70 Strength",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 82,
@@ -744,7 +826,8 @@
     "task": "Defeat K'ril Tsutsaroth.",
     "information": "Defeat K'ril Tsutsaroth",
     "requirements": "70 Constitution",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 83,
@@ -753,7 +836,8 @@
     "task": "Defeat Kree'arra.",
     "information": "Defeat Kree'arra",
     "requirements": "70 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 84,
@@ -762,7 +846,8 @@
     "task": "Defeat Nex.",
     "information": "Defeat Nex",
     "requirements": "70 Agility, 70 Strength, 70 Constitution, 70 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 85,
@@ -771,7 +856,8 @@
     "task": "Defeat Kree'arra. (100 times)",
     "information": "Defeat Kree'arra 100 times.",
     "requirements": "70 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 86,
@@ -780,7 +866,8 @@
     "task": "Assemble any godsword from the God Wars Dungeon.",
     "information": "Assemble any godsword from the God Wars Dungeon.",
     "requirements": "80 Smithing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 87,
@@ -789,7 +876,8 @@
     "task": "Defeat the Queen Black Dragon.",
     "information": "Defeat the Queen Black Dragon.",
     "requirements": "60 Summoning",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 88,
@@ -798,7 +886,8 @@
     "task": "Defeat the Queen Black Dragon. (100 times)",
     "information": "Defeat the Queen Black Dragon 100 times.",
     "requirements": "60 Summoning",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 89,
@@ -807,7 +896,8 @@
     "task": "Bury some frost dragon bones.",
     "information": "Bury some frost dragon bones.",
     "requirements": "85 Dungeoneering",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 90,
@@ -816,7 +906,8 @@
     "task": "Complete the task set: Elite Falador.",
     "information": "Complete the Elite Falador achievements.",
     "requirements": "Achievement: Elite Falador",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 91,
@@ -825,7 +916,8 @@
     "task": "Complete the Invention tutorial.",
     "information": "Complete the Invention tutorial.",
     "requirements": "80 Divination, 80 Smithing, 80 Crafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 92,
@@ -834,7 +926,8 @@
     "task": "Defeat Vorago, if you think you're hard enough.",
     "information": "Defeat Vorago.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 93,
@@ -843,7 +936,8 @@
     "task": "Defeat Vorago, if you think you're hard enough. (50 times)",
     "information": "Defeat Vorago 50 times.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 94,
@@ -852,7 +946,8 @@
     "task": "Equip a seismic wand or seismic singularity.",
     "information": "Equip a seismic wand or singularity.",
     "requirements": "90 Magic",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 95,
@@ -861,7 +956,8 @@
     "task": "Harvest some starbloom flowers from the flower patch south of Falador.",
     "information": "Harvest some starbloom flowers from the flower patch south of Falador.",
     "requirements": "84 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 96,
@@ -870,7 +966,8 @@
     "task": "Unlock the Royale Cannon from the Artisans' Workshop reward shop.",
     "information": "Unlock the royale dwarf multicannon from the Artisans' Workshop Reward Shop.",
     "requirements": "100% respect",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 97,
@@ -879,7 +976,8 @@
     "task": "Equip a piece of masterwork melee armour.",
     "information": "Equip a piece of masterwork melee armour.",
     "requirements": "99 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Master"
   },
   {
     "id": 98,
@@ -888,7 +986,8 @@
     "task": "Equip a full set of Bandos armour.",
     "information": "Equip a full set of Bandos armour.",
     "requirements": "70 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 99,
@@ -897,7 +996,8 @@
     "task": "Equip a full set of Armadyl armour.",
     "information": "Equip a full set of Armadyl armour.",
     "requirements": "70 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 100,
@@ -906,7 +1006,8 @@
     "task": "Equip a full set of subjugation armour.",
     "information": "Equip a full set of subjugation armour.",
     "requirements": "70 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 101,
@@ -915,7 +1016,8 @@
     "task": "Equip a piece of Torva, Pernix or Virtus armour.",
     "information": "Equip a piece of Torva, Pernix or Virtus armour.",
     "requirements": "80 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 102,
@@ -924,7 +1026,8 @@
     "task": "Defeat Nex, the Angel of Death.",
     "information": "Kill Nex: Angel of Death.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 103,
@@ -933,7 +1036,8 @@
     "task": "Defeat Nex, the Angel of Death. (50 times)",
     "information": "Kill Nex: Angel of Death 50 times.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 104,
@@ -942,7 +1046,8 @@
     "task": "Kill a living wyvern.",
     "information": "Kill a wyvern.",
     "requirements": "96 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 105,
@@ -951,7 +1056,8 @@
     "task": "Complete all of the Combat Achievements for God Wars Dungeon bosses, including Nex.",
     "information": "Complete all of the Combat Achievements for God Wars Dungeon bosses, including Nex.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 106,
@@ -960,7 +1066,8 @@
     "task": "Unlock all the prayers from the Praesul Codex.",
     "information": "Unlock all the prayers from the Praesul codex.",
     "requirements": "99 Prayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 107,
@@ -969,7 +1076,8 @@
     "task": "Enter Menaphos.",
     "information": "Enter Menaphos.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 108,
@@ -978,7 +1086,8 @@
     "task": "Catch a whirligig at Het's Oasis.",
     "information": "Catch a whirligig at Het's Oasis.",
     "requirements": "1 Hunter",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 109,
@@ -987,7 +1096,8 @@
     "task": "Search the Grand Gold Chest in room 1 of Pyramid Plunder in Sophanem.",
     "information": "Search the grand gold chest in room 1 of Pyramid Plunder in Sophanem.",
     "requirements": "21 Thieving",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 110,
@@ -996,7 +1106,8 @@
     "task": "Search the Grand Gold Chest in room 2 of Pyramid Plunder in Sophanem.",
     "information": "Search the grand gold chest in room 2 of Pyramid Plunder in Sophanem.",
     "requirements": "31 Thieving",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 111,
@@ -1005,7 +1116,8 @@
     "task": "Search the Grand Gold Chest in room 3 of Pyramid Plunder in Sophanem.",
     "information": "Search the grand gold chest in room 3 of Pyramid Plunder in Sophanem.",
     "requirements": "41 Thieving",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 112,
@@ -1014,7 +1126,8 @@
     "task": "Mine a gem rock at the Al Kharid mine.",
     "information": "Mine a gem rock at the Al Kharid mine. A common gem rock can be mined with level 1 Mining.",
     "requirements": "1 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 113,
@@ -1023,7 +1136,8 @@
     "task": "Kill a crocodile.",
     "information": "Kill a crocodile.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 114,
@@ -1032,7 +1146,8 @@
     "task": "Create a spirit kalphite pouch at the obelisk south west of Pollnivneach.",
     "information": "Create a spirit kalphite pouch at the obelisk south west of Pollnivneach.",
     "requirements": "25 Summoning",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 115,
@@ -1041,7 +1156,8 @@
     "task": "Squish 10 corrupted scarabs.",
     "information": "Squish 10 corrupted scarabs.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 116,
@@ -1050,7 +1166,8 @@
     "task": "Sell a pyramid top to Simon.",
     "information": "Hand Simon Templeton a pyramid top.",
     "requirements": "30 Agility",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 117,
@@ -1059,7 +1176,8 @@
     "task": "Use any of the magic carpets in the desert.",
     "information": "Use any of the magic carpets in the desert.",
     "requirements": "1,000 gp",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 118,
@@ -1068,7 +1186,8 @@
     "task": "Harvest a rose at Het's Oasis.",
     "information": "Harvest a rose at Het's Oasis.",
     "requirements": "30 Farming",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 119,
@@ -1077,7 +1196,8 @@
     "task": "Clear the Fort debris at the Kharid-et Dig Site.",
     "information": "Clear the fort debris at the Kharid-et Dig Site.",
     "requirements": "12 Archaeology",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 120,
@@ -1086,7 +1206,8 @@
     "task": "Complete the quest: One Piercing Note.",
     "information": "Complete One Piercing Note.",
     "requirements": "Quest: One Piercing Note",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 121,
@@ -1095,7 +1216,8 @@
     "task": "Complete a lap of the Het's Oasis agility course.",
     "information": "Complete a lap of the Het's Oasis agility course.",
     "requirements": "65 Agility",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 122,
@@ -1104,7 +1226,8 @@
     "task": "Defeat the Kalphite Queen.",
     "information": "Defeat the Kalphite Queen.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 123,
@@ -1113,7 +1236,8 @@
     "task": "Defeat the Kalphite Queen. (100 times)",
     "information": "Defeat the Kalphite Queen 100 times.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 124,
@@ -1122,7 +1246,8 @@
     "task": "Defeat 100 bosses in the Dominion Tower.",
     "information": "Defeat 100 bosses in the Dominion Tower.",
     "requirements": "Completion of at least 20 various quests",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 125,
@@ -1131,7 +1256,8 @@
     "task": "Complete the task set: Easy Desert.",
     "information": "Easy desert tasks.",
     "requirements": "Achievement: Easy Desert",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 126,
@@ -1140,7 +1266,8 @@
     "task": "Complete the task set: Medium Desert.",
     "information": "Medium desert tasks.",
     "requirements": "Achievement: Medium Desert",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 127,
@@ -1149,7 +1276,8 @@
     "task": "Steal from the lamp stall in Menaphos.",
     "information": "Steal from the lamp stall in Menaphos.",
     "requirements": "46 Thieving",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 128,
@@ -1158,7 +1286,8 @@
     "task": "Buy some runes from Ali Morrisane.",
     "information": "Buy some runes from Ali Morrisane.",
     "requirements": "Completion of the runes portion of Ali the Trader",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 129,
@@ -1167,7 +1296,8 @@
     "task": "Catch a catfish.",
     "information": "Catch a raw catfish.",
     "requirements": "60 Fishing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 130,
@@ -1176,7 +1306,8 @@
     "task": "Restore a Pontifex signet ring.",
     "information": "Restore a pontifex signet ring.",
     "requirements": "58 Archaeology",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 131,
@@ -1185,7 +1316,8 @@
     "task": "Search the Grand Gold Chest in room 4 of Pyramid Plunder in Sophanem.",
     "information": "Search the Grand Gold Chest in room 4 of Pyramid Plunder in Sophanem.",
     "requirements": "51 Thieving",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 132,
@@ -1194,7 +1326,8 @@
     "task": "Search the Grand Gold Chest in room 5 of Pyramid Plunder in Sophanem.",
     "information": "Search the Grand Gold Chest in room 5 of Pyramid Plunder in Sophanem.",
     "requirements": "61 Thieving",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 133,
@@ -1203,7 +1336,8 @@
     "task": "Search the Grand Gold Chest in room 6 of Pyramid Plunder in Sophanem.",
     "information": "Search the Grand Gold Chest in room 6 of Pyramid Plunder in Sophanem.",
     "requirements": "71 Thieving",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 134,
@@ -1212,7 +1346,8 @@
     "task": "Complete the quest: Smoking Kills.",
     "information": "Complete Smoking Kills.",
     "requirements": "Quest: Smoking Kills",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 135,
@@ -1221,7 +1356,8 @@
     "task": "Complete the quest: Desert Treasure.",
     "information": "Complete Desert Treasure.",
     "requirements": "Quest: Desert Treasure",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 136,
@@ -1230,7 +1366,8 @@
     "task": "Fully repair the statue of Het.",
     "information": "Repair the statue of Het at Het's Oasis.",
     "requirements": "200 pieces of Het",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 137,
@@ -1239,7 +1376,8 @@
     "task": "Defeat the Kalphite King.",
     "information": "Defeat the Kalphite King.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 138,
@@ -1248,7 +1386,8 @@
     "task": "Defeat the Kalphite King. (100 times)",
     "information": "Defeat the Kalphite King 100 times.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 139,
@@ -1257,7 +1396,8 @@
     "task": "Equip a drygore weapon.",
     "information": "Equip a drygore weapon.",
     "requirements": "90 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 140,
@@ -1266,7 +1406,8 @@
     "task": "Become an honorary druid at the Garden of Kharid.",
     "information": "Purchase the Druid/Druidess title for 50,000 Crux Eqal favour",
     "requirements": "50 Farming",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 141,
@@ -1275,7 +1416,8 @@
     "task": "Deploy a dreadnip.",
     "information": "Deploy a dreadnip.",
     "requirements": "450 Dominion Tower kills",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 142,
@@ -1284,7 +1426,8 @@
     "task": "Complete the task set: Hard Desert.",
     "information": "Complete the Hard Desert achievements.",
     "requirements": "Achievement: Hard Desert",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 143,
@@ -1293,7 +1436,8 @@
     "task": "Defeat Avaryss and Nymora.",
     "information": "Defeat the Twin Furies.",
     "requirements": "80 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 144,
@@ -1302,7 +1446,8 @@
     "task": "Defeat Gregorovic.",
     "information": "Defeat Gregorovic.",
     "requirements": "80 Prayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 145,
@@ -1311,7 +1456,8 @@
     "task": "Defeat Vindicta and Gorvek.",
     "information": "Defeat Vindicta.",
     "requirements": "80 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 146,
@@ -1320,7 +1466,8 @@
     "task": "Defeat Helwyr.",
     "information": "Defeat Helwyr.",
     "requirements": "80 Magic",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 147,
@@ -1329,7 +1476,8 @@
     "task": "Defeat Avaryss and Nymora. (100 times)",
     "information": "Defeat the Twin Furies 100 times.",
     "requirements": "80 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 148,
@@ -1338,7 +1486,8 @@
     "task": "Defeat Gregorovic. (100 times)",
     "information": "Defeat Gregorovic 100 times.",
     "requirements": "80 Prayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 149,
@@ -1347,7 +1496,8 @@
     "task": "Defeat Vindicta and Gorvek. (100 times)",
     "information": "Defeat Vindicta 100 times.",
     "requirements": "80 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 150,
@@ -1356,7 +1506,8 @@
     "task": "Defeat Helwyr. (100 times)",
     "information": "Defeat Helwyr 100 times.",
     "requirements": "80 Magic",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 151,
@@ -1365,7 +1516,8 @@
     "task": "Equip a Dragon Rider lance.",
     "information": "Equip a Dragon Rider lance.",
     "requirements": "85 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 152,
@@ -1374,7 +1526,8 @@
     "task": "Equip a wand or orb of the Cywir elders.",
     "information": "Equip a wand or orb of the Cywir elders.",
     "requirements": "85 Magic",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 153,
@@ -1383,7 +1536,8 @@
     "task": "Equip a shadow glaive.",
     "information": "Equip a shadow glaive.",
     "requirements": "85 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 154,
@@ -1392,7 +1546,8 @@
     "task": "Equip a blade of Nymora or Avaryss.",
     "information": "Equip a blade of Nymora or Avaryss.",
     "requirements": "85 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 155,
@@ -1401,7 +1556,8 @@
     "task": "Slay a combination of 500 corrupted or devourer creatures.",
     "information": "Slay a combination of 500 corrupted creatures or soul devourers.",
     "requirements": "88 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 156,
@@ -1410,7 +1566,8 @@
     "task": "Defeat the Magister.",
     "information": "Defeat the Magister.",
     "requirements": "115 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 157,
@@ -1419,7 +1576,8 @@
     "task": "Defeat the Magister. (50 times)",
     "information": "Defeat the Magister 50 times.",
     "requirements": "115 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 158,
@@ -1428,7 +1586,8 @@
     "task": "Find an Off-hand khopesh of the Kharidian in Shifting Tombs.",
     "information": "Find an off-hand khopesh of the Kharidian in Shifting Tombs.",
     "requirements": "50 Dungeoneering, 50 Agility, 50 Thieving, or 50 Construction",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 159,
@@ -1437,7 +1596,8 @@
     "task": "Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.",
     "information": "Search the Grand Gold Chest in room 7 of Pyramid Plunder in Sophanem.",
     "requirements": "81 Thieving",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 160,
@@ -1446,7 +1606,8 @@
     "task": "Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.",
     "information": "Search the Grand Gold Chest in room 8 of Pyramid Plunder in Sophanem.",
     "requirements": "91 Thieving",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 161,
@@ -1455,7 +1616,8 @@
     "task": "Complete the quest: Beneath Scabaras' Sands.",
     "information": "Complete Beneath Scabaras' Sands.",
     "requirements": "Quest: Beneath Scabaras' Sands",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 162,
@@ -1464,7 +1626,8 @@
     "task": "Kill a desert strykewyrm wearing a Full Slayer Helm and wielding an ancient staff.",
     "information": "Kill a desert strykewyrm wearing a full Slayer helm and wielding an ancient staff.",
     "requirements": "77 Slayer, 50 Magic, 20 Defence, 55 Crafting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 163,
@@ -1473,7 +1636,8 @@
     "task": "Defeat Telos, the Warden.",
     "information": "Defeat Telos, the Warden.",
     "requirements": "80 Attack, 80 Prayer, 80 Magic, 80 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 164,
@@ -1482,7 +1646,8 @@
     "task": "Complete the task set: Elite Desert.",
     "information": "Complete the Elite Desert achievements.",
     "requirements": "Achievement: Elite Desert",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 165,
@@ -1491,7 +1656,8 @@
     "task": "Defeat Telos, the Warden at 100% enrage.",
     "information": "Defeat Telos, the Warden at 100% enrage.",
     "requirements": "80 Attack, 80 Prayer, 80 Magic, 80 Ranged",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 166,
@@ -1500,7 +1666,8 @@
     "task": "Defeat Telos, the Warden at 500% enrage.",
     "information": "Defeat Telos, the Warden at 500% enrage.",
     "requirements": "80 Attack, 80 Prayer, 80 Magic, 80 Ranged",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 167,
@@ -1509,7 +1676,8 @@
     "task": "Craft some Soul runes.",
     "information": "Craft some soul runes.",
     "requirements": "90 Runecrafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 168,
@@ -1518,7 +1686,8 @@
     "task": "Defeat a Camel Warrior.",
     "information": "Defeat a camel warrior.",
     "requirements": "96 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 169,
@@ -1527,7 +1696,8 @@
     "task": "Escape Kharid-et by boat.",
     "information": "Complete the Aquatic Escape achievement.",
     "requirements": "93 Archaeology",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 170,
@@ -1536,7 +1706,8 @@
     "task": "Defeat the Kalphite King solo.",
     "information": "Kill the Kalphite King solo.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 171,
@@ -1545,7 +1716,8 @@
     "task": "Cast Ice Barrage in the desert.",
     "information": "Cast Ice Barrage in the desert.",
     "requirements": "94 Magic",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 172,
@@ -1554,7 +1726,8 @@
     "task": "Craft a Zaros godsword, Seren godbow or staff of Sliske.",
     "information": "Craft a Zaros godsword, Seren godbow or staff of Sliske.",
     "requirements": "92 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 173,
@@ -1563,7 +1736,8 @@
     "task": "Defeat Amascut, the Devourer.",
     "information": "Defeat Amascut, the Devourer.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 174,
@@ -1572,7 +1746,8 @@
     "task": "Defeat Telos, the Warden at 1,000% enrage.",
     "information": "Defeat Telos, the Warden at 1000% enrage.",
     "requirements": "80 Attack, 80 Prayer, 80 Magic, 80 Ranged",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 175,
@@ -1581,7 +1756,8 @@
     "task": "Complete all of the Combat Achievements for the Heart of Gielinor bosses (excluding Telos).",
     "information": "Complete all of the Combat Achievements for the Heart of Gielinor bosses (excluding Telos).",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 176,
@@ -1590,7 +1766,8 @@
     "task": "Defeat Amascut, the Devourer. (100 times)",
     "information": "Defeat Amascut, the Devourer 100 times.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 177,
@@ -1599,7 +1776,8 @@
     "task": "Switch to the Lunar Spellbook at the astral altar.",
     "information": "Switch to the Lunar Spellbook at the astral altar.",
     "requirements": "Completion of Lunar Diplomacy",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 178,
@@ -1608,7 +1786,8 @@
     "task": "Defeat a Rock Crab in the Fremennik Province.",
     "information": "Defeat a Rock Crab in the Fremennik Province.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 179,
@@ -1617,7 +1796,8 @@
     "task": "Defeat a Cockatrice in the Fremennik Province.",
     "information": "Defeat a cockatrice in the Fremennik Province.",
     "requirements": "25 Slayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 180,
@@ -1626,7 +1806,8 @@
     "task": "Defeat a Troll in the Fremennik Province.",
     "information": "Defeat a troll in the Fremennik Province.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 181,
@@ -1635,7 +1816,8 @@
     "task": "Deposit an item with Peer the Seer.",
     "information": "Deposit an item with Peer the Seer.",
     "requirements": "Completion of the easy Fremennik achievements",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 182,
@@ -1644,7 +1826,8 @@
     "task": "Use the Bank on Jatizso or Neitiznot.",
     "information": "Use the Bank on Jatizso or Neitiznot.",
     "requirements": "Partial completion of The Fremennik Isles",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 183,
@@ -1653,7 +1836,8 @@
     "task": "Catch a Sapphire Glacialis.",
     "information": "Catch a Sapphire Glacialis.",
     "requirements": "25 Hunter",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 184,
@@ -1662,7 +1846,8 @@
     "task": "Cast Moonclan Teleport.",
     "information": "Cast Moonclan Teleport.",
     "requirements": "69 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 185,
@@ -1671,7 +1856,8 @@
     "task": "Move Your House to Rellekka.",
     "information": "Move your player-owned house's location to Rellekka by speaking to an estate agent.",
     "requirements": "30 Construction",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 186,
@@ -1680,7 +1866,8 @@
     "task": "Craft 50 Astral Runes.",
     "information": "Craft 50 astral runes.",
     "requirements": "40 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 187,
@@ -1689,7 +1876,8 @@
     "task": "Complete the Penguin Agility Course.",
     "information": "Complete the Penguin Agility Course.",
     "requirements": "30 Agility",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 188,
@@ -1698,7 +1886,8 @@
     "task": "Catch a Snowy Knight.",
     "information": "Catch a Snowy Knight.",
     "requirements": "35 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 189,
@@ -1707,7 +1896,8 @@
     "task": "Defeat a Kurask in the Fremennik Province.",
     "information": "Defeat a Kurask in the Fremennik Province.",
     "requirements": "70 Slayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 190,
@@ -1716,7 +1906,8 @@
     "task": "Defeat a Dagannoth in the Fremennik Province.",
     "information": "Defeat a dagannoth in the Fremennik Province.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 191,
@@ -1725,7 +1916,8 @@
     "task": "Equip a Helm of Neitiznot.",
     "information": "Equip a Helm of Neitiznot.",
     "requirements": "55 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 192,
@@ -1734,7 +1926,8 @@
     "task": "Defeat a Jelly in the Fremennik Province.",
     "information": "Defeat a jelly in the Fremennik Province.",
     "requirements": "52 Slayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 193,
@@ -1743,7 +1936,8 @@
     "task": "Complete the quest: Throne of Miscellania.",
     "information": "Complete Throne of Miscellania.",
     "requirements": "Quest: Throne of Miscellania",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 194,
@@ -1752,7 +1946,8 @@
     "task": "Complete the quest: Royal Trouble.",
     "information": "Complete Royal Trouble.",
     "requirements": "Quest: Royal Trouble",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 195,
@@ -1761,7 +1956,8 @@
     "task": "Equip a Granite Shield.",
     "information": "Equip a granite shield.",
     "requirements": "55 Defence, 55 Strength",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 196,
@@ -1770,7 +1966,8 @@
     "task": "Equip a full set of Graahk, Larupia or Kyatt hunter gear.",
     "information": "Equip a full set of graahk, larupia or kyatt hunter gear.",
     "requirements": "31 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 197,
@@ -1779,7 +1976,8 @@
     "task": "Defeat any of the Dagannoth Kings.",
     "information": "Defeat any of the Dagannoth Kings 1 time.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 198,
@@ -1788,7 +1986,8 @@
     "task": "Defeat any of the Dagannoth Kings.",
     "information": "Defeat any of the Dagannoth Kings 100 times.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 199,
@@ -1797,7 +1996,8 @@
     "task": "Complete the task set: Easy Fremennik.",
     "information": "Complete the Easy Fremennik achievements.",
     "requirements": "Achievement: Easy Fremennik Province",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 200,
@@ -1806,7 +2006,8 @@
     "task": "Ride a mine cart into Keldagrim.",
     "information": "Ride a mine cart into Keldagrim.",
     "requirements": "Completion of The Giant Dwarf",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 201,
@@ -1815,7 +2016,8 @@
     "task": "Travel to the Mammoth Iceberg.",
     "information": "Travel to the Mammoth Iceberg.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 202,
@@ -1824,7 +2026,8 @@
     "task": "Steal from the fish stall in Rellekka.",
     "information": "Steal from the fish stall in Rellekka.",
     "requirements": "42 Thieving",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 203,
@@ -1833,7 +2036,8 @@
     "task": "Harvest 100 sparkling energy from Sparkling Wisps.",
     "information": "Harvest 100 sparkling energy from sparkling wisps.",
     "requirements": "40 Divination",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 204,
@@ -1842,7 +2046,8 @@
     "task": "Climb to the top of the lighthouse.",
     "information": "Climb to the top of the lighthouse.",
     "requirements": "Completion of Horror from the Deep",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 205,
@@ -1851,7 +2056,8 @@
     "task": "Chop 10 Artic[sic] Pine trees.",
     "information": "Chop 10 arctic pine trees.",
     "requirements": "54 Woodcutting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 206,
@@ -1860,7 +2066,8 @@
     "task": "Kill 25 Yaks.",
     "information": "Kill 25 yaks.",
     "requirements": "Partial completion of The Fremennik Isles",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 207,
@@ -1869,7 +2076,8 @@
     "task": "Interact with a pet rock.",
     "information": "Interact with a pet rock.",
     "requirements": "Partial completion of The Fremennik Trials",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 208,
@@ -1878,7 +2086,8 @@
     "task": "Complete the task set: Medium Fremennik.",
     "information": "Complete the Medium Fremennik achievements.",
     "requirements": "Achievement: Medium Fremennik Province",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 209,
@@ -1887,7 +2096,8 @@
     "task": "Cast Fertile Soil.",
     "information": "Cast Fertile Soil.",
     "requirements": "83 Magic",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 210,
@@ -1896,7 +2106,8 @@
     "task": "Build a Gilded Altar.",
     "information": "Build a gilded altar in your player-owned house's chapel.",
     "requirements": "75 Construction",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 211,
@@ -1905,7 +2116,8 @@
     "task": "Trap a Sabre-Toothed Kyatt.",
     "information": "Trap a sabre-toothed kyatt.",
     "requirements": "55 Hunter",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 212,
@@ -1914,7 +2126,8 @@
     "task": "Defeat all the Dagannoth Kings without leaving a solo boss instance.",
     "information": "Defeat all the Dagannoth Kings without leaving a solo boss instance.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 213,
@@ -1923,7 +2136,8 @@
     "task": "Equip a Berserker, Warrior, Seers, or Archers Ring.",
     "information": "Equip a Berserker, Warrior, Seers, or Archers Ring.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 214,
@@ -1932,7 +2146,8 @@
     "task": "Use the Special Attack of a Dragon Axe.",
     "information": "Use the special attack of a dragon hatchet.",
     "requirements": "60 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 215,
@@ -1941,7 +2156,8 @@
     "task": "Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.",
     "information": "Defeat a Dagannoth King solo whilst wearing full yak-hide armour and a Fremennik round shield.",
     "requirements": "25 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 216,
@@ -1950,7 +2166,8 @@
     "task": "Equip a full set of Skeletal, Spined, or Rockshell armour.",
     "information": "Equip a full skeletal, spined, or rock-shell armour set.",
     "requirements": "50 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 217,
@@ -1959,7 +2176,8 @@
     "task": "Collect Miscellania Resources at Full Approval.",
     "information": "Collect from Managing Miscellania with a 100% approval rating.",
     "requirements": "Completion of Throne of Miscellania",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 218,
@@ -1968,7 +2186,8 @@
     "task": "Travel to the island of Ungael.",
     "information": "Travel to the island of Ungael.",
     "requirements": "Partial completion of Ancient Awakening",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 219,
@@ -1977,7 +2196,8 @@
     "task": "Adopt a baby yak.",
     "information": "Obtain an unchecked/baby Fremennik yak.",
     "requirements": "71 Farming",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 220,
@@ -1986,7 +2206,8 @@
     "task": "Catch 50 Azure Skillchompas.",
     "information": "Catch 50 azure skillchompas.",
     "requirements": "68 Hunter",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 221,
@@ -1995,7 +2216,8 @@
     "task": "Mine 10 Banite Ore north of Rellekka.",
     "information": "Mine 10 Banite ore in the arctic (azure) habitat mine.",
     "requirements": "80 Mining",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 222,
@@ -2004,7 +2226,8 @@
     "task": "Smith a piece of Bane equipment to +4 in Rellekka.",
     "information": "Upgrade a piece of bane equipment to +4 in Rellekka.",
     "requirements": "80 Smithing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 223,
@@ -2013,7 +2236,8 @@
     "task": "Use a Crystal triskelion key to obtain some treasures.",
     "information": "Use a crystal triskelion to obtain some treasures.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 224,
@@ -2022,7 +2246,8 @@
     "task": "Create a Catherby Teleport Tablet.",
     "information": "Create a Catherby teleport tablet.",
     "requirements": "87 Magic, 67 Construction",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 225,
@@ -2031,7 +2256,8 @@
     "task": "Gather a seed from an Aquanite using Seedicide.",
     "information": "Gather a seed from an aquanite using Seedicide.",
     "requirements": "78 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 226,
@@ -2040,7 +2266,8 @@
     "task": "Complete the task set: Hard Fremennik.",
     "information": "Complete the Hard Fremennik achievements.",
     "requirements": "Achievement: Hard Fremennik Province",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 227,
@@ -2049,7 +2276,8 @@
     "task": "Cast Spellbook Swap from the Lunar spellbook.",
     "information": "Cast Spellbook Swap from the lunar spellbook.",
     "requirements": "96 Magic",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 228,
@@ -2058,7 +2286,8 @@
     "task": "Equip Every Dagannoth King Ring.",
     "information": "Equip every Dagannoth King ring.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 229,
@@ -2067,7 +2296,8 @@
     "task": "Equip a Completed God Book.",
     "information": "Equip a completed god book.",
     "requirements": "Completion of Horror from the Deep",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 230,
@@ -2076,7 +2306,8 @@
     "task": "Defeat 20 Acheron Mammoths.",
     "information": "Defeat 20 acheron mammoths.",
     "requirements": "96 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 231,
@@ -2085,7 +2316,8 @@
     "task": "Cast the Paradox spell on any tree, rock, fishing spot, or box trap.",
     "information": "Cast the Paradox spell on any tree, rock, fishing spot, or box trap.",
     "requirements": "99 Necromancy",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 232,
@@ -2094,7 +2326,8 @@
     "task": "Build a Demonic Throne.",
     "information": "Build a demonic throne.",
     "requirements": "99 Construction",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 233,
@@ -2103,7 +2336,8 @@
     "task": "Perform a Powerful Necroplasm ritual at the Ungael ritual site.",
     "information": "Perform a powerful necroplasm ritual at the Ungael ritual site.",
     "requirements": "90 Necromancy",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 234,
@@ -2112,7 +2346,8 @@
     "task": "Defeat the Abomination once after Hero's Welcome.",
     "information": "Defeat the Abomination once after Hero's Welcome.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 235,
@@ -2121,7 +2356,8 @@
     "task": "Summon a Pack Mammoth.",
     "information": "Summon a pack mammoth.",
     "requirements": "96 Summoning",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 236,
@@ -2130,7 +2366,8 @@
     "task": "Complete the task set: Elite Fremennik.",
     "information": "Complete the Elite Fremennik achievements.",
     "requirements": "Achievement: Elite Fremennik Province",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 237,
@@ -2139,7 +2376,8 @@
     "task": "Complete the Ungael combat activity on hard mode.",
     "information": "Complete the Ungael combat activity on hard mode.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 238,
@@ -2148,7 +2386,8 @@
     "task": "Use the Trap Telekinesis spell to catch Azure Skillchompas 25 times.",
     "information": "Use the Trap Telekinesis spell to catch azure skillchompas 25 times.",
     "requirements": "70 Magic",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 239,
@@ -2157,7 +2396,8 @@
     "task": "Equip every completed God Book.",
     "information": "Equip every completed god book.",
     "requirements": "Completion of Horror from the Deep",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 240,
@@ -2166,7 +2406,8 @@
     "task": "Level up any of your skills for the first time.",
     "information": "Level up any of your skills for the first time.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 241,
@@ -2175,7 +2416,8 @@
     "task": "Reach level 5 in any skill.",
     "information": "Reach level 5 in any skill.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 242,
@@ -2184,7 +2426,8 @@
     "task": "Reach level 10 in any skill.",
     "information": "Reach level 10 in any skill.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 243,
@@ -2193,7 +2436,8 @@
     "task": "Reach level 20 in any skill.",
     "information": "Reach level 20 in any skill.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 244,
@@ -2202,7 +2446,8 @@
     "task": "Reach combat level 5.",
     "information": "Reach combat level 5.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 245,
@@ -2211,7 +2456,8 @@
     "task": "Reach combat level 10.",
     "information": "Reach combat level 10.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 246,
@@ -2220,7 +2466,8 @@
     "task": "Reach total level 50.",
     "information": "Reach total level 50.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 247,
@@ -2229,7 +2476,8 @@
     "task": "Reach total level 100.",
     "information": "Reach total level 100.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 248,
@@ -2238,7 +2486,8 @@
     "task": "Mine a copper ore.",
     "information": "Mine copper ore from a copper rock.",
     "requirements": "1 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 249,
@@ -2247,7 +2496,8 @@
     "task": "Mine 10 copper ore.",
     "information": "Mine 10 copper ore.",
     "requirements": "1 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 250,
@@ -2256,7 +2506,8 @@
     "task": "Mine a tin ore.",
     "information": "Mine tin ore from a tin rock.",
     "requirements": "1 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 251,
@@ -2265,7 +2516,8 @@
     "task": "Mine 10 tin ore.",
     "information": "Mine 10 tin ore.",
     "requirements": "1 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 252,
@@ -2274,7 +2526,8 @@
     "task": "Smelt a bronze bar.",
     "information": "Smelt a bronze bar.",
     "requirements": "1 Smithing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 253,
@@ -2283,7 +2536,8 @@
     "task": "Smelt 10 bronze bars.",
     "information": "Smelt 10 bronze bars.",
     "requirements": "1 Smithing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 254,
@@ -2292,7 +2546,8 @@
     "task": "Smith any bronze item.",
     "information": "Smith any bronze item.",
     "requirements": "1 Smithing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 255,
@@ -2301,7 +2556,8 @@
     "task": "Mine clay.",
     "information": "Mine clay.",
     "requirements": "1 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 256,
@@ -2310,7 +2566,8 @@
     "task": "Make some soft clay.",
     "information": "Make soft clay by using clay on a water source or with a container of water",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 257,
@@ -2319,7 +2576,8 @@
     "task": "Mine any ore 5 times.",
     "information": "Mine any ore 5 times.",
     "requirements": "1 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 258,
@@ -2328,7 +2586,8 @@
     "task": "Chop any tree 5 times.",
     "information": "Chop any tree 5 times.",
     "requirements": "1 Woodcutting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 259,
@@ -2337,7 +2596,8 @@
     "task": "Chop a basic tree.",
     "information": "Chop a basic tree.",
     "requirements": "1 Woodcutting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 260,
@@ -2346,7 +2606,8 @@
     "task": "Chop 10 basic trees.",
     "information": "Chop 10 basic trees.",
     "requirements": "1 Woodcutting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 261,
@@ -2355,7 +2616,8 @@
     "task": "Chop an oak tree.",
     "information": "Chop an oak tree.",
     "requirements": "10 Woodcutting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 262,
@@ -2364,7 +2626,8 @@
     "task": "Burn any logs.",
     "information": "Burn any logs.",
     "requirements": "1 Firemaking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 263,
@@ -2373,7 +2636,8 @@
     "task": "Burn any logs 5 times.",
     "information": "Burn any logs 5 times.",
     "requirements": "1 Firemaking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 264,
@@ -2382,7 +2646,8 @@
     "task": "Catch a shrimp.",
     "information": "Catch a raw shrimp.",
     "requirements": "1 Fishing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 265,
@@ -2391,7 +2656,8 @@
     "task": "Catch 10 shrimp.",
     "information": "Catch 10 raw shrimps.",
     "requirements": "1 Fishing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 266,
@@ -2400,7 +2666,8 @@
     "task": "Catch an anchovy.",
     "information": "Catch a raw anchovy.",
     "requirements": "15 Fishing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 267,
@@ -2409,7 +2676,8 @@
     "task": "Catch a herring.",
     "information": "Catch a raw herring.",
     "requirements": "10 Fishing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 268,
@@ -2418,7 +2686,8 @@
     "task": "Cook shrimp, meat, or chicken.",
     "information": "Cook raw shrimps, raw meat, or raw chicken.",
     "requirements": "1 Cooking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 269,
@@ -2427,7 +2696,8 @@
     "task": "Cook 10 shrimp, meat, or chicken.",
     "information": "Cook 10 raw shrimps, raw meat, or raw chicken.",
     "requirements": "1 Cooking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 270,
@@ -2436,7 +2706,8 @@
     "task": "Burn any food.",
     "information": "Burn any food.",
     "requirements": "1 Cooking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 271,
@@ -2445,7 +2716,8 @@
     "task": "Catch any fish 5 times.",
     "information": "Catch any fish 5 times.",
     "requirements": "1 Fishing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 272,
@@ -2454,7 +2726,8 @@
     "task": "Bury any bones.",
     "information": "Bury any bones.",
     "requirements": "1 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 273,
@@ -2463,7 +2736,8 @@
     "task": "Bury any bones 10 times.",
     "information": "Bury any bones 10 times.",
     "requirements": "1 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 274,
@@ -2472,7 +2746,8 @@
     "task": "Activate the thick skin, rock skin, or steel skin Prayer.",
     "information": "Activate the Thick Skin, Rock Skin, or Steel Skin prayer.",
     "requirements": "1 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 275,
@@ -2481,7 +2756,8 @@
     "task": "Run out of Prayer points.",
     "information": "Run out of Prayer points.",
     "requirements": "1 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 276,
@@ -2490,7 +2766,8 @@
     "task": "Harvest any memory from a wisp 5 times.",
     "information": "Harvest any memory from a wisp 5 times.",
     "requirements": "1 Divination",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 277,
@@ -2499,7 +2776,8 @@
     "task": "Pickpocket from a man or woman.",
     "information": "Pickpocket from a man or woman.",
     "requirements": "1 Thieving",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 278,
@@ -2508,7 +2786,8 @@
     "task": "Pickpocket from a man or woman 10 times.",
     "information": "Pickpocket from a man or woman 10 times.",
     "requirements": "1 Thieving",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 279,
@@ -2517,7 +2796,8 @@
     "task": "Steal from any stall.",
     "information": "Steal from any stall.",
     "requirements": "2 Thieving",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 280,
@@ -2526,7 +2806,8 @@
     "task": "Steal from any stall 10 times.",
     "information": "Steal from any stall 10 times.",
     "requirements": "2 Thieving",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 281,
@@ -2535,7 +2816,8 @@
     "task": "Pickpocket anyone 5 times.",
     "information": "Pickpocket anyone 5 times.",
     "requirements": "1 Thieving",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 282,
@@ -2544,7 +2826,8 @@
     "task": "Rake any farming patch.",
     "information": "Rake any farming patch.",
     "requirements": "1 Farming",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 283,
@@ -2553,7 +2836,8 @@
     "task": "Plant seeds in any farming patch.",
     "information": "Plant seeds in any farming patch.",
     "requirements": "1 Farming",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 284,
@@ -2562,7 +2846,8 @@
     "task": "Plant seeds in any farming patch 10 times.",
     "information": "Plant seeds in any farming patch 10 times.",
     "requirements": "1 Farming",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 285,
@@ -2571,7 +2856,8 @@
     "task": "Add any compostable item to a compost bin.",
     "information": "Add any compostable item to a compost bin.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 286,
@@ -2580,7 +2866,8 @@
     "task": "Have a tool leprechaun note any produce.",
     "information": "Have a tool leprechaun note any produce.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 287,
@@ -2589,7 +2876,8 @@
     "task": "Use the Home Teleport spell to return to Lumbridge.",
     "information": "Use the Home Teleport spell to return to Lumbridge.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 288,
@@ -2598,7 +2886,8 @@
     "task": "Eat a cabbage.",
     "information": "Eat a cabbage.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 289,
@@ -2607,7 +2896,8 @@
     "task": "Eat a baked potato.",
     "information": "Eat a baked potato.",
     "requirements": "7 Cooking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 290,
@@ -2616,7 +2906,8 @@
     "task": "Eat an onion.",
     "information": "Eat an onion.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 291,
@@ -2625,7 +2916,8 @@
     "task": "Kill an imp.",
     "information": "Kill an imp.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 292,
@@ -2634,7 +2926,8 @@
     "task": "Kill a chicken.",
     "information": "Kill a chicken.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 293,
@@ -2643,7 +2936,8 @@
     "task": "Claim a free item from any store.",
     "information": "Claim a free item from any store e.g. a tinderbox from Lumbridge General Store",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 294,
@@ -2652,7 +2946,8 @@
     "task": "Return a free item to any store.",
     "information": "Return a free item to any store e.g. a tinderbox from Lumbridge General Store",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 295,
@@ -2661,7 +2956,8 @@
     "task": "Sell an item to any store.",
     "information": "Sell an item to any store.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 296,
@@ -2670,7 +2966,8 @@
     "task": "Listen to any musician.",
     "information": "Listen to any musician.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 297,
@@ -2679,7 +2976,8 @@
     "task": "Pick wheat from a field.",
     "information": "Pick wheat from a field.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 298,
@@ -2688,7 +2986,8 @@
     "task": "Prospect any rock.",
     "information": "Prospect any rock.",
     "requirements": "1 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 299,
@@ -2697,7 +2996,8 @@
     "task": "View the skillguide.",
     "information": "View the skill guide.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 300,
@@ -2706,7 +3006,8 @@
     "task": "Create a Guthix Rest Potion.",
     "information": "Create a Guthix rest potion.",
     "requirements": "18 Herblore",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 301,
@@ -2715,7 +3016,8 @@
     "task": "Make 5 potions of any kind.",
     "information": "Make 5 potions of any kind.",
     "requirements": "1 Herblore",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 302,
@@ -2724,7 +3026,8 @@
     "task": "Drink a Strength Potion.",
     "information": "Drink a Strength Potion.",
     "requirements": "Giving a limpwurt root and red spiders' eggs to the Apothecary",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 303,
@@ -2733,7 +3036,8 @@
     "task": "Make an Attack Potion.",
     "information": "Make an Attack potion.",
     "requirements": "1 Herblore",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 304,
@@ -2742,7 +3046,8 @@
     "task": "Make a Necromancy Potion.",
     "information": "Make a Necromancy potion.",
     "requirements": "11 Herblore",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 305,
@@ -2751,7 +3056,8 @@
     "task": "Clean 5 Grimy Guam.",
     "information": "Clean 5 grimy guam.",
     "requirements": "1 Herblore",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 306,
@@ -2760,7 +3066,8 @@
     "task": "Clean 15 Grimy Tarromin.",
     "information": "Clean 15 grimy tarromin.",
     "requirements": "5 Herblore",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 307,
@@ -2769,7 +3076,8 @@
     "task": "Clean 5 of any herb.",
     "information": "Clean 5 of any herb.",
     "requirements": "1 Herblore",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 308,
@@ -2778,7 +3086,8 @@
     "task": "Clean 10 of any herb",
     "information": "Clean 10 of any herb",
     "requirements": "1 Herblore",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 309,
@@ -2787,7 +3096,8 @@
     "task": "Fletch an Oak Shortbow (unstrung).",
     "information": "Fletch an unstrung oak shortbow.",
     "requirements": "20 Fletching",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 310,
@@ -2796,7 +3106,8 @@
     "task": "Fletch some arrow shafts.",
     "information": "Fletch some arrow shafts.",
     "requirements": "1 Fletching",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 311,
@@ -2805,7 +3116,8 @@
     "task": "Fletch 50 Bronze bolts.",
     "information": "Fletch 50 bronze bolts.",
     "requirements": "9 Fletching",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 312,
@@ -2814,7 +3126,8 @@
     "task": "Complete 10 laps of any Agility course.",
     "information": "Complete 10 laps of any Agility course.",
     "requirements": "1 Agility",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 313,
@@ -2823,7 +3136,8 @@
     "task": "Smith 10 of any metal weapon or armour piece.",
     "information": "Smith 10 of any metal weapon or armour piece.",
     "requirements": "1 Smithing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 314,
@@ -2832,7 +3146,8 @@
     "task": "Open 30 Sedimentary Geodes.",
     "information": "Open 30 sedimentary geodes. These are found randomly while mining.",
     "requirements": "1 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 315,
@@ -2841,7 +3156,8 @@
     "task": "Maintain nearly maximum stamina when mining for 60 seconds.",
     "information": "Maintain nearly maximum stamina when mining for 60 seconds.",
     "requirements": "1 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 316,
@@ -2850,7 +3166,8 @@
     "task": "Harvest a Grimy Marrentill.",
     "information": "Harvest a grimy marrentill.",
     "requirements": "9 Farming",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 317,
@@ -2859,7 +3176,8 @@
     "task": "Harvest 10 Grimy Tarromin.",
     "information": "Harvest 10 grimy tarromin.",
     "requirements": "19 Farming",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 318,
@@ -2868,7 +3186,8 @@
     "task": "Cook 5 fish.",
     "information": "Cook 5 fish.",
     "requirements": "1 Cooking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 319,
@@ -2877,7 +3196,8 @@
     "task": "Make some Bread.",
     "information": "Make some bread. Bread dough can be created by using a pot of flour with water, it must be cooked at a range.",
     "requirements": "1 Cooking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 320,
@@ -2886,7 +3206,8 @@
     "task": "Make some flour.",
     "information": "Make a pot of flour by grinding wheat at a windmill and collecting the flour in an empty pot.",
     "requirements": "Wheat and an empty pot",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 321,
@@ -2895,7 +3216,8 @@
     "task": "Offer 5 bones of any kind to an altar.",
     "information": "Offer 5 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel",
     "requirements": "1 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 322,
@@ -2904,7 +3226,8 @@
     "task": "Offer 25 bones of any kind to an altar.",
     "information": "Offer 25 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel",
     "requirements": "1 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 323,
@@ -2913,7 +3236,8 @@
     "task": "Scatter some Ashes.",
     "information": "Scatter some ashes.",
     "requirements": "1 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 324,
@@ -2922,7 +3246,8 @@
     "task": "Scatter 25 ashes of any kind.",
     "information": "Scatter 25 ashes of any kind.",
     "requirements": "1 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 325,
@@ -2931,7 +3256,8 @@
     "task": "Restore 50 Prayer Points at an Altar at once.",
     "information": "Restore 50 Prayer Points at an Altar at once.",
     "requirements": "5 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 326,
@@ -2940,7 +3266,8 @@
     "task": "Activate Superhuman or Ultimate Strength and Improved or Incredible Reflexes prayers at the same time.",
     "information": "Activate Superhuman or Ultimate Strength and Improved or Incredible Reflexes prayers at the same time.",
     "requirements": "16 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 327,
@@ -2949,7 +3276,8 @@
     "task": "Catch a Baby Impling.",
     "information": "Catch a baby impling.",
     "requirements": "17 Hunter",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 328,
@@ -2958,7 +3286,8 @@
     "task": "Catch 10 Implings of any kind.",
     "information": "Catch 10 implings of any kind.",
     "requirements": "17 Hunter",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 329,
@@ -2967,7 +3296,8 @@
     "task": "Catch 5 Hunter creatures.",
     "information": "Catch 5 Hunter creatures.",
     "requirements": "1 Hunter",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 330,
@@ -2976,7 +3306,8 @@
     "task": "Complete 5 Slayer tasks.",
     "information": "Complete 5 Slayer assignments.",
     "requirements": "1 Slayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 331,
@@ -2985,7 +3316,8 @@
     "task": "Pick 5 Flax.",
     "information": "Pick 5 flax from flax fields.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 332,
@@ -2994,7 +3326,8 @@
     "task": "Spin 5 bowstring.",
     "information": "Spin 5 bowstrings by using flax on a spinning wheel.",
     "requirements": "1 Fletching",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 333,
@@ -3003,7 +3336,8 @@
     "task": "Surge a distance of one tile.",
     "information": "Surge a distance of one tile.",
     "requirements": "5 Agility",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 334,
@@ -3012,7 +3346,8 @@
     "task": "Spin a Ball of Wool.",
     "information": "Spin a ball of wool by using wool at a spinning wheel.",
     "requirements": "1 Fletching",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 335,
@@ -3021,7 +3356,8 @@
     "task": "Equip a full set of Iron armour without any upgrades.",
     "information": "Equip an iron full helm, iron platebody, iron platelegs / iron plateskirt, iron gauntlets, iron armoured boots, and an iron kiteshield. Substitutes for pieces (e.g. med helm instead of full helm, chainbody instead of platebody, square shield instead of kite shield) will work. Iron armour can be bought at Horvik's Armour Shop.",
     "requirements": "10 Defence",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 336,
@@ -3030,7 +3366,8 @@
     "task": "Equip a full set of Green Dragonhide armour.",
     "information": "Equip a full set of green dragonhide armour.",
     "requirements": "40 Defence",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 337,
@@ -3039,7 +3376,8 @@
     "task": "Equip a full set of Imphide robes.",
     "information": "Equip a full set of imphide robes.",
     "requirements": "10 Defence",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 338,
@@ -3048,7 +3386,8 @@
     "task": "Equip a full set of Spider silk robes.",
     "information": "Equip a full set of spider silk robes.",
     "requirements": "20 Defence",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 339,
@@ -3057,7 +3396,8 @@
     "task": "Store the items required for an emote clue in a Treasure Trail hidey-hole.",
     "information": "Store the items required for an emote clue in a Treasure Trail hidey-hole.",
     "requirements": "27 Construction",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 340,
@@ -3066,7 +3406,8 @@
     "task": "Complete an Easy clue scroll.",
     "information": "Complete an easy clue scroll.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 341,
@@ -3075,7 +3416,8 @@
     "task": "Collect 10 unique items for the General clue rewards collection log.",
     "information": "Collect 10 unique items for the general clue rewards collection log.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 342,
@@ -3084,7 +3426,8 @@
     "task": "Obtain a Naragi engram from Orla Fairweather.",
     "information": "Obtain a Naragi engram from Orla Fairweather. The engram is given to the player during the tutorial for Memorial to Guthix",
     "requirements": "1 Divination",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 343,
@@ -3093,7 +3436,8 @@
     "task": "Catch a Wild Kebbit.",
     "information": "Catch a wild kebbit.",
     "requirements": "23 Hunter",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 344,
@@ -3102,7 +3446,8 @@
     "task": "Reach level 50 in any skill.",
     "information": "Reach level 50 in any skill.",
     "requirements": "Any skill at level 50",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 345,
@@ -3111,7 +3456,8 @@
     "task": "Reach at least level 5 in all non-elite skills.",
     "information": "Reach at least level 5 in all non-elite skills.",
     "requirements": "All skills except Invention at level 5",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 346,
@@ -3120,7 +3466,8 @@
     "task": "Reach at least level 10 in all non-elite skills.",
     "information": "Reach at least level 10 in all non-elite skills.",
     "requirements": "All skills except Invention at level 10",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 347,
@@ -3129,7 +3476,8 @@
     "task": "Reach at least level 20 in all non-elite skills.",
     "information": "Reach at least level 20 in all non-elite skills.",
     "requirements": "All skills except Invention at level 20",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 348,
@@ -3138,7 +3486,8 @@
     "task": "Reach combat level 50.",
     "information": "Reach combat level 50.",
     "requirements": "50 Combat level",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 349,
@@ -3147,7 +3496,8 @@
     "task": "Reach total level 500.",
     "information": "Reach total level 500. This task is currently bugged and may complete before you have reached 500 total levels",
     "requirements": "500 Skills Total level",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 350,
@@ -3156,7 +3506,8 @@
     "task": "Mine any ore 200 times.",
     "information": "Mine any ore 200 times.",
     "requirements": "1 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 351,
@@ -3165,7 +3516,8 @@
     "task": "Chop any tree 200 times.",
     "information": "Chop any tree 200 times.",
     "requirements": "1 Woodcutting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 352,
@@ -3174,7 +3526,8 @@
     "task": "Chop a willow tree.",
     "information": "Chop a willow tree.",
     "requirements": "20 Woodcutting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 353,
@@ -3183,7 +3536,8 @@
     "task": "Burn any logs 200 times.",
     "information": "Burn any logs 200 times.",
     "requirements": "1 Firemaking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 354,
@@ -3192,7 +3546,8 @@
     "task": "Catch any fish 200 times.",
     "information": "Catch any fish 200 times.",
     "requirements": "1 Fishing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 355,
@@ -3201,7 +3556,8 @@
     "task": "Harvest any memory from a wisp 200 times.",
     "information": "Harvest any memory from a wisp 200 times.",
     "requirements": "1 Divination",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 356,
@@ -3210,7 +3566,8 @@
     "task": "Pickpocket anyone 200 times.",
     "information": "Pickpocket anyone 200 times.",
     "requirements": "1 Thieving",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 357,
@@ -3219,7 +3576,8 @@
     "task": "Plant seeds in any farming patch 100 times.",
     "information": "Plant seeds in any farming patch 100 times.",
     "requirements": "1 Farming",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 358,
@@ -3228,7 +3586,8 @@
     "task": "Unlock all of the Free to Play Lodestones.",
     "information": "Unlock all of the Free to Play Lodestones.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 359,
@@ -3237,7 +3596,8 @@
     "task": "Make 200 potions of any kind.",
     "information": "Make 200 potions of any kind.",
     "requirements": "1 Herblore",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 360,
@@ -3246,7 +3606,8 @@
     "task": "Clean 200 of any herb.",
     "information": "Clean 200 of any herb.",
     "requirements": "1 Herblore",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 361,
@@ -3255,7 +3616,8 @@
     "task": "Fletch 1,000 arrow shafts.",
     "information": "Fletch 1,000 Arrow Shafts.",
     "requirements": "1 Fletching",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 362,
@@ -3264,7 +3626,8 @@
     "task": "Complete 25 laps of any Agility course.",
     "information": "Complete 25 laps of any Agility course.",
     "requirements": "1 Agility",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 363,
@@ -3273,7 +3636,8 @@
     "task": "Smith 25 of any metal weapon or armour piece.",
     "information": "Smith 25 of any metal weapon or armour piece.",
     "requirements": "1 Smithing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 364,
@@ -3282,7 +3646,8 @@
     "task": "Cook 200 fish.",
     "information": "Cook 200 fish.",
     "requirements": "1 Cooking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 365,
@@ -3291,7 +3656,8 @@
     "task": "Offer 100 bones of any kind to an altar.",
     "information": "Offer 100 bones (ashes also work) at the chaos altar in the Wilderness, the altar in Fort Forinthry, or an altar in the player-owned house chapel",
     "requirements": "1 Prayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 366,
@@ -3300,7 +3666,8 @@
     "task": "Scatter 100 ashes of any kind.",
     "information": "Scatter 100 ashes of any kind.",
     "requirements": "1 Prayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 367,
@@ -3309,7 +3676,8 @@
     "task": "Restore 500 Prayer Points at an Altar at once.",
     "information": "Restore 500 Prayer Points at an Altar at once.",
     "requirements": "50 Prayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 368,
@@ -3318,7 +3686,8 @@
     "task": "Catch 25 Implings of any kind.",
     "information": "Catch 25 implings of any kind.",
     "requirements": "17 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 369,
@@ -3327,7 +3696,8 @@
     "task": "Catch 35 Implings of any kind.",
     "information": "Catch 35 Implings of any kind.",
     "requirements": "17 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 370,
@@ -3336,7 +3706,8 @@
     "task": "Catch 200 Hunter creatures.",
     "information": "Catch 200 Hunter creatures.",
     "requirements": "1 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 371,
@@ -3345,7 +3716,8 @@
     "task": "Complete 25 Easy clue scrolls.",
     "information": "Complete 25 easy clue scrolls.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 372,
@@ -3354,7 +3726,8 @@
     "task": "Complete 75 Easy clue scrolls.",
     "information": "Complete 75 easy clue scrolls.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 373,
@@ -3363,7 +3736,8 @@
     "task": "Collect 25 unique items for the General clue rewards collection log.",
     "information": "Collect 25 unique items for the general clue rewards collection log.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 374,
@@ -3372,7 +3746,8 @@
     "task": "Make 30 Prayer Potions.",
     "information": "Make 30 prayer potions.",
     "requirements": "38 Herblore",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 375,
@@ -3381,7 +3756,8 @@
     "task": "Make a 4-dose Potion.",
     "information": "Make a 4-dose potion.",
     "requirements": "1 Herblore",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 376,
@@ -3390,7 +3766,8 @@
     "task": "Make 20 Super Attack Potions.",
     "information": "Make 20 super attack potions.",
     "requirements": "45 Herblore",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 377,
@@ -3399,7 +3776,8 @@
     "task": "Clean 50 Grimy Ranarr.",
     "information": "Clean 50 grimy ranarr.",
     "requirements": "25 Herblore",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 378,
@@ -3408,7 +3786,8 @@
     "task": "Clean 50 Grimy Avantoe.",
     "information": "Clean 50 grimy avantoe.",
     "requirements": "48 Herblore",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 379,
@@ -3417,7 +3796,8 @@
     "task": "Harvest 5 Grimy Ranarr.",
     "information": "Harvest 5 grimy ranarr.",
     "requirements": "32 Farming",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 380,
@@ -3426,7 +3806,8 @@
     "task": "Equip an Iron Crossbow.",
     "information": "Equip an iron crossbow.",
     "requirements": "10 Ranged",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 381,
@@ -3435,7 +3816,8 @@
     "task": "Equip a Maple shieldbow.",
     "information": "Equip a maple shieldbow.",
     "requirements": "30 Ranged, 30 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 382,
@@ -3444,7 +3826,8 @@
     "task": "Fletch 50 Maple shieldbow (unstrung).",
     "information": "Fletch 50 unstrung maple shieldbows.",
     "requirements": "55 Fletching",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 383,
@@ -3453,7 +3836,8 @@
     "task": "Fletch 400 Steel arrows.",
     "information": "Fletch 400 steel arrows.",
     "requirements": "30 Fletching",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 384,
@@ -3462,7 +3846,8 @@
     "task": "Fletch 100 Iron bolts.",
     "information": "Fletch 100 iron bolts.",
     "requirements": "39 Fletching",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 385,
@@ -3471,7 +3856,8 @@
     "task": "Mine some Ore With a Rune Pickaxe.",
     "information": "Mine some ore with a rune pickaxe.",
     "requirements": "50 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 386,
@@ -3480,7 +3866,8 @@
     "task": "Mine 20 Mithril Ore.",
     "information": "Mine 20 mithril ore.",
     "requirements": "30 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 387,
@@ -3489,7 +3876,8 @@
     "task": "Mine 30 Adamant Ore.",
     "information": "Mine 30 adamantite ore.",
     "requirements": "40 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 388,
@@ -3498,7 +3886,8 @@
     "task": "Mine 40 Runite Ore.",
     "information": "Mine 40 runite ore.",
     "requirements": "50 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 389,
@@ -3507,7 +3896,8 @@
     "task": "Open 20 Igenous[sic] Geodes.",
     "information": "Open 20 igneous geodes. These are found randomly while mining from rocks which require at least level 60 Mining",
     "requirements": "60 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 390,
@@ -3516,7 +3906,8 @@
     "task": "Check a grown Fruit Tree.",
     "information": "Check a tree grown in a fruit tree patch.",
     "requirements": "27 Farming",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 391,
@@ -3525,7 +3916,8 @@
     "task": "Catch 100 Lobsters.",
     "information": "Catch 100 lobsters.",
     "requirements": "40 Fishing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 392,
@@ -3534,7 +3926,8 @@
     "task": "Catch 50 Swordfish.",
     "information": "Catch 50 swordfish.",
     "requirements": "50 Fishing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 393,
@@ -3543,7 +3936,8 @@
     "task": "Catch 50 Salmon.",
     "information": "Catch 50 salmon.",
     "requirements": "30 Fishing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 394,
@@ -3552,7 +3946,8 @@
     "task": "Catch 10 Pike.",
     "information": "Catch 10 pike.",
     "requirements": "25 Fishing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 395,
@@ -3561,7 +3956,8 @@
     "task": "Make a Pineapple pizza.",
     "information": "Make a pineapple pizza by adding pineapple chunks or a pineapple ring to a plain pizza.",
     "requirements": "65 Cooking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 396,
@@ -3570,7 +3966,8 @@
     "task": "Make a Stew.",
     "information": "Make a stew: add a raw potato to a bowl of water, then add either cooked meat or chicken, and cook the stew at a range.",
     "requirements": "25 Cooking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 397,
@@ -3579,7 +3976,8 @@
     "task": "Make a Chocolate Cake.",
     "information": "Make a chocolate cake by adding a chocolate bar to a cooked cake.",
     "requirements": "50 Cooking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 398,
@@ -3588,7 +3986,8 @@
     "task": "Bury some Baby Dragon bones.",
     "information": "Bury some baby dragon bones.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 399,
@@ -3597,7 +3996,8 @@
     "task": "Bury 5 Dragon bones.",
     "information": "Bury 5 dragon bones.",
     "requirements": "1 Prayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 400,
@@ -3606,7 +4006,8 @@
     "task": "Activate Protect from Melee prayer.",
     "information": "Activate the Protect from Melee prayer.",
     "requirements": "43 Prayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 401,
@@ -3615,7 +4016,8 @@
     "task": "Catch a Gourmet Impling.",
     "information": "Catch a gourmet impling.",
     "requirements": "28 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 402,
@@ -3624,7 +4026,8 @@
     "task": "Light a Bullseye Lantern.",
     "information": "Light a bullseye lantern.",
     "requirements": "49 Firemaking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 403,
@@ -3633,7 +4036,8 @@
     "task": "Teleport using Law runes.",
     "information": "Teleport using law runes. The lowest level teleport spell is South Feldip Hills Teleport which also requires one air and one water rune",
     "requirements": "10 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 404,
@@ -3642,7 +4046,8 @@
     "task": "Craft some Combination runes.",
     "information": "Craft some combination runes: mist runes have the lowest level requirement. They can made by using a pure essence and 1 water rune and a water talisman at the air altar or 1 air rune and an air talisman at the water altar",
     "requirements": "6 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 405,
@@ -3651,7 +4056,8 @@
     "task": "Craft 100 runes.",
     "information": "Craft 100 runes.",
     "requirements": "1 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 406,
@@ -3660,7 +4066,8 @@
     "task": "Craft 1,000 runes.",
     "information": "Craft 1,000 runes.",
     "requirements": "1 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 407,
@@ -3669,7 +4076,8 @@
     "task": "Equip a full set of Steel armour.",
     "information": "Equip a full set of steel armour (helm, body, legs, boots, and gauntlets).",
     "requirements": "20 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 408,
@@ -3678,7 +4086,8 @@
     "task": "Equip a full set of Mithril armour.",
     "information": "Equip a full set of mithril armour (full helm, platebody, legs, boots, and gauntlets).",
     "requirements": "30 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 409,
@@ -3687,7 +4096,8 @@
     "task": "Equip a full set of Adamant armour.",
     "information": "Equip a full set of adamant armour (full helm, platebody, legs, boots, and gauntlets).",
     "requirements": "40 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 410,
@@ -3696,7 +4106,8 @@
     "task": "Equip a full set of Rune armour.",
     "information": "Equip a full set of rune armour (full helm, platebody, legs, boots, and gauntlets).",
     "requirements": "50 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 411,
@@ -3705,7 +4116,8 @@
     "task": "Equip a full set of Blue Dragonhide armour.",
     "information": "Equip a full set of blue dragonhide armour.",
     "requirements": "50 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 412,
@@ -3714,7 +4126,8 @@
     "task": "Equip a full set of Red Dragonhide armour.",
     "information": "Equip a full set of red Dragonhide armour.",
     "requirements": "55 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 413,
@@ -3723,7 +4136,8 @@
     "task": "Equip a full set of Batwing robes.",
     "information": "Equip a full set of batwing robes.",
     "requirements": "30 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 414,
@@ -3732,7 +4146,8 @@
     "task": "Equip a full set of Mystic robes.",
     "information": "Equip a full set of mystic robes.",
     "requirements": "50 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 415,
@@ -3741,7 +4156,8 @@
     "task": "Create a Mithril Grapple.",
     "information": "Create a mithril grapple.",
     "requirements": "59 Fletching, 30 Smithing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 416,
@@ -3750,7 +4166,8 @@
     "task": "Burn 25 Willow logs.",
     "information": "Burn 25 willow logs.",
     "requirements": "30 Firemaking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 417,
@@ -3759,7 +4176,8 @@
     "task": "Burn 50 Maple logs.",
     "information": "Burn 50 maple logs.",
     "requirements": "45 Firemaking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 418,
@@ -3768,7 +4186,8 @@
     "task": "Equip any elemental battlestaff.",
     "information": "Equip any elemental battlestaff.",
     "requirements": "30 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 419,
@@ -3777,7 +4196,8 @@
     "task": "Equip a mystic staff.",
     "information": "Equip a mystic staff.",
     "requirements": "40 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 420,
@@ -3786,7 +4206,8 @@
     "task": "Obtain 50 Quest Points.",
     "information": "Obtain 50 quest points.",
     "requirements": "50 Quest points",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 421,
@@ -3795,7 +4216,8 @@
     "task": "Complete 100 clues of any tier.",
     "information": "Complete 100 clues of any tier.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 422,
@@ -3804,7 +4226,8 @@
     "task": "Complete a Medium clue scroll.",
     "information": "Complete a medium clue scroll.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 423,
@@ -3813,7 +4236,8 @@
     "task": "Complete 25 Medium clue scrolls.",
     "information": "Complete 25 medium clue scrolls.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 424,
@@ -3822,7 +4246,8 @@
     "task": "Complete 75 Medium clue scrolls.",
     "information": "Complete 75 medium clue scrolls.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 425,
@@ -3831,7 +4256,8 @@
     "task": "Complete a Hard clue scroll.",
     "information": "Complete a hard clue scroll.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 426,
@@ -3840,7 +4266,8 @@
     "task": "Complete 25 Hard clue scrolls.",
     "information": "Complete 25 hard clue scrolls.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 427,
@@ -3849,7 +4276,8 @@
     "task": "Collect 5 unique items for the Easy clue rewards collection log.",
     "information": "Collect 5 unique items for the easy clue rewards collection log.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 428,
@@ -3858,7 +4286,8 @@
     "task": "Collect 10 unique items for the Easy clue rewards collection log.",
     "information": "Collect 10 unique items for the easy clue rewards collection log.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 429,
@@ -3867,7 +4296,8 @@
     "task": "Collect 5 unique items for the Medium clue rewards collection log.",
     "information": "Collect 5 unique items for the medium clue rewards collection log.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 430,
@@ -3876,7 +4306,8 @@
     "task": "Collect 10 unique items for the Medium clue rewards collection log.",
     "information": "Collect 10 unique items for the Medium clue rewards collection log.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 431,
@@ -3885,7 +4316,8 @@
     "task": "Collect 5 unique items for the Hard clue rewards collection log.",
     "information": "Collect 5 unique items for the hard clue rewards collection log.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 432,
@@ -3894,7 +4326,8 @@
     "task": "Equip any 2 pieces of an Elegant outfit.",
     "information": "Equip any 2 pieces of an elegant outfit.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 433,
@@ -3903,7 +4336,8 @@
     "task": "Equip a composite bow of any kind.",
     "information": "Equip a composite bow of any kind.",
     "requirements": "20 Ranged",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 434,
@@ -3912,7 +4346,8 @@
     "task": "Perform a Special Attack.",
     "information": "Perform a special attack.",
     "requirements": "5 Attack or 5 Ranged or 5 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 435,
@@ -3921,7 +4356,8 @@
     "task": "Reach level 30 in any skill.",
     "information": "Reach level 30 in any skill.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 436,
@@ -3930,7 +4366,8 @@
     "task": "Reach level 40 in any skill.",
     "information": "Reach level 40 in any skill.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 437,
@@ -3939,7 +4376,8 @@
     "task": "Reach level 60 in any skill.",
     "information": "Reach level 60 in any skill.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 438,
@@ -3948,7 +4386,8 @@
     "task": "Reach at least level 30 in all non-elite skills.",
     "information": "Reach at least level 30 in all non-elite skills.",
     "requirements": "All skills except Invention at level 30",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 439,
@@ -3957,7 +4396,8 @@
     "task": "Equip a Spottier Cape.",
     "information": "Equip a spottier cape.",
     "requirements": "66 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 440,
@@ -3966,7 +4406,8 @@
     "task": "Hunt 10 Spotted Kebbits with the help of a falcon.",
     "information": "Hunt 10 spotted kebbits with using falconry.",
     "requirements": "43 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 441,
@@ -3975,7 +4416,8 @@
     "task": "Complete the quest: The Needle Skips.",
     "information": "Complete The Needle Skips.",
     "requirements": "Quest: The Needle Skips",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 442,
@@ -3984,7 +4426,8 @@
     "task": "Catch a Monkfish.",
     "information": "Catch a raw monkfish.",
     "requirements": "62 Fishing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 443,
@@ -3993,7 +4436,8 @@
     "task": "Recover all data for one memory-storage bot in the Hall of Memories.",
     "information": "Recover all data for memory-storage bot (Aagi) in the Hall of Memories.",
     "requirements": "70 Divination",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 444,
@@ -4002,7 +4446,8 @@
     "task": "Mine 25 Platinum Ore south of Piscatoris Fishing Colony.",
     "information": "Mine 25 platinum ores south of Piscatoris Fishing Colony.",
     "requirements": "70 Mining",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 445,
@@ -4011,7 +4456,8 @@
     "task": "Chop 50 Eternal Magic logs.",
     "information": "Chop 50 eternal magic logs.",
     "requirements": "75 Woodcutting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 446,
@@ -4020,7 +4466,8 @@
     "task": "Reach at least level 50 in all non-elite skills.",
     "information": "Reach at least level 50 in all non-elite skills.",
     "requirements": "All skills except Invention at level 50",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 447,
@@ -4029,7 +4476,8 @@
     "task": "Reach combat level 100.",
     "information": "Reach combat level 100.",
     "requirements": "100 Combat",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 448,
@@ -4038,7 +4486,8 @@
     "task": "Reach total level 1000.",
     "information": "Reach total level 1000. This task is currently bugged and may complete before you have reached 1000 total levels",
     "requirements": "1000 Skills Total level",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 449,
@@ -4047,7 +4496,8 @@
     "task": "Mine any ore 1000 times.",
     "information": "Mine any ore 1000 times.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 450,
@@ -4056,7 +4506,8 @@
     "task": "Chop any tree 1000 times.",
     "information": "Chop any tree 1000 times.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 451,
@@ -4065,7 +4516,8 @@
     "task": "Burn any logs 1000 times.",
     "information": "Burn any logs 1000 times.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 452,
@@ -4074,7 +4526,8 @@
     "task": "Catch any fish 1000 times.",
     "information": "Catch any fish 1000 times.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 453,
@@ -4083,7 +4536,8 @@
     "task": "Harvest any memory from a wisp 1000 times.",
     "information": "Harvest any memory from a wisp 1000 times.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 454,
@@ -4092,7 +4546,8 @@
     "task": "Pickpocket anyone 1000 times.",
     "information": "Pickpocket anyone 1000 times.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 455,
@@ -4101,7 +4556,8 @@
     "task": "Unlock all of the Lodestones.",
     "information": "Unlock all of the lodestones.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 456,
@@ -4110,7 +4566,8 @@
     "task": "Make 1,000 potions of any kind.",
     "information": "Make 1,000 potions of any kind.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 457,
@@ -4119,7 +4576,8 @@
     "task": "Clean 1,000 of any herb.",
     "information": "Clean 1,000 of any herb.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 458,
@@ -4128,7 +4586,8 @@
     "task": "Complete 50 laps of any Agility course.",
     "information": "Complete 50 laps of any Agility course.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 459,
@@ -4137,7 +4596,8 @@
     "task": "Complete 100 laps of any Agility course.",
     "information": "Complete 100 laps of any Agility course.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 460,
@@ -4146,7 +4606,8 @@
     "task": "Smith 50 of any metal weapon or armour piece.",
     "information": "Smith 50 of any metal weapon or armour piece.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 461,
@@ -4155,7 +4616,8 @@
     "task": "Smith 100 of any metal weapon or armour piece.",
     "information": "Smith 100 of any metal weapon or armour piece.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 462,
@@ -4164,7 +4626,8 @@
     "task": "Cook 1,000 fish.",
     "information": "Cook 1,000 fish.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 463,
@@ -4173,7 +4636,8 @@
     "task": "Catch 1,000 Hunter creatures.",
     "information": "Catch 1,000 Hunter creatures.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 464,
@@ -4182,7 +4646,8 @@
     "task": "Complete 15 Slayer tasks.",
     "information": "Complete 15 Slayer tasks.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 465,
@@ -4191,7 +4656,8 @@
     "task": "Complete 150 Easy clue scrolls.",
     "information": "Complete 150 easy clue scrolls.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 466,
@@ -4200,7 +4666,8 @@
     "task": "Collect 50 unique items for the General clue rewards collection log.",
     "information": "Collect 50 unique items for the general clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 467,
@@ -4209,7 +4676,8 @@
     "task": "Craft 10,000 runes.",
     "information": "Craft 10,000 runes.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 468,
@@ -4218,7 +4686,8 @@
     "task": "Craft 20,000 runes.",
     "information": "Craft 20,000 runes.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 469,
@@ -4227,7 +4696,8 @@
     "task": "Obtain 75 Quest Points.",
     "information": "Obtain 75 quest points.",
     "requirements": "75 Quest points",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 470,
@@ -4236,7 +4706,8 @@
     "task": "Obtain 100 Quest Points.",
     "information": "Obtain 100 quest points.",
     "requirements": "100 Quest points",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 471,
@@ -4245,7 +4716,8 @@
     "task": "Complete 150 Medium clue scrolls.",
     "information": "Complete 150 medium clue scrolls.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 472,
@@ -4254,7 +4726,8 @@
     "task": "Complete 75 Hard clue scrolls.",
     "information": "Complete 75 hard clue scrolls.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 473,
@@ -4263,7 +4736,8 @@
     "task": "Complete 150 Hard clue scrolls.",
     "information": "Complete 150 hard clue scrolls.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 474,
@@ -4272,7 +4746,8 @@
     "task": "Collect 25 unique items for the Easy clue rewards collection log.",
     "information": "Collect 25 unique items for the easy clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 475,
@@ -4281,7 +4756,8 @@
     "task": "Collect 50 unique items for the Easy clue rewards collection log.",
     "information": "Collect 50 unique items for the easy clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 476,
@@ -4290,7 +4766,8 @@
     "task": "Collect 25 unique items for the Medium clue rewards collection log.",
     "information": "Collect 25 unique items for the medium clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 477,
@@ -4299,7 +4776,8 @@
     "task": "Collect 50 unique items for the Medium clue rewards collection log.",
     "information": "Collect 50 unique items for the medium clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 478,
@@ -4308,7 +4786,8 @@
     "task": "Collect 10 unique items for the Hard clue rewards collection log.",
     "information": "Collect 10 unique items for the hard clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 479,
@@ -4317,7 +4796,8 @@
     "task": "Collect 25 unique items for the Hard clue rewards collection log.",
     "information": "Collect 25 unique items for the hard clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 480,
@@ -4326,7 +4806,8 @@
     "task": "Equip any Dragon mask.",
     "information": "Equip any dragon mask.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 481,
@@ -4335,7 +4816,8 @@
     "task": "Make any Perfect Juju Potion.",
     "information": "Make any perfect juju potion.",
     "requirements": "75 Herblore",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 482,
@@ -4344,7 +4826,8 @@
     "task": "Make 15 Antifire Potions.",
     "information": "Make 15 antifire potions.",
     "requirements": "69 Herblore",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 483,
@@ -4353,7 +4836,8 @@
     "task": "Clean 50 Grimy Cadantine.",
     "information": "Clean 50 grimy cadantine.",
     "requirements": "65 Herblore",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 484,
@@ -4362,7 +4846,8 @@
     "task": "Clean 100 Grimy Lantadyme.",
     "information": "Clean 100 grimy lantadyme.",
     "requirements": "67 Herblore",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 485,
@@ -4371,7 +4856,8 @@
     "task": "Clean 100 Dwarf Weed.",
     "information": "Clean 100 grimy dwarf weed.",
     "requirements": "70 Herblore",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 486,
@@ -4380,7 +4866,8 @@
     "task": "Clean 100 Arbuck.",
     "information": "Clean 100 grimy arbuck.",
     "requirements": "77 Herblore, 77 Farming",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 487,
@@ -4389,7 +4876,8 @@
     "task": "Equip a Yew shortbow.",
     "information": "Equip a yew shortbow.",
     "requirements": "40 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 488,
@@ -4398,7 +4886,8 @@
     "task": "Equip a Magic shortbow.",
     "information": "Equip a magic shortbow.",
     "requirements": "50 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 489,
@@ -4407,7 +4896,8 @@
     "task": "Fletch some Broad Arrows or Bolts.",
     "information": "Fletch some broad arrows or bolts.",
     "requirements": "52 Fletching",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 490,
@@ -4416,7 +4906,8 @@
     "task": "Fletch 100 Yew shortbows (unstrung).",
     "information": "Fletch 100 Yew shortbows (unstrung).",
     "requirements": "65 Fletching",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 491,
@@ -4425,7 +4916,8 @@
     "task": "Fletch 100 Yew stocks.",
     "information": "Fletch 100 yew stocks.",
     "requirements": "69 Fletching",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 492,
@@ -4434,7 +4926,8 @@
     "task": "Fletch a Rune Crossbow.",
     "information": "Fletch a rune crossbow.",
     "requirements": "69 Fletching",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 493,
@@ -4443,7 +4936,8 @@
     "task": "Fletch 35 or more arrow shafts from a single log.",
     "information": "Fletch 35 or more arrow shafts from a single log.",
     "requirements": "60 Fletching",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 494,
@@ -4452,7 +4946,8 @@
     "task": "Fletch 500 Adamant arrows.",
     "information": "Fletch 500 adamant arrows.",
     "requirements": "60 Fletching",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 495,
@@ -4461,7 +4956,8 @@
     "task": "Fletch 750 Rune arrows.",
     "information": "Fletch 750 rune arrows.",
     "requirements": "75 Fletching",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 496,
@@ -4470,7 +4966,8 @@
     "task": "Fletch 75 Onyx bolts.",
     "information": "Fletch 75 onyx bolts.",
     "requirements": "73 Fletching",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 497,
@@ -4479,7 +4976,8 @@
     "task": "Equip a Rune Ceremonial Sword.",
     "information": "Equip a rune ceremonial sword.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 498,
@@ -4488,7 +4986,8 @@
     "task": "Equip a full set of the Blacksmith's outfit.",
     "information": "Equip a full set of the blacksmith's outfit.",
     "requirements": "Total of 250% Artisans' Workshop respect",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 499,
@@ -4497,7 +4996,8 @@
     "task": "Power up the Artisan's Workshop with a Luminite Injector.",
     "information": "Power up the Artisan's Workshop with a luminite Injector.",
     "requirements": "100% Artisans' Workshop respect",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 500,
@@ -4506,7 +5006,8 @@
     "task": "Mine 50 Orichalcite Ore.",
     "information": "Mine 50 orichalcite ore.",
     "requirements": "60 Mining",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 501,
@@ -4515,7 +5016,8 @@
     "task": "Mine 50 Drakolith.",
     "information": "Mine 50 drakolith",
     "requirements": "60 Mining",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 502,
@@ -4524,7 +5026,8 @@
     "task": "Mine 60 Necrite Ore.",
     "information": "Mine 60 necrite ore.",
     "requirements": "70 Mining",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 503,
@@ -4533,7 +5036,8 @@
     "task": "Mine 60 Phasmatite.",
     "information": "Mine 60 phasmatite.",
     "requirements": "70 Mining",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 504,
@@ -4542,7 +5046,8 @@
     "task": "Harvest 20 Grimy Kwuarm.",
     "information": "Harvest 20 grimy kwuarm.",
     "requirements": "56 Farming",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 505,
@@ -4551,7 +5056,8 @@
     "task": "Catch 100 Shark.",
     "information": "Catch 100 raw sharks.",
     "requirements": "76 Fishing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 506,
@@ -4560,7 +5066,8 @@
     "task": "Catch 100 Green Blubber Jellyfish.",
     "information": "Catch 100 green blubber jellyfish.",
     "requirements": "68 Fishing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 507,
@@ -4569,7 +5076,8 @@
     "task": "Catch a Spirit Impling.",
     "information": "Catch a spirit impling.",
     "requirements": "54 Hunter",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 508,
@@ -4578,7 +5086,8 @@
     "task": "Equip a Slayer helmet.",
     "information": "Equip a Slayer helmet.",
     "requirements": "55 Crafting, 35 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 509,
@@ -4587,7 +5096,8 @@
     "task": "Complete a Soul Reaper task.",
     "information": "Complete a Soul Reaper task.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 510,
@@ -4596,7 +5106,8 @@
     "task": "Complete 5 Soul Reaper tasks.",
     "information": "Complete 5 Soul Reaper tasks.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 511,
@@ -4605,7 +5116,8 @@
     "task": "Equip a full set of Orikalkum armour.",
     "information": "Equip a full set of orikalkum armour.",
     "requirements": "60 Smithing, 60 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 512,
@@ -4614,7 +5126,8 @@
     "task": "Equip a full set of Necronium armour.",
     "information": "Equip a full set of necronium armour.",
     "requirements": "70 Smithing, 70 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 513,
@@ -4623,7 +5136,8 @@
     "task": "Equip a full set of Black Dragonhide armour.",
     "information": "Equip a full set of black dragonhide armour.",
     "requirements": "60 Defence, 60 Crafting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 514,
@@ -4632,7 +5146,8 @@
     "task": "Equip a full set of Royal Dragonhide armour.",
     "information": "Equip a full set of royal dragonhide armour.",
     "requirements": "65 Defence, 65 Crafting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 515,
@@ -4641,7 +5156,8 @@
     "task": "Cast a Wave spell.",
     "information": "Cast a wave spell.",
     "requirements": "62 Magic",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 516,
@@ -4650,7 +5166,8 @@
     "task": "Burn 75 Yew logs.",
     "information": "Burn 75 yew logs.",
     "requirements": "60 Firemaking",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 517,
@@ -4659,7 +5176,8 @@
     "task": "Unlock the Ring of Quests from May's Quest Caravan.",
     "information": "Unlock the Ring of Quests from May's Quest Caravan.",
     "requirements": "75 Quest points",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 518,
@@ -4668,7 +5186,8 @@
     "task": "Complete 250 clues of any tier.",
     "information": "Complete 250 clues of any tier.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 519,
@@ -4677,7 +5196,8 @@
     "task": "Complete 500 clues of any tier.",
     "information": "Complete 500 clues of any tier.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 520,
@@ -4686,7 +5206,8 @@
     "task": "Complete an Elite clue scroll.",
     "information": "Complete an elite clue scroll.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 521,
@@ -4695,7 +5216,8 @@
     "task": "Complete 25 Elite clue scrolls.",
     "information": "Complete 25 elite clue scrolls.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 522,
@@ -4704,7 +5226,8 @@
     "task": "Complete a Master clue scroll.",
     "information": "Complete a master clue scroll.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Master"
   },
   {
     "id": 523,
@@ -4713,7 +5236,8 @@
     "task": "Collect 5 unique items for the Elite clue rewards collection log.",
     "information": "Collect 5 unique items for the elite clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 524,
@@ -4722,7 +5246,8 @@
     "task": "Collect 10 unique items for the Elite clue rewards collection log.",
     "information": "Collect 10 unique items for the elite clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 525,
@@ -4731,7 +5256,8 @@
     "task": "Collect 20 unique items for the Elite clue rewards collection log.",
     "information": "Collect 20 unique items for the elite clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 526,
@@ -4740,7 +5266,8 @@
     "task": "Collect 5 unique items for the Master clue rewards collection log.",
     "information": "Collect 5 unique items for the master clue rewards collection log.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Master"
   },
   {
     "id": 527,
@@ -4749,7 +5276,8 @@
     "task": "Catch a Manta ray.",
     "information": "Catch a raw manta ray.",
     "requirements": "81 Fishing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 528,
@@ -4758,7 +5286,8 @@
     "task": "Reach level 70 in any skill.",
     "information": "Reach level 70 in any skill.",
     "requirements": "Any skill at level 70",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 529,
@@ -4767,7 +5296,8 @@
     "task": "Reach level 80 in any skill.",
     "information": "Reach level 80 in any skill.",
     "requirements": "Any skill at level 80",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 530,
@@ -4776,7 +5306,8 @@
     "task": "Reach at least level 40 in all non-elite skills.",
     "information": "Reach at least level 40 in all non-elite skills.",
     "requirements": "All skills except Invention at level 40",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 531,
@@ -4785,7 +5316,8 @@
     "task": "Reach at least level 60 in all non-elite skills.",
     "information": "Reach at least level 60 in all non-elite skills.",
     "requirements": "All skills except Invention at level 60",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 532,
@@ -4794,7 +5326,8 @@
     "task": "Reach at least level 70 in all non-elite skills.",
     "information": "Reach at least level 70 in all non-elite skills.",
     "requirements": "All skills except Invention at level 70",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 533,
@@ -4803,7 +5336,8 @@
     "task": "Reach maximum combat level.",
     "information": "Reach maximum combat level.",
     "requirements": "138 Combat",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 534,
@@ -4812,7 +5346,8 @@
     "task": "Reach total level 2000.",
     "information": "Reach total level 2000.",
     "requirements": "2000 Skills Total level",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 535,
@@ -4821,7 +5356,8 @@
     "task": "Complete 50 Slayer tasks.",
     "information": "Complete 50 Slayer tasks.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 536,
@@ -4830,7 +5366,8 @@
     "task": "Complete 75 Slayer tasks.",
     "information": "Complete 75 Slayer tasks.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 537,
@@ -4839,7 +5376,8 @@
     "task": "Obtain 125 Quest Points.",
     "information": "Obtain 125 quest points.",
     "requirements": "125 Quest points",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 538,
@@ -4848,7 +5386,8 @@
     "task": "Collect 75 unique items for the Hard clue rewards collection log.",
     "information": "Collect 75 unique items for the hard clue rewards collection log.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 539,
@@ -4857,7 +5396,8 @@
     "task": "Complete 10 Soul Reaper tasks.",
     "information": "Complete 10 Soul Reaper tasks.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 540,
@@ -4866,7 +5406,8 @@
     "task": "Complete 75 Elite clue scrolls.",
     "information": "Complete 75 elite clue scrolls.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 541,
@@ -4875,7 +5416,8 @@
     "task": "Complete 150 Elite clue scrolls.",
     "information": "Complete 150 elite clue scrolls.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 542,
@@ -4884,7 +5426,8 @@
     "task": "Complete 25 Master clue scrolls.",
     "information": "Complete 25 master clue scrolls.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Master"
   },
   {
     "id": 543,
@@ -4893,7 +5436,8 @@
     "task": "Complete 75 Master clue scrolls.",
     "information": "Complete 75 master clue scrolls.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Master"
   },
   {
     "id": 544,
@@ -4902,7 +5446,8 @@
     "task": "Collect 35 unique items for the Elite clue rewards collection log.",
     "information": "Collect 35 unique items for the elite clue rewards collection log.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 545,
@@ -4911,7 +5456,8 @@
     "task": "Collect 10 unique items for the Master clue rewards collection log.",
     "information": "Collect 10 unique items for the master clue rewards collection log.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Master"
   },
   {
     "id": 546,
@@ -4920,7 +5466,8 @@
     "task": "Collect 15 unique items for the Master clue rewards collection log.",
     "information": "Collect 15 unique items for the master clue rewards collection log.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Master"
   },
   {
     "id": 547,
@@ -4929,7 +5476,8 @@
     "task": "Collect 30 unique items for the Master clue rewards collection log.",
     "information": "Collect 30 unique items for the master clue rewards collection log.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Master"
   },
   {
     "id": 548,
@@ -4938,7 +5486,8 @@
     "task": "Make 25 Powerburst Potions.",
     "information": "Make 25 powerbursts.",
     "requirements": "92 Herblore",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 549,
@@ -4947,7 +5496,8 @@
     "task": "Make 25 Bomb Potions.",
     "information": "Make 25 bomb potions.",
     "requirements": "93 Herblore",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 550,
@@ -4956,7 +5506,8 @@
     "task": "Make 5 Perfect Plus Potions.",
     "information": "Make 5 perfect plus potions.",
     "requirements": "84 Herblore",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 551,
@@ -4965,7 +5516,8 @@
     "task": "Make 15 Overload Potions.",
     "information": "Make 15 overloads.",
     "requirements": "96 Herblore",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 552,
@@ -4974,7 +5526,8 @@
     "task": "Make a Spiritual Prayer Potion.",
     "information": "Make a spiritual prayer potion.",
     "requirements": "97 Herblore",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 553,
@@ -4983,7 +5536,8 @@
     "task": "Fletch 200 Magic stocks.",
     "information": "Fletch 200 magic stocks.",
     "requirements": "82 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 554,
@@ -4992,7 +5546,8 @@
     "task": "Fletch 750 Elder arrow shafts.",
     "information": "Fletch 750 elder arrow shafts.",
     "requirements": "90 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 555,
@@ -5001,7 +5556,8 @@
     "task": "Fletch 20 Elder shortbow (unstrung)",
     "information": "Fletch 20 unstrung elder shortbows",
     "requirements": "90 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 556,
@@ -5010,7 +5566,8 @@
     "task": "Fletch an Eternal magic shortbow (Martial) or Primal crossbow (martial).",
     "information": "Fletch an eternal magic shortbow (martial) or primal crossbow (martial).",
     "requirements": "95 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 557,
@@ -5019,7 +5576,8 @@
     "task": "Fletch 1,000 Eternal magic shafts.",
     "information": "Fletch 1,000 eternal magic shafts.",
     "requirements": "90 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 558,
@@ -5028,7 +5586,8 @@
     "task": "Fletch 1,500 Primal arrows.",
     "information": "Fletch 1,500 primal arrows.",
     "requirements": "92 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 559,
@@ -5037,7 +5596,8 @@
     "task": "Fletch an Eternal Magic Wood Box.",
     "information": "Fletch an eternal magic wood box.",
     "requirements": "90 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 560,
@@ -5046,7 +5606,8 @@
     "task": "Fletch 350 Rune darts.",
     "information": "Fletch 350 rune darts.",
     "requirements": "81 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 561,
@@ -5055,7 +5616,8 @@
     "task": "Smith a Primal Ore Box.",
     "information": "Smith a primal ore box.",
     "requirements": "99 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 562,
@@ -5064,7 +5626,8 @@
     "task": "Smith 10,000 Armour Spikes.",
     "information": "Smith 10,000 armour spikes.",
     "requirements": "80 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 563,
@@ -5073,7 +5636,8 @@
     "task": "Smith 10,000 Primal Armour Spikes.",
     "information": "Smith 10,000 primal armour spikes.",
     "requirements": "99 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 564,
@@ -5082,7 +5646,8 @@
     "task": "Mine each of the 10 ores on the surface of the Daemonheim peninsula in under 5 minutes.",
     "information": "Mine each of the 10 ores on the surface of the Daemonheim peninsula in under 5 minutes.",
     "requirements": "80 Mining",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 565,
@@ -5091,7 +5656,8 @@
     "task": "Mine 70 Banite Ore.",
     "information": "Mine 70 banite ore.",
     "requirements": "80 Mining",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 566,
@@ -5100,7 +5666,8 @@
     "task": "Mine 100 Dark or Light Animica.",
     "information": "Mine 100 dark or light animica.",
     "requirements": "90 Mining",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 567,
@@ -5109,7 +5676,8 @@
     "task": "Open 10 Metamorphic Geodes.",
     "information": "Open 10 metamorphic geodes. These are found randomly while mining from rocks which require at least level 60 Mining",
     "requirements": "60 Mining",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 568,
@@ -5118,7 +5686,8 @@
     "task": "Harvest 40 Grimy Lantadyme.",
     "information": "Harvest 40 grimy lantadyme.",
     "requirements": "73 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 569,
@@ -5127,7 +5696,8 @@
     "task": "Harvest 50 Grimy Fellstalk.",
     "information": "Harvest 50 grimy fellstalk.",
     "requirements": "91 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 570,
@@ -5136,7 +5706,8 @@
     "task": "Plant an Avocado seed in a bush patch.",
     "information": "Plant an avocado seed in a bush patch.",
     "requirements": "69 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 571,
@@ -5145,7 +5716,8 @@
     "task": "Harvest 20 Lychee.",
     "information": "Harvest 20 lychee.",
     "requirements": "99 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 572,
@@ -5154,7 +5726,8 @@
     "task": "Harvest 24 Starbloom Flowers.",
     "information": "Harvest 24 starbloom flowers.",
     "requirements": "84 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 573,
@@ -5163,7 +5736,8 @@
     "task": "Catch 150 Rocktail.",
     "information": "Catch 150 raw rocktails.",
     "requirements": "90 Fishing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 574,
@@ -5172,7 +5746,8 @@
     "task": "Catch 200 Sailfish.",
     "information": "Catch 200 raw sailfish.",
     "requirements": "97 Fishing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 575,
@@ -5181,7 +5756,8 @@
     "task": "Catch 150 Blue Blubber Jellyfish.",
     "information": "Catch 150 raw blue blubber jellyfish.",
     "requirements": "91 Fishing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 576,
@@ -5190,7 +5766,8 @@
     "task": "Obtain the highest boost available in the 'Fishing Frenzy' activity.",
     "information": "Obtain the highest boost available in the 'Fishing Frenzy' activity at Deep Sea Fishing.",
     "requirements": "94 Fishing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 577,
@@ -5199,7 +5776,8 @@
     "task": "Catch a Cavefish.",
     "information": "Catch a raw cavefish.",
     "requirements": "85 Fishing, 80 Cooking",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 578,
@@ -5208,7 +5786,8 @@
     "task": "Manually bury or scatter each of the listed bones and ashes.",
     "information": "Complete the Bury All achievement.",
     "requirements": "90 Prayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 579,
@@ -5217,7 +5796,8 @@
     "task": "Activate Soul Split prayer.",
     "information": "Activate Soul Split prayer.",
     "requirements": "92 Prayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 580,
@@ -5226,7 +5806,8 @@
     "task": "Catch a Dragon Impling.",
     "information": "Catch a dragon impling.",
     "requirements": "80 Hunter",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 581,
@@ -5235,7 +5816,8 @@
     "task": "Catch a Kingly Impling.",
     "information": "Catch a kingly impling.",
     "requirements": "90 Hunter",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 582,
@@ -5244,7 +5826,8 @@
     "task": "Equip a full set of Bane armour.",
     "information": "Equip a full set of bane armour.",
     "requirements": "80 Smithing, 80 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 583,
@@ -5253,7 +5836,8 @@
     "task": "Equip a full set of Elder Rune armour.",
     "information": "Equip a full set of elder rune armour.",
     "requirements": "90 Smithing, 90 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 584,
@@ -5262,7 +5846,8 @@
     "task": "Cast a Surge spell.",
     "information": "Cast a Surge spell.",
     "requirements": "81 Magic",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 585,
@@ -5271,7 +5856,8 @@
     "task": "Burn 100 Magic Logs",
     "information": "Burn 100 magic logs",
     "requirements": "75 Firemaking",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 586,
@@ -5280,7 +5866,8 @@
     "task": "Burn 10 Elder logs.",
     "information": "Burn 10 elder logs.",
     "requirements": "90 Firemaking",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 587,
@@ -5289,7 +5876,8 @@
     "task": "Reach level 99 in the Agility skill.",
     "information": "Reach level 99 Agility.",
     "requirements": "99 Agility",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 588,
@@ -5298,7 +5886,8 @@
     "task": "Reach level 99 in the Archaeology skill.",
     "information": "Reach level 99 Archaeology.",
     "requirements": "99 Archaeology",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 589,
@@ -5307,7 +5896,8 @@
     "task": "Reach level 99 in the Attack skill.",
     "information": "Reach level 99 Attack.",
     "requirements": "99 Attack",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 590,
@@ -5316,7 +5906,8 @@
     "task": "Reach level 99 in the Construction skill.",
     "information": "Reach level 99 Construction.",
     "requirements": "99 Construction",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 591,
@@ -5325,7 +5916,8 @@
     "task": "Reach level 99 in the Cooking skill.",
     "information": "Reach level 99 Cooking.",
     "requirements": "99 Cooking",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 592,
@@ -5334,7 +5926,8 @@
     "task": "Reach level 99 in the Crafting skill.",
     "information": "Reach level 99 Crafting.",
     "requirements": "99 Crafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 593,
@@ -5343,7 +5936,8 @@
     "task": "Reach level 99 in the Defence skill.",
     "information": "Reach level 99 Defence.",
     "requirements": "99 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 594,
@@ -5352,7 +5946,8 @@
     "task": "Reach level 99 in the Divination skill.",
     "information": "Reach level 99 Divination.",
     "requirements": "99 Divination",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 595,
@@ -5361,7 +5956,8 @@
     "task": "Reach level 99 in the Dungeoneering skill.",
     "information": "Reach level 99 Dungeoneering.",
     "requirements": "99 Dungeoneering",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 596,
@@ -5370,7 +5966,8 @@
     "task": "Reach level 99 in the Farming skill.",
     "information": "Reach level 99 Farming.",
     "requirements": "99 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 597,
@@ -5379,7 +5976,8 @@
     "task": "Reach level 99 in the Firemaking skill. (Where arson is its own reward.)",
     "information": "Reach level 99 Firemaking.",
     "requirements": "99 Firemaking",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 598,
@@ -5388,7 +5986,8 @@
     "task": "Reach level 99 in the Fishing skill.",
     "information": "Reach level 99 Fishing.",
     "requirements": "99 Fishing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 599,
@@ -5397,7 +5996,8 @@
     "task": "Reach level 99 in the Fletching skill.",
     "information": "Reach level 99 Fletching.",
     "requirements": "99 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 600,
@@ -5406,7 +6006,8 @@
     "task": "Reach level 99 in the Herblore skill.",
     "information": "Reach level 99 Herblore.",
     "requirements": "99 Herblore",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 601,
@@ -5415,7 +6016,8 @@
     "task": "Reach level 99 in the Constitution skill.",
     "information": "Reach level 99 Constitution.",
     "requirements": "99 Constitution",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 602,
@@ -5424,7 +6026,8 @@
     "task": "Reach level 99 in the Hunter skill.",
     "information": "Reach level 99 Hunter.",
     "requirements": "99 Hunter",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 603,
@@ -5433,7 +6036,8 @@
     "task": "Reach level 99 in the Invention skill.",
     "information": "Reach level 99 Invention.",
     "requirements": "99 Invention",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 604,
@@ -5442,7 +6046,8 @@
     "task": "Reach level 99 in the Magic skill.",
     "information": "Reach level 99 Magic.",
     "requirements": "99 Magic",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 605,
@@ -5451,7 +6056,8 @@
     "task": "Reach level 99 in the Mining skill.",
     "information": "Reach level 99 Mining.",
     "requirements": "99 Mining",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 606,
@@ -5460,7 +6066,8 @@
     "task": "Reach level 99 in the Necromancy skill.",
     "information": "Reach level 99 Necromancy.",
     "requirements": "99 Necromancy",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 607,
@@ -5469,7 +6076,8 @@
     "task": "Reach level 99 in the Prayer skill.",
     "information": "Reach level 99 Prayer.",
     "requirements": "99 Prayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 608,
@@ -5478,7 +6086,8 @@
     "task": "Reach level 99 in the Ranged skill.",
     "information": "Reach level 99 Ranged.",
     "requirements": "99 Ranged",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 609,
@@ -5487,7 +6096,8 @@
     "task": "Reach level 99 in the Runecrafting skill.",
     "information": "Reach level 99 Runecrafting.",
     "requirements": "99 Runecrafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 610,
@@ -5496,7 +6106,8 @@
     "task": "Reach level 99 in the Slayer skill.",
     "information": "Reach level 99 Slayer.",
     "requirements": "99 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 611,
@@ -5505,7 +6116,8 @@
     "task": "Reach level 99 in the Smithing skill.",
     "information": "Reach level 99 Smithing.",
     "requirements": "99 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 612,
@@ -5514,7 +6126,8 @@
     "task": "Reach level 99 in the Strength skill.",
     "information": "Reach level 99 Strength.",
     "requirements": "99 Strength",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 613,
@@ -5523,7 +6136,8 @@
     "task": "Reach level 99 in the Summoning skill.",
     "information": "Reach level 99 Summoning.",
     "requirements": "99 Summoning",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 614,
@@ -5532,7 +6146,8 @@
     "task": "Reach level 99 in the Thieving skill.",
     "information": "Reach level 99 Thieving.",
     "requirements": "99 Thieving",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 615,
@@ -5541,7 +6156,8 @@
     "task": "Reach level 99 in the Woodcutting skill.",
     "information": "Reach level 99 Woodcutting.",
     "requirements": "99 Woodcutting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 616,
@@ -5550,7 +6166,8 @@
     "task": "Reach level 110 in the Mining skill.",
     "information": "Reach level 110 Mining.",
     "requirements": "110 Mining",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 617,
@@ -5559,7 +6176,8 @@
     "task": "Reach level 110 in the Smithing skill.",
     "information": "Reach level 110 Smithing.",
     "requirements": "110 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 618,
@@ -5568,7 +6186,8 @@
     "task": "Reach level 110 in the Crafting skill.",
     "information": "Reach level 110 Crafting",
     "requirements": "110 Crafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 619,
@@ -5577,7 +6196,8 @@
     "task": "Reach level 110 in the Firemaking skill.",
     "information": "Reach level 110 Firemaking.",
     "requirements": "110 Firemaking",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 620,
@@ -5586,7 +6206,8 @@
     "task": "Reach level 110 in the Fletching skill.",
     "information": "Reach level 110 Fletching.",
     "requirements": "110 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 621,
@@ -5595,7 +6216,8 @@
     "task": "Reach level 110 in the Woodcutting skill.",
     "information": "Reach level 110 Woodcutting.",
     "requirements": "110 Woodcutting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 622,
@@ -5604,7 +6226,8 @@
     "task": "Reach level 110 in the Runecrafting skill.",
     "information": "Reach level 110 Runecrafting.",
     "requirements": "110 Runecrafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 623,
@@ -5613,7 +6236,8 @@
     "task": "Reach level 120 in the Dungeoneering skill.",
     "information": "Reach level 120 Dungeoneering.",
     "requirements": "120 Dungeoneering",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 624,
@@ -5622,7 +6246,8 @@
     "task": "Reach level 120 in the Farming skill.",
     "information": "Reach level 120 Farming.",
     "requirements": "120 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 625,
@@ -5631,7 +6256,8 @@
     "task": "Reach level 120 in the Herblore skill.",
     "information": "Reach level 120 Herblore.",
     "requirements": "120 Herblore",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 626,
@@ -5640,7 +6266,8 @@
     "task": "Reach level 120 in the Slayer skill.",
     "information": "Reach level 120 Slayer.",
     "requirements": "120 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 627,
@@ -5649,7 +6276,8 @@
     "task": "Reach level 120 in the Invention skill.",
     "information": "Reach level 120 Invention.",
     "requirements": "120 Invention",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 628,
@@ -5658,7 +6286,8 @@
     "task": "Reach level 120 in the Archaeology skill.",
     "information": "Reach level 120 Archaeology",
     "requirements": "120 Archaeology",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 629,
@@ -5667,7 +6296,8 @@
     "task": "Reach level 120 in the Necromancy skill.",
     "information": "Reach level 120 Necromancy.",
     "requirements": "120 Necromancy",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 630,
@@ -5676,7 +6306,8 @@
     "task": "Obtain 50 Million Agility XP.",
     "information": "Obtain 50 million Agility XP.",
     "requirements": "50,000,000 Agility XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 631,
@@ -5685,7 +6316,8 @@
     "task": "Obtain 50 Million Construction XP.",
     "information": "Obtain 50 million Construction XP.",
     "requirements": "50,000,000 Construction XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 632,
@@ -5694,7 +6326,8 @@
     "task": "Obtain 50 Million Cooking XP.",
     "information": "Obtain 50 million Cooking XP.",
     "requirements": "50,000,000 Cooking XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 633,
@@ -5703,7 +6336,8 @@
     "task": "Obtain 50 Million Crafting XP.",
     "information": "Obtain 50 million Crafting XP.",
     "requirements": "50,000,000 Crafting XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 634,
@@ -5712,7 +6346,8 @@
     "task": "Obtain 50 Million Farming XP.",
     "information": "Obtain 50 million Farming XP.",
     "requirements": "50,000,000 Farming XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 635,
@@ -5721,7 +6356,8 @@
     "task": "Obtain 50 Million Firemaking XP.",
     "information": "Obtain 50 million Firemaking XP.",
     "requirements": "50,000,000 Firemaking XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 636,
@@ -5730,7 +6366,8 @@
     "task": "Obtain 50 Million Fishing XP.",
     "information": "Obtain 50 million Fishing XP.",
     "requirements": "50,000,000 Fishing XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 637,
@@ -5739,7 +6376,8 @@
     "task": "Obtain 50 Million Fletching XP.",
     "information": "Obtain 50 million Fletching XP.",
     "requirements": "50,000,000 Fletching XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 638,
@@ -5748,7 +6386,8 @@
     "task": "Obtain 50 Million Herblore XP.",
     "information": "Obtain 50 million Herblore XP.",
     "requirements": "50,000,000 Herblore XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 639,
@@ -5757,7 +6396,8 @@
     "task": "Obtain 50 Million Hunter XP.",
     "information": "Obtain 50 million Hunter XP.",
     "requirements": "50,000,000 Hunter XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 640,
@@ -5766,7 +6406,8 @@
     "task": "Obtain 50 Million Mining XP.",
     "information": "Obtain 50 million Mining XP.",
     "requirements": "50,000,000 Mining XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 641,
@@ -5775,7 +6416,8 @@
     "task": "Obtain 50 Million Prayer XP.",
     "information": "Obtain 50 million Prayer XP.",
     "requirements": "50,000,000 Prayer XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 642,
@@ -5784,7 +6426,8 @@
     "task": "Obtain 50 Million Runecrafting XP.",
     "information": "Obtain 50 million Runecrafting XP.",
     "requirements": "50,000,000 Runecrafting XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 643,
@@ -5793,7 +6436,8 @@
     "task": "Obtain 50 Million Slayer XP.",
     "information": "Obtain 50 million Slayer XP.",
     "requirements": "50,000,000 Slayer XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 644,
@@ -5802,7 +6446,8 @@
     "task": "Obtain 50 Million Smithing XP.",
     "information": "Obtain 50 million Smithing XP.",
     "requirements": "50,000,000 Smithing XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 645,
@@ -5811,7 +6456,8 @@
     "task": "Obtain 50 Million Thieving XP.",
     "information": "Obtain 50 million Thieving XP.",
     "requirements": "50,000,000 Thieving XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 646,
@@ -5820,7 +6466,8 @@
     "task": "Obtain 50 Million Woodcutting XP.",
     "information": "Obtain 50 million Woodcutting XP.",
     "requirements": "50,000,000 Woodcutting XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 647,
@@ -5829,7 +6476,8 @@
     "task": "Obtain 50 Million Dungeoneering XP.",
     "information": "Obtain 50 million Dungeoneering XP.",
     "requirements": "50,000,000 Dungeoneering XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 648,
@@ -5838,7 +6486,8 @@
     "task": "Obtain 50 Million Invention XP.",
     "information": "Obtain 50 million Invention XP.",
     "requirements": "50,000,000 Invention XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 649,
@@ -5847,7 +6496,8 @@
     "task": "Obtain 50 Million Divination XP.",
     "information": "Obtain 50 million Divination XP.",
     "requirements": "50,000,000 Divination XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 650,
@@ -5856,7 +6506,8 @@
     "task": "Obtain 50 Million Archaeology XP.",
     "information": "Obtain 50 million Archaeology XP.",
     "requirements": "50,000,000 Archaeology XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 651,
@@ -5865,7 +6516,8 @@
     "task": "Obtain 50 Million Attack XP.",
     "information": "Obtain 50 million Attack XP.",
     "requirements": "50,000,000 Attack XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 652,
@@ -5874,7 +6526,8 @@
     "task": "Obtain 50 Million Constitution XP.",
     "information": "Obtain 50 million Constitution XP.",
     "requirements": "50,000,000 Constitution XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 653,
@@ -5883,7 +6536,8 @@
     "task": "Obtain 50 Million Strength XP.",
     "information": "Obtain 50 million Strength XP.",
     "requirements": "50,000,000 Strength XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 654,
@@ -5892,7 +6546,8 @@
     "task": "Obtain 50 Million Defence XP.",
     "information": "Obtain 50 million Defence XP.",
     "requirements": "50,000,000 Defence XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 655,
@@ -5901,7 +6556,8 @@
     "task": "Obtain 50 Million Ranged XP.",
     "information": "Obtain 50 million Ranged XP.",
     "requirements": "50,000,000 Ranged XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 656,
@@ -5910,7 +6566,8 @@
     "task": "Obtain 50 Million Magic XP.",
     "information": "Obtain 50 million Magic XP.",
     "requirements": "50,000,000 Magic XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 657,
@@ -5919,7 +6576,8 @@
     "task": "Obtain 50 Million Summoning XP.",
     "information": "Obtain 50 million Summoning XP.",
     "requirements": "50,000,000 Summoning XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 658,
@@ -5928,7 +6586,8 @@
     "task": "Obtain 50 Million Necromancy XP.",
     "information": "Obtain 50 million Necromancy XP.",
     "requirements": "50,000,000 Necromancy XP",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 659,
@@ -5937,7 +6596,8 @@
     "task": "Complete 750 clues of any tier.",
     "information": "Complete 750 clues of any tier.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 660,
@@ -5946,7 +6606,8 @@
     "task": "Complete 1000 clues of any tier.",
     "information": "Complete 1000 clues of any tier.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 661,
@@ -5955,7 +6616,8 @@
     "task": "Make 5 Elder Overload Salve Potions.",
     "information": "Make 5 elder overload salves.",
     "requirements": "107 Herblore",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 662,
@@ -5964,7 +6626,8 @@
     "task": "Equip an Eternal Magic shortbow.",
     "information": "Equip an eternal magic shortbow.",
     "requirements": "95 Ranged, 90 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 663,
@@ -5973,7 +6636,8 @@
     "task": "Equip a full set of Primal armour.",
     "information": "Equip a full set of primal armour.",
     "requirements": "99 Smithing, 99 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 664,
@@ -5982,7 +6646,8 @@
     "task": "Reach level 90 in any skill.",
     "information": "Reach level 90 in any skill.",
     "requirements": "Any skill at level 90",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 665,
@@ -5991,7 +6656,8 @@
     "task": "Reach level 95 in any skill.",
     "information": "Reach level 95 in any skill.",
     "requirements": "Any skill at level 95",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 666,
@@ -6000,7 +6666,8 @@
     "task": "Reach at least level 80 in all non-elite skills.",
     "information": "Reach at least level 80 in all non-elite skills.",
     "requirements": "All skills except Invention at level 80",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 667,
@@ -6009,7 +6676,8 @@
     "task": "Reach at least level 90 in all non-elite skills.",
     "information": "Reach at least level 90 in all non-elite skills.",
     "requirements": "All skills except Invention at level 90",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 668,
@@ -6018,7 +6686,8 @@
     "task": "Help the Archivist recover all core memory data in the Hall of Memories.",
     "information": "Recover all core memory data in the Hall of Memories.",
     "requirements": "70 Divination",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 669,
@@ -6027,7 +6696,8 @@
     "task": "Attune and hand all engrams in to the Memorial to Guthix.",
     "information": "Hand all engrams in to the Memorial to Guthix.",
     "requirements": "82 Divination",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 670,
@@ -6036,7 +6706,8 @@
     "task": "Reach maximum total level.",
     "information": "Reach maximum total level.",
     "requirements": "Maximum total level",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 671,
@@ -6045,7 +6716,8 @@
     "task": "Complete 150 Master clue scrolls.",
     "information": "Complete 150 master clue scrolls.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Master"
   },
   {
     "id": 672,
@@ -6054,7 +6726,8 @@
     "task": "Work with Ramarno (in Camdozaal) to obtain a pickaxe of life and death.",
     "information": "Create a pickaxe of life and death.",
     "requirements": "99 Mining",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 673,
@@ -6063,7 +6736,8 @@
     "task": "Have something planted and living in every farming patch.",
     "information": "Have something planted and living in every farming patch.",
     "requirements": "99 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 674,
@@ -6072,7 +6746,8 @@
     "task": "Work with Ramarno (in Camdozaal) to obtain a hatchet of bloom and blight.",
     "information": "Create a hatchet of bloom and blight.",
     "requirements": "99 Woodcutting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 675,
@@ -6081,7 +6756,8 @@
     "task": "Equip any Masterwork weapon.",
     "information": "Equip any masterwork weapon.",
     "requirements": "92 Attack",
-    "points": 200
+    "points": 200,
+    "tier": "Master"
   },
   {
     "id": 676,
@@ -6090,7 +6766,8 @@
     "task": "Equip a full set of Masterwork armour.",
     "information": "Equip a full set of masterwork armour.",
     "requirements": "99 Smithing, 92 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Master"
   },
   {
     "id": 677,
@@ -6099,7 +6776,8 @@
     "task": "Unlock the Richie pet from helping Richie accumulate wealth at the Grand Exchange.",
     "information": "Donate 100,000,000 GP to Richie.",
     "requirements": "100,000,000 gp",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 678,
@@ -6108,7 +6786,8 @@
     "task": "Obtain 200 Million XP in any single skill.",
     "information": "Obtain 200 Million XP in any single skill.",
     "requirements": "200,000,000 XP in any skill",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 679,
@@ -6117,7 +6796,8 @@
     "task": "Fill all of the Treasure Trail hidey-holes. You can find a complete list of hidey-holes at the noticeboard by Zaida.",
     "information": "Fill all of the Treasure Trail hidey-holes.",
     "requirements": "Various",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 680,
@@ -6126,7 +6806,8 @@
     "task": "Obtain a dye, or a piece of Third-age or Second-age gear from a clue scroll.",
     "information": "Obtain a dye, or a piece of Third-age or Second-age gear from a clue scroll.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 681,
@@ -6135,7 +6816,8 @@
     "task": "Reach at least level 95 in all non-elite skills.",
     "information": "Reach at least level 95 in all non-elite skills.",
     "requirements": "All skills except Invention at level 95",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 682,
@@ -6144,7 +6826,8 @@
     "task": "Complete the Gnome Stronghold Agility Course.",
     "information": "Complete the Gnome Stronghold Agility Course.",
     "requirements": "1 Agility",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 683,
@@ -6153,7 +6836,8 @@
     "task": "Catch a Crimson Swift in the Feldip Hills.",
     "information": "Catch a crimson swift in the Feldip Hills.",
     "requirements": "1 Hunter",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 684,
@@ -6162,7 +6846,8 @@
     "task": "Defeat a Tortoise with riders in Kandarin.",
     "information": "Defeat a tortoise with riders in Kandarin.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 685,
@@ -6171,7 +6856,8 @@
     "task": "Complete the quest: You Are It.",
     "information": "Complete You Are It.",
     "requirements": "Quest: You Are It",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 686,
@@ -6180,7 +6866,8 @@
     "task": "Let Brimstail teleport you to the Rune Essence mine.",
     "information": "Let Brimstail teleport you to the Rune Essence mine.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 687,
@@ -6189,7 +6876,8 @@
     "task": "Equip a Marksman hat.",
     "information": "Equip a marksman hat.",
     "requirements": "125 chompy bird kills",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 688,
@@ -6198,7 +6886,8 @@
     "task": "Learn how many beans make five (complete the Player Owned Farm tutorial).",
     "information": "Complete the player-owned farm tutorial at Manor Farm.",
     "requirements": "17 Farming, 20 Construction",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 689,
@@ -6207,7 +6896,8 @@
     "task": "Teleport to the Wilderness using the lever in Ardougne.",
     "information": "Pull the lever in Ardougne.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 690,
@@ -6216,7 +6906,8 @@
     "task": "Use a ring of duelling to teleport to Castle Wars.",
     "information": "Teleport to Castle Wars with a ring of duelling.",
     "requirements": "27 Magic, 27 Crafting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 691,
@@ -6225,7 +6916,8 @@
     "task": "Make a Pineapple Punch cocktail.",
     "information": "Make a pineapple punch cocktail.",
     "requirements": "8 Cooking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 692,
@@ -6234,7 +6926,8 @@
     "task": "Fletch 50 Maple shieldbow (unstrung) in Kandarin.",
     "information": "Fletch 50 unstrung maple shieldbows in Kandarin.",
     "requirements": "55 Fletching",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 693,
@@ -6243,7 +6936,8 @@
     "task": "Pickpocket a Knight of Ardougne 50 times.",
     "information": "Pickpocket a knight of Ardougne 50 times.",
     "requirements": "55 Thieving",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 694,
@@ -6252,7 +6946,8 @@
     "task": "Complete the Barbarian Outpost Agility Course.",
     "information": "Complete the Barbarian Outpost Agility Course.",
     "requirements": "35 Agility",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 695,
@@ -6261,7 +6956,8 @@
     "task": "Catch a red salamander from the Hunter area outside of Ourania Altar.",
     "information": "Catch a red salamander.",
     "requirements": "59 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 696,
@@ -6270,7 +6966,8 @@
     "task": "Enter the Fishing Guild.",
     "information": "Enter the Fishing Guild.",
     "requirements": "68 Fishing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 697,
@@ -6279,7 +6976,8 @@
     "task": "Check a grown Papaya Tree inside Tree Gnome Stronghold.",
     "information": "Check a grown papaya tree inside Tree Gnome Stronghold.",
     "requirements": "57 Farming",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 698,
@@ -6288,7 +6986,8 @@
     "task": "Kill a mithril dragon.",
     "information": "Defeat a mithril dragon.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 699,
@@ -6297,7 +6996,8 @@
     "task": "Enter the Magic Guild in Yanille.",
     "information": "Enter the Wizards' Guild.",
     "requirements": "66 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 700,
@@ -6306,7 +7006,8 @@
     "task": "Defeat a Fire Giant in Kandarin.",
     "information": "Defeat a fire giant in Kandarin.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 701,
@@ -6315,7 +7016,8 @@
     "task": "Use the Chivalry Prayer.",
     "information": "Use the Chivalry prayer.",
     "requirements": "60 Prayer, 65 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 702,
@@ -6324,7 +7026,8 @@
     "task": "Be on the winning side in a game of Castle Wars.",
     "information": "Win a game of Castle Wars.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 703,
@@ -6333,7 +7036,8 @@
     "task": "Complete the quest: Elemental Workshop II.",
     "information": "Complete Elemental Workshop II.",
     "requirements": "Quest: Elemental Workshop II",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 704,
@@ -6342,7 +7046,8 @@
     "task": "Equip an Ogre Forester Hat.",
     "information": "Equip an ogre forester hat.",
     "requirements": "300 chompy bird kills",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 705,
@@ -6351,7 +7056,8 @@
     "task": "Complete the task set: Easy Ardougne.",
     "information": "Complete the Easy Ardougne achievements.",
     "requirements": "Achievement: Easy Ardougne",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 706,
@@ -6360,7 +7066,8 @@
     "task": "Create the listed gnome cocktails.",
     "information": "Make one of each type of cocktail.",
     "requirements": "37 Cooking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 707,
@@ -6369,7 +7076,8 @@
     "task": "Earn a total amount of 10,000 beans.",
     "information": "Earn a total of 10,000 beans from selling animals in player-owned farm.",
     "requirements": "17 Farming",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 708,
@@ -6378,7 +7086,8 @@
     "task": "Complete the task set: Medium Ardougne.",
     "information": "Complete the Medium Ardougne achievements.",
     "requirements": "Achievement: Medium Ardougne",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 709,
@@ -6387,7 +7096,8 @@
     "task": "Throw coins into the deep sea whirlpool.",
     "information": "Throw some gold coins into the whirlpool at the Deep Sea Fishing platform.",
     "requirements": "68 Fishing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 710,
@@ -6396,7 +7106,8 @@
     "task": "Solve the Archaeology mystery: Leap of Faith.",
     "information": "Solve the Leap of Faith Archaeology mystery.",
     "requirements": "70 Archaeology",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 711,
@@ -6405,7 +7116,8 @@
     "task": "Collect all breeds of chinchompa at the Player Owned Farm.",
     "information": "Breed all types of chinchompas.",
     "requirements": "54 Farming, 20 Construction",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 712,
@@ -6414,7 +7126,8 @@
     "task": "Equip one piece of the Fishing outfit.",
     "information": "Equip one piece of the fishing outfit.",
     "requirements": "140 fishing tokens",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 713,
@@ -6423,7 +7136,8 @@
     "task": "Defeat the Penance Queen.",
     "information": "Defeat the Penance Queen.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 714,
@@ -6432,7 +7146,8 @@
     "task": "Pickpocket a Hero.",
     "information": "Pickpocket a hero.",
     "requirements": "80 Thieving",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 715,
@@ -6441,7 +7156,8 @@
     "task": "Catch 50 Red Chinchompas in Kandarin.",
     "information": "Catch 50 carnivorous chinchompas in Kandarin.",
     "requirements": "63 Hunter",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 716,
@@ -6450,7 +7166,8 @@
     "task": "Equip an Ogre Expert hat.",
     "information": "Equip an Ogre Expert hat.",
     "requirements": "1,000 chompy bird kills",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 717,
@@ -6459,7 +7176,8 @@
     "task": "Use the Piety Prayer.",
     "information": "Use the Piety Prayer.",
     "requirements": "70 Prayer, 70 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 718,
@@ -6468,7 +7186,8 @@
     "task": "Complete the task set: Hard Ardougne.",
     "information": "Complete the Hard Ardougne achievements.",
     "requirements": "Achievement: Hard Ardougne",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 719,
@@ -6477,7 +7196,8 @@
     "task": "Equip a dragon full helm.",
     "information": "Equip a dragon full helm.",
     "requirements": "60 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 720,
@@ -6486,7 +7206,8 @@
     "task": "Chop an Elder Tree until it no longer has logs remaining.",
     "information": "Chop an elder tree until it no longer has logs remaining.",
     "requirements": "90 Woodcutting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 721,
@@ -6495,7 +7216,8 @@
     "task": "Obtain a Crystal Geode from a Crystal Tree.",
     "information": "Obtain a crystal geode from a crystal tree.",
     "requirements": "94 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 722,
@@ -6504,7 +7226,8 @@
     "task": "Reach Howl's Workshop in the Stormguard Citadel.",
     "information": "Partial completion of the Howl's Floating Workshop mystery.",
     "requirements": "95 Archaeology",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 723,
@@ -6513,7 +7236,8 @@
     "task": "Equip a Dragon Archer hat.",
     "information": "Equip a Dragon Archer hat.",
     "requirements": "2,000 chompy bird kills",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 724,
@@ -6522,7 +7246,8 @@
     "task": "Complete the task set: Elite Ardougne.",
     "information": "Complete the Elite Ardougne achievements.",
     "requirements": "Achievement: Elite Ardougne",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 725,
@@ -6531,7 +7256,8 @@
     "task": "Successfully breed a royal dragon.",
     "information": "Breed a royal dragon.",
     "requirements": "92 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 726,
@@ -6540,7 +7266,8 @@
     "task": "Defeat an Automaton after 'The World Wakes'.",
     "information": "Defeat an automaton after The World Wakes.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 727,
@@ -6549,7 +7276,8 @@
     "task": "Equip an Expert Dragon Archer hat.",
     "information": "Equip an Expert Dragon Archer hat.",
     "requirements": "4,000 chompy bird kills",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 728,
@@ -6558,7 +7286,8 @@
     "task": "Throw 100,000,000 gold coins into the Whirlpool at the Deep Sea Fishing platform.",
     "information": "Throw 100,000,000 gold coins into the Whirlpool at the Deep Sea Fishing platform.",
     "requirements": "68 Fishing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 729,
@@ -6567,7 +7296,8 @@
     "task": "Collect 5 seaweed from anywhere on Karamja.",
     "information": "Collect 5 seaweed from anywhere on Karamja.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 730,
@@ -6576,7 +7306,8 @@
     "task": "Fill up Luthas' crate near the Musa Point plantation with bananas and receive 30 coins for your work.",
     "information": "Fill up Luthas' crate near the Banana plantation with bananas and talk to him to receive 30 coins for your work.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 731,
@@ -6585,7 +7316,8 @@
     "task": "Claim a ticket from Brimhaven Agility Arena.",
     "information": "Claim a ticket from Brimhaven Agility Arena.",
     "requirements": "1 Agility",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 732,
@@ -6594,7 +7326,8 @@
     "task": "Kill a snake.",
     "information": "Kill a snake.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 733,
@@ -6603,7 +7336,8 @@
     "task": "Catch a Karambwanji.",
     "information": "Catch a raw karambwanji.",
     "requirements": "5 Fishing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 734,
@@ -6612,7 +7346,8 @@
     "task": "Be assigned a Slayer task in Shilo Village.",
     "information": "Be assigned a Slayer task in Shilo Village.",
     "requirements": "100 Combat, 50 Slayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 735,
@@ -6621,7 +7356,8 @@
     "task": "Defeat a Greater Demon on Karamja.",
     "information": "Defeat a greater demon on Karamja.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 736,
@@ -6630,7 +7366,8 @@
     "task": "Pick a pineapple on Karamja.",
     "information": "Pick a pineapple on Karamja from the pineapple plants near the lodestone.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 737,
@@ -6639,7 +7376,8 @@
     "task": "Enter the Brimhaven Dungeon.",
     "information": "Enter the Brimhaven Dungeon.",
     "requirements": "875 coins",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 738,
@@ -6648,7 +7386,8 @@
     "task": "Cross the spiky pit using the stepping stones within Brimhaven Dungeon.",
     "information": "Cross the spiky pit using the stepping stones within Brimhaven Dungeon.",
     "requirements": "12 Agility",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 739,
@@ -6657,7 +7396,8 @@
     "task": "Complete the task set: Easy Karamja.",
     "information": "Complete the Easy Karamja achievements.",
     "requirements": "Achievement: Easy Karamja",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 740,
@@ -6666,7 +7406,8 @@
     "task": "Craft 50 Nature runes.",
     "information": "Craft 50 nature runes.",
     "requirements": "44 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 741,
@@ -6675,7 +7416,8 @@
     "task": "Catch a salmon on Karamja.",
     "information": "Catch a salmon on Karamja.",
     "requirements": "30 Fishing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 742,
@@ -6684,7 +7426,8 @@
     "task": "Get Stiles to exchange some of your fish for bank notes.",
     "information": "Get Stiles to exchange some of your fish for bank notes.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 743,
@@ -6693,7 +7436,8 @@
     "task": "Convert 100 gleaming memories in an energy rift.",
     "information": "Convert 100 gleaming memories in an energy rift.",
     "requirements": "50 Divination",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 744,
@@ -6702,7 +7446,8 @@
     "task": "Mine a drakolith rock in the Tai Bwo Wannai mine.",
     "information": "Mine a drakolith rock in the Tai Bwo Wannai mine.",
     "requirements": "60 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 745,
@@ -6711,7 +7456,8 @@
     "task": "Mine a ruby from a gem rock in Shilo Village.",
     "information": "Mine a ruby from a gem rock in Shilo Village.",
     "requirements": "30 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 746,
@@ -6720,7 +7466,8 @@
     "task": "Enter the Hardwood Grove in Tai Bwo Wannai.",
     "information": "Enter the Hardwood Grove in Tai Bwo Wannai.",
     "requirements": "Completion of Jungle Potion",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 747,
@@ -6729,7 +7476,8 @@
     "task": "Complete the quest: Dragon Slayer.",
     "information": "Complete Dragon Slayer.",
     "requirements": "Quest: Dragon Slayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 748,
@@ -6738,7 +7486,8 @@
     "task": "Check a grown banana tree on Karamja.",
     "information": "Check a grown banana tree on Karamja.",
     "requirements": "33 Farming",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 749,
@@ -6747,7 +7496,8 @@
     "task": "Defeat a TzHaar.",
     "information": "Defeat a TzHaar.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 750,
@@ -6756,7 +7506,8 @@
     "task": "Equip an Obsidian cape.",
     "information": "Equip an obsidian cape.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 751,
@@ -6765,7 +7516,8 @@
     "task": "Kill a metal dragon in Brimhaven Dungeon.",
     "information": "Kill a metal dragon in Brimhaven Dungeon.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 752,
@@ -6774,7 +7526,8 @@
     "task": "Catch 25 lobsters on Karamja.",
     "information": "Catch 25 lobsters on Karamja.",
     "requirements": "40 Fishing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 753,
@@ -6783,7 +7536,8 @@
     "task": "Equip a Toktz-Ket-Xil.",
     "information": "Equip a Toktz-Ket-Xil.",
     "requirements": "60 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 754,
@@ -6792,7 +7546,8 @@
     "task": "Equip a Tzhaar-Ket-Om.",
     "information": "Equip a Tzhaar-Ket-Om.",
     "requirements": "60 Strength",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 755,
@@ -6801,7 +7556,8 @@
     "task": "Equip a Toktz-Xil-Ak.",
     "information": "Equip a Toktz-Xil-Ak.",
     "requirements": "60 Attack",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 756,
@@ -6810,7 +7566,8 @@
     "task": "Equip a Toktz-Xil-Ek.",
     "information": "Equip a Toktz-Xil-Ek.",
     "requirements": "60 Attack",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 757,
@@ -6819,7 +7576,8 @@
     "task": "Complete the task set: Medium Karamja.",
     "information": "Complete the Medium Karamja achievements.",
     "requirements": "Achievement: Medium Karamja",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 758,
@@ -6828,7 +7586,8 @@
     "task": "Use the stepping stone across the river in Shilo village.",
     "information": "Use the stepping stones Agility Shortcut in Shilo Village.",
     "requirements": "74 Agility",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 759,
@@ -6837,7 +7596,8 @@
     "task": "Equip a full set of Obsidian armour.",
     "information": "Equip a full set of obsidian armour.",
     "requirements": "60 Defence, 80 Smithing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 760,
@@ -6846,7 +7606,8 @@
     "task": "Equip a Red Topaz Machete.",
     "information": "Equip a red topaz machete.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 761,
@@ -6855,7 +7616,8 @@
     "task": "Find a Gout Tuber.",
     "information": "Find a gout tuber.",
     "requirements": "10 Woodcutting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 762,
@@ -6864,7 +7626,8 @@
     "task": "Defeat TzTok-Jad.",
     "information": "Defeat TzTok-Jad once.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 763,
@@ -6873,7 +7636,8 @@
     "task": "Defeat TzTok-Jad. (25 times)",
     "information": "Defeat TzTok-Jad 25 times.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 764,
@@ -6882,7 +7646,8 @@
     "task": "Use your fire cape on TzTok-Jad before defeating them.",
     "information": "Use your fire cape on TzTok-Jad before defeating them.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 765,
@@ -6891,7 +7656,8 @@
     "task": "Equip a Fire Cape.",
     "information": "Equip a fire cape.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 766,
@@ -6900,7 +7666,8 @@
     "task": "Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.",
     "information": "Defeat TokHaar-Hok in the Fight Cauldron minigame using only obsidian equipment.",
     "requirements": "60 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 767,
@@ -6909,7 +7676,8 @@
     "task": "Repair the fairy ring inside the Kharazi jungle.",
     "information": "Repair the fairy ring inside the Kharazi jungle.",
     "requirements": "Partial completion of Legends' Quest",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 768,
@@ -6918,7 +7686,8 @@
     "task": "Access the Gemstone cavern.",
     "information": "Access the gemstone cavern.",
     "requirements": "Hard Karamja achievements",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 769,
@@ -6927,7 +7696,8 @@
     "task": "Catch a Draconic jadinko at Herblore Habitat.",
     "information": "Catch a draconic jadinko at Herblore Habitat.",
     "requirements": "80 Hunter",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 770,
@@ -6936,7 +7706,8 @@
     "task": "Craft a Bolas.",
     "information": "Craft a bolas.",
     "requirements": "87 Fletching, 80 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 771,
@@ -6945,7 +7716,8 @@
     "task": "Complete the task set: Hard Karamja.",
     "information": "Complete the Hard Karamja achievements.",
     "requirements": "Achievement: Hard Karamja",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 772,
@@ -6954,7 +7726,8 @@
     "task": "Collect 60 Agility Arena tickets from the Brimhaven Agility Arena.",
     "information": "Receive 60 Agility Arena tickets",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 773,
@@ -6963,7 +7736,8 @@
     "task": "Defeat TzTok-Jad in less than 45:00.",
     "information": "Defeat TzTok-Jad in less than 45:00.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 774,
@@ -6972,7 +7746,8 @@
     "task": "Complete the Fight Kiln.",
     "information": "Complete the Fight Kiln.",
     "requirements": "Completion of The Elder Kiln",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 775,
@@ -6981,7 +7756,8 @@
     "task": "Equip a TokHaar-Kal-Ket.",
     "information": "Equip a TokHaar-Kal-Ket.",
     "requirements": "Completion of The Elder Kiln",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 776,
@@ -6990,7 +7766,8 @@
     "task": "Equip a TokHaar-Kal-Xil.",
     "information": "Equip a TokHaar-Kal-Xil.",
     "requirements": "Completion of The Elder Kiln",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 777,
@@ -6999,7 +7776,8 @@
     "task": "Equip a TokHaar-Kal-Mej.",
     "information": "Equip a TokHaar-Kal-Mej.",
     "requirements": "Completion of The Elder Kiln",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 778,
@@ -7008,7 +7786,8 @@
     "task": "Equip a TokHaar-Kal-Mor.",
     "information": "Equip a TokHaar-Kal-Mor.",
     "requirements": "Completion of The Elder Kiln",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 779,
@@ -7017,7 +7796,8 @@
     "task": "Complete the Fight Kiln and collect an uncut onyx.",
     "information": "Complete the Fight Kiln and collect an uncut onyx.",
     "requirements": "Completion of The Elder Kiln",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 780,
@@ -7026,7 +7806,8 @@
     "task": "Complete all TzTok-Jad combat achievements.",
     "information": "Complete all TzTok-Jad combat achievements.",
     "requirements": "Achievement: TzTok-Jad",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 781,
@@ -7035,7 +7816,8 @@
     "task": "Purchase an uncut onyx from Tzhaar-Hur-Lek's ore and gem store.",
     "information": "Purchase an uncut onyx from TzHaar-Hur-Lek's Ore and Gem Store.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 782,
@@ -7044,7 +7826,8 @@
     "task": "Defeat the Har-Aken. (10 times)",
     "information": "Defeat Har-Aken 10 times.",
     "requirements": "Completion of The Elder Kiln",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 783,
@@ -7053,7 +7836,8 @@
     "task": "Defeat 10 gemstone dragons inside the Gemstone cavern.",
     "information": "Defeat 10 gemstone dragons inside the Gemstone cavern.",
     "requirements": "95 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 784,
@@ -7062,7 +7846,8 @@
     "task": "Equip a piece of Gemstone armour.",
     "information": "Equip a piece of gemstone armour.",
     "requirements": "95 Slayer, 80 Defence, 80 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 785,
@@ -7071,7 +7856,8 @@
     "task": "Complete the task set: Elite Karamja.",
     "information": "Complete the Elite Karamja achievements.",
     "requirements": "Achievement: Elite Karamja",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 786,
@@ -7080,7 +7866,8 @@
     "task": "Complete all Har-Aken combat achievements.",
     "information": "Complete all Har-Aken combat achievements.",
     "requirements": "Achievement: Har-Aken",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 787,
@@ -7089,7 +7876,8 @@
     "task": "Progress through the Leagues tutorial to unlock your first relic.",
     "information": "Progress through the Leagues tutorial to unlock your first relic.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 788,
@@ -7098,7 +7886,8 @@
     "task": "Climb to the top of the Wizards' Tower.",
     "information": "Climb to the top of the Wizards' Tower.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 789,
@@ -7107,7 +7896,8 @@
     "task": "Have Ned make you some rope from balls of wool.",
     "information": "Have Ned make you some rope from 4 balls of wool.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 790,
@@ -7116,7 +7906,8 @@
     "task": "Siphon from a fire essling in the Runespan.",
     "information": "Siphon from a fire essling in the Runespan.",
     "requirements": "14 Runecrafting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 791,
@@ -7125,7 +7916,8 @@
     "task": "Convert at least one pale memory into energy.",
     "information": "Convert at least one pale memory into energy.",
     "requirements": "1 Divination",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 792,
@@ -7134,7 +7926,8 @@
     "task": "Kill a mugger near the Edgeville lodestone.",
     "information": "Kill a mugger near the Edgeville lodestone.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 793,
@@ -7143,7 +7936,8 @@
     "task": "Mine some coal in the centre of Barbarian village.",
     "information": "Mine some coal in the centre of Barbarian Village.",
     "requirements": "20 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 794,
@@ -7152,7 +7946,8 @@
     "task": "Use the bank in the workshop at Fort Forinthry.",
     "information": "Use the bank in the workshop at Fort Forinthry.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 795,
@@ -7161,7 +7956,8 @@
     "task": "Kill a giant rat in Lumbridge Swamp.",
     "information": "Kill a giant rat in Lumbridge Swamp.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 796,
@@ -7170,7 +7966,8 @@
     "task": "Kill a goblin in Lumbridge.",
     "information": "Kill a goblin in Lumbridge.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 797,
@@ -7179,7 +7976,8 @@
     "task": "Kill a giant spider in Lumbridge or Lumbridge Swamp.",
     "information": "Kill a giant spider in Lumbridge or Lumbridge Swamp.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 798,
@@ -7188,7 +7986,8 @@
     "task": "Milk a cow.",
     "information": "Milk a cow.",
     "requirements": "A bucket",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 799,
@@ -7197,7 +7996,8 @@
     "task": "Talk to Hans and find out how old you are.",
     "information": "Talk to Hans and find out how old you are.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 800,
@@ -7206,7 +8006,8 @@
     "task": "Complete the quest: The Blood Pact.",
     "information": "Complete The Blood Pact.",
     "requirements": "Quest: The Blood Pact",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 801,
@@ -7215,7 +8016,8 @@
     "task": "Catch some shrimp in the fishing spot to the east of Lumbridge Swamp.",
     "information": "Catch some shrimp in the fishing spot to the east of Lumbridge Swamp.",
     "requirements": "1 Fishing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 802,
@@ -7224,7 +8026,8 @@
     "task": "Smelt a steel bar in the furnace in Lumbridge.",
     "information": "Smelt a steel bar in the furnace in Lumbridge.",
     "requirements": "20 Smithing",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 803,
@@ -7233,7 +8036,8 @@
     "task": "Cook some rat meat on a fire in Lumbridge Swamp.",
     "information": "Cook some rat meat on a campfire in Lumbridge Swamp.",
     "requirements": "1 Cooking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 804,
@@ -7242,7 +8046,8 @@
     "task": "Mine iron ore from the mining site south-west of Lumbridge Swamp.",
     "information": "Mine iron ore from the mining site south-west of Lumbridge Swamp.",
     "requirements": "10 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 805,
@@ -7251,7 +8056,8 @@
     "task": "Craft a water rune at the Water Altar.",
     "information": "Craft a water rune at the Water altar.",
     "requirements": "5 Runecrafting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 806,
@@ -7260,7 +8066,8 @@
     "task": "Complete a task from Jacquelyn, the Lumbridge Slayer master.",
     "information": "Complete a task from Jacquelyn, the Lumbridge Slayer master.",
     "requirements": "1 Slayer",
-    "points": 10
+    "points": 10,
+    "tier": "Master"
   },
   {
     "id": 807,
@@ -7269,7 +8076,8 @@
     "task": "Fill a Charmed Sack with corruption at the Nexus in Lumbridge Swamp.",
     "information": "Fill a charmed sack with corruption at the Nexus in Lumbridge Swamp.",
     "requirements": "1 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 808,
@@ -7278,7 +8086,8 @@
     "task": "Complete the quest: Necromancy!.",
     "information": "Complete Necromancy!",
     "requirements": "Quest: Necromancy!",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 809,
@@ -7287,7 +8096,8 @@
     "task": "Upgrade a piece of Death Skull or Deathwarden equipment to tier 20.",
     "information": "Upgrade a piece of death skull or deathwarden equipment to tier 20.",
     "requirements": "20 Necromancy, 15 Smithing or 15 Crafting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 810,
@@ -7296,7 +8106,8 @@
     "task": "Craft some spirit or bone runes.",
     "information": "Craft some spirit or bone runes.",
     "requirements": "1 Runecrafting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 811,
@@ -7305,7 +8116,8 @@
     "task": "Complete a Lesser Necroplasm ritual.",
     "information": "Complete a Lesser Necroplasm ritual.",
     "requirements": "5 Necromancy",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 812,
@@ -7314,7 +8126,8 @@
     "task": "Conjure a skeleton at the City of Um ritual site.",
     "information": "Conjure a Skeleton Warrior at the Um ritual site.",
     "requirements": "2 Necromancy",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 813,
@@ -7323,7 +8136,8 @@
     "task": "Conjure a zombie at the City of Um ritual site.",
     "information": "Conjure a Putrid Zombie at the Um ritual site.",
     "requirements": "40 Necromancy",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 814,
@@ -7332,7 +8146,8 @@
     "task": "Conjure a ghost at the City of Um ritual site.",
     "information": "Conjure a Vengeful Ghost at the Um ritual site.",
     "requirements": "40 Necromancy",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 815,
@@ -7341,7 +8156,8 @@
     "task": "Kill a dark wizard.",
     "information": "Kill a dark wizard.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 816,
@@ -7350,7 +8166,8 @@
     "task": "Enter the Earth Altar using an earth tiara or talisman.",
     "information": "Enter the earth altar using an earth tiara or talisman.",
     "requirements": "1 Runecrafting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 817,
@@ -7359,7 +8176,8 @@
     "task": "Have Elsie tell you a story.",
     "information": "Have Elsie tell you a story, she is found upstairs in the church in Varrock. You must give her a cup of tea",
     "requirements": "A cup of tea",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 818,
@@ -7368,7 +8186,8 @@
     "task": "Give a bone to one of Varrock's stray dogs (or to your pet stray dog if you have one).",
     "information": "Use some bones on one of Varrock's stray dogs (or to your pet stray dog if you have one).",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 819,
@@ -7377,7 +8196,8 @@
     "task": "Claim a free clue scroll from Zaida at the Grand Exchange.",
     "information": "Claim a free clue scroll from Zaida at the Grand Exchange.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 820,
@@ -7386,7 +8206,8 @@
     "task": "Give Bill a beer in Fort Forinthry.",
     "information": "Give Bill a beer in Fort Forinthry.",
     "requirements": "A beer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 821,
@@ -7395,7 +8216,8 @@
     "task": "Complete the Archaeology tutorial.",
     "information": "Complete the Archaeology tutorial.",
     "requirements": "1 Archaeology",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 822,
@@ -7404,7 +8226,8 @@
     "task": "Make a plank yourself on the sawmill in Fort Forinthry.",
     "information": "Make a plank yourself on the sawmill in Fort Forinthry.",
     "requirements": "1 Construction",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 823,
@@ -7413,7 +8236,8 @@
     "task": "Mine some iron ore in the mining spot south-west of Varrock.",
     "information": "Mine some iron ore in the mining spot south-west of Varrock.",
     "requirements": "10 Mining",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 824,
@@ -7422,7 +8246,8 @@
     "task": "Steal from the Varrock tea stall.",
     "information": "Steal from the Varrock tea stall.",
     "requirements": "5 Thieving",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 825,
@@ -7431,7 +8256,8 @@
     "task": "Pan in the river at the Digsite.",
     "information": "This can only be completed after the point during The Dig Site quest where the panning guide teaches you how to pan for gold. You can then use the panning point. If you complete the quest without completing this achievement the task will be completed by attempting to pan with a panning tray in your inventory.",
     "requirements": "Partial completion of The Dig Site",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 826,
@@ -7440,7 +8266,8 @@
     "task": "Harvest a memory from a pale wisp.",
     "information": "Harvest a pale memory from a pale wisp.",
     "requirements": "1 Divination",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 827,
@@ -7449,7 +8276,8 @@
     "task": "Harvest 10 memories from a pale wisp.",
     "information": "Harvest 10 pale memories from a pale wisp.",
     "requirements": "1 Divination",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 828,
@@ -7458,7 +8286,8 @@
     "task": "Kill the lesser demon in the Wizards' Tower.",
     "information": "Kill the lesser demon in the Wizards' Tower.",
     "requirements": "Cannot be attacked with short-range melee",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 829,
@@ -7467,7 +8296,8 @@
     "task": "Hunt a yellow wizard in the RuneSpan and give them some items.",
     "information": "Hunt a yellow wizard in the Runespan and give them some items.",
     "requirements": "1 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 830,
@@ -7476,7 +8306,8 @@
     "task": "Use the Rune Goldberg Machine to create Vis wax.",
     "information": "Use the Rune Goldberg Machine to create vis wax.",
     "requirements": "50 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 831,
@@ -7485,7 +8316,8 @@
     "task": "Siphon from a nature esshound in the Runespan.",
     "information": "Siphon from a nature esshound in the Runespan.",
     "requirements": "44 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 832,
@@ -7494,7 +8326,8 @@
     "task": "Siphon Rune dust from a RuneSphere in the RuneSpan.",
     "information": "Siphon rune dust from a Runesphere in the RuneSpan.",
     "requirements": "1 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 833,
@@ -7503,7 +8336,8 @@
     "task": "Fully complete the Stronghold of Player Safety.",
     "information": "Fully complete the Stronghold of Player Safety by pulling an old lever on the upper floor and then opening the treasure chest in the secure sector.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 834,
@@ -7512,7 +8346,8 @@
     "task": "Complete the quest: New Foundations.",
     "information": "Complete New Foundations.",
     "requirements": "Quest: New Foundations",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 835,
@@ -7521,7 +8356,8 @@
     "task": "Complete the task set: Beginner Lumbridge.",
     "information": "Given by Explorer Jack in Lumbridge for completing all Beginner Tasks in Lumbridge.",
     "requirements": "Achievement: Beginner Lumbridge & Draynor",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 836,
@@ -7530,7 +8366,8 @@
     "task": "Complete the quest: Duck Quest.",
     "information": "Complete Duck Quest.",
     "requirements": "Quest: Duck Quest",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 837,
@@ -7539,7 +8376,8 @@
     "task": "Complete the task set: Easy Lumbridge.",
     "information": "Given by Bob, the axe seller in Lumbridge, for completing all Easy Tasks in Lumbridge.",
     "requirements": "Achievement: Easy Lumbridge & Draynor",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 838,
@@ -7548,7 +8386,8 @@
     "task": "Complete the task set: Medium Lumbridge.",
     "information": "Given by Ned in Draynor Village for completing all Medium Tasks in Lumbridge.",
     "requirements": "Achievement: Medium Lumbridge & Draynor",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 839,
@@ -7557,7 +8396,8 @@
     "task": "Drink from the Tears of Guthix.",
     "information": "Drink from the Tears of Guthix.",
     "requirements": "Completion of Tears of Guthix quest",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 840,
@@ -7566,7 +8406,8 @@
     "task": "Complete world 25 in Shattered Worlds.",
     "information": "Reach world 25 in Shattered Worlds.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 841,
@@ -7575,7 +8416,8 @@
     "task": "Catch 20 implings in Puro-Puro.",
     "information": "Catch 20 implings in Puro-Puro.",
     "requirements": "17 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 842,
@@ -7584,7 +8426,8 @@
     "task": "Complete the quest: Sheep Shearer (miniquest).",
     "information": "Complete Sheep Shearer miniquest.",
     "requirements": "Quest: Sheep Shearer (miniquest)",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 843,
@@ -7593,7 +8436,8 @@
     "task": "Cut a willow tree east of Lumbridge Castle.",
     "information": "Cut the willow tree east of Lumbridge Castle, by the bridge across the River Lum.",
     "requirements": "20 Woodcutting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 844,
@@ -7602,7 +8446,8 @@
     "task": "Craft 50 Water Runes.",
     "information": "Craft 50 water runes.",
     "requirements": "5 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 845,
@@ -7611,7 +8456,8 @@
     "task": "Pickpocket a H.A.M. member.",
     "information": "Pickpocket a H.A.M. member.",
     "requirements": "15 Thieving",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 846,
@@ -7620,7 +8466,8 @@
     "task": "Churn some butter.",
     "information": "Make a pat of butter by using a bucket of milk at a dairy churn",
     "requirements": "38 Cooking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 847,
@@ -7629,7 +8476,8 @@
     "task": "Craft 50 cosmic runes.",
     "information": "Craft 50 cosmic runes.",
     "requirements": "27 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 848,
@@ -7638,7 +8486,8 @@
     "task": "Steal a lantern from a cave goblin.",
     "information": "Steal a lantern from a cave goblin (only the ones in Dorgesh-Kaan have the lantern as a possible loot from pickpocketting).",
     "requirements": "36 Thieving",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 849,
@@ -7647,7 +8496,8 @@
     "task": "Use the range in Lumbridge Castle to bake a cake.",
     "information": "Use the range in Lumbridge Castle to bake a cake.",
     "requirements": "40 Cooking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 850,
@@ -7656,7 +8506,8 @@
     "task": "Have either a Putrid Zombie or Vengeful Ghost conjured while fighting the matching creature.",
     "information": "Have either a Putrid Zombie or Vengeful Ghost conjured while fighting the matching creature.",
     "requirements": "40 Necromancy",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 851,
@@ -7665,7 +8516,8 @@
     "task": "Learn how to craft moonstone jewellery.",
     "information": "Learn how to craft moonstone jewellery.",
     "requirements": "50 Necromancy",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 852,
@@ -7674,7 +8526,8 @@
     "task": "Disgruntle an inhabitant of Um by wearing a bedsheet.",
     "information": "Disgruntle an inhabitant of Um by wearing a bedsheet, see Poor Imitation for NPCs which can be disgruntled.",
     "requirements": "Completion of Ghosts Ahoy quest, bedsheet",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 853,
@@ -7683,7 +8536,8 @@
     "task": "Upgrade a piece of Death Skull or Deathwarden equipment to tier 50.",
     "information": "Upgrade a piece of Death Skull or Deathwarden equipment to tier 50.",
     "requirements": "20 Necromancy",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 854,
@@ -7692,7 +8546,8 @@
     "task": "Complete a communion ritual using a memento.",
     "information": "Complete a communion ritual using a memento.",
     "requirements": "5 Necromancy",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 855,
@@ -7701,7 +8556,8 @@
     "task": "Conjure a Phantom Guardian at the City of Um ritual site.",
     "information": "Conjure a Phantom Guardian at the Um ritual site.",
     "requirements": "70 Necromancy",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 856,
@@ -7710,7 +8566,8 @@
     "task": "Complete the task set: Easy Underworld.",
     "information": "Complete the Easy Underworld achievements.",
     "requirements": "Achievement: Easy City of Um",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 857,
@@ -7719,7 +8576,8 @@
     "task": "Complete the task set: Medium Underworld.",
     "information": "Complete the Medium Underworld achievements.",
     "requirements": "Achievement: Medium City of Um",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 858,
@@ -7728,7 +8586,8 @@
     "task": "Complete the task set: Easy Varrock.",
     "information": "Given by Rat Burgiss south of Varrock for completing all Easy Tasks in Varrock.",
     "requirements": "Achievement: Easy Varrock",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 859,
@@ -7737,7 +8596,8 @@
     "task": "Complete the task set: Medium Varrock.",
     "information": "Given by Reldo in Varrock Palace's library for completing all Medium Tasks in Varrock.",
     "requirements": "Achievement: Medium Varrock",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 860,
@@ -7746,7 +8606,8 @@
     "task": "Browse through Oziach's Armour Shop.",
     "information": "Browse through Oziach's Armour Shop.",
     "requirements": "Completion of Dragon Slayer quest",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 861,
@@ -7755,7 +8616,8 @@
     "task": "Enter the Cooks' Guild.",
     "information": "Enter the Cooks' Guild.",
     "requirements": "32 Cooking",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 862,
@@ -7764,7 +8626,8 @@
     "task": "Complete the quest: Demon Slayer.",
     "information": "Complete Demon Slayer.",
     "requirements": "Quest: Demon Slayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 863,
@@ -7773,7 +8636,8 @@
     "task": "Complete the quest: Vampyre Slayer.",
     "information": "Complete Vampyre Slayer.",
     "requirements": "Quest: Vampyre Slayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 864,
@@ -7782,7 +8646,8 @@
     "task": "Mine 50 pure essence.",
     "information": "Mine 50 pure essence.",
     "requirements": "30 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 865,
@@ -7791,7 +8656,8 @@
     "task": "Pickpocket a guard in Varrock Palace's courtyard.",
     "information": "Pickpocket a Varrock guard.",
     "requirements": "40 Thieving",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 866,
@@ -7800,7 +8666,8 @@
     "task": "Gather and convert 50 bright memories.",
     "information": "Gather and convert 50 bright memories.",
     "requirements": "20 Divination",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 867,
@@ -7809,7 +8676,8 @@
     "task": "Siphon from a death esswraith in the RuneSpan.",
     "information": "Siphon from a death esswraith in the RuneSpan.",
     "requirements": "66 Runecrafting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 868,
@@ -7818,7 +8686,8 @@
     "task": "Obtain the Massive Pouch from the RuneSpan.",
     "information": "Obtain the massive pouch from the RuneSpan.",
     "requirements": "90 Runecrafting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 869,
@@ -7827,7 +8696,8 @@
     "task": "Equip the full Master Runecrafter skilling outfit.",
     "information": "Equip the full master runecrafter robes set.",
     "requirements": "50 Runecrafting",
-    "points": 80
+    "points": 80,
+    "tier": "Master"
   },
   {
     "id": 870,
@@ -7836,7 +8706,8 @@
     "task": "Complete the task set: Hard Varrock.",
     "information": "Complete all of the Hard Varrock achievements and claim rewards from Vannaka in Edgeville.",
     "requirements": "Achievement: Hard Varrock",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 871,
@@ -7845,7 +8716,8 @@
     "task": "Make a waka canoe near Edgeville.",
     "information": "Make a waka canoe near Edgeville.",
     "requirements": "57 Woodcutting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 872,
@@ -7854,7 +8726,8 @@
     "task": "Chop down the Edgeville elder tree.",
     "information": "Chop down the Edgeville elder tree.",
     "requirements": "90 Woodcutting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 873,
@@ -7863,7 +8736,8 @@
     "task": "Upgrade the workshop in Fort Forinthry to Tier 3.",
     "information": "Upgrade the workshop in Fort Forinthry to tier 3.",
     "requirements": "75 Construction",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 874,
@@ -7872,7 +8746,8 @@
     "task": "Enter Zanaris via Lumbridge Swamp.",
     "information": "Enter Zanaris via Lumbridge Swamp.",
     "requirements": "Partial completion of Lost City",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 875,
@@ -7881,7 +8756,8 @@
     "task": "Complete the task set: Hard Lumbridge.",
     "information": "Complete all Hard Tasks in Lumbridge and claim rewards from Ned in Draynor Village.",
     "requirements": "Achievement: Hard Lumbridge & Draynor",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 876,
@@ -7890,7 +8766,8 @@
     "task": "Unlock the Bladed Dive ability from Shattered Worlds.",
     "information": "Unlock the Bladed Dive ability from Shattered Worlds.",
     "requirements": "63,000,000 shattered anima",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 877,
@@ -7899,7 +8776,8 @@
     "task": "Smith a mithril platebody on the anvil in the jailhouse sewers.",
     "information": "Smith a mithril platebody on the anvil in Draynor Sewers.",
     "requirements": "30 Smithing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 878,
@@ -7908,7 +8786,8 @@
     "task": "Fully grow a magic tree in Lumbridge.",
     "information": "Fully grow a magic tree in Lumbridge.",
     "requirements": "75 Farming",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 879,
@@ -7917,7 +8796,8 @@
     "task": "Defeat Hermod, the Spirit of War.",
     "information": "Defeat Hermod, the Spirit of War once.",
     "requirements": "Completion of The Spirit of War",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 880,
@@ -7926,7 +8806,8 @@
     "task": "Defeat Hermod, the Spirit of War. (100 times)",
     "information": "Defeat Hermod, the Spirit of War 100 times.",
     "requirements": "Completion of The Spirit of War",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 881,
@@ -7935,7 +8816,8 @@
     "task": "Rest whilst listening to the Dead Beats in the City of Um.",
     "information": "Rest whilst listening to the Dead Beats in the City of Um.",
     "requirements": "Completion of That Old Black Magic",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 882,
@@ -7944,7 +8826,8 @@
     "task": "Smelt a necronium bar at the smithy in the City of Um.",
     "information": "Smelt a necronium bar at the smithy in the City of Um.",
     "requirements": "70 Smithing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 883,
@@ -7953,7 +8836,8 @@
     "task": "Create a passing bracelet, performing each step in the City of Um.",
     "information": "Create a passing bracelet, performing each step in the City of Um.",
     "requirements": "60 Necromancy, 79 Crafting, 68 Magic",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 884,
@@ -7962,7 +8846,8 @@
     "task": "Catch a ghostly impling while wearing a full set of ghostly robes.",
     "information": "Catch a ghostly impling while wearing a full set of ghostly robes.",
     "requirements": "68 Hunter",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 885,
@@ -7971,7 +8856,8 @@
     "task": "Upgrade a set of Death Skull equipment to tier 70.",
     "information": "Upgrade a set of Death Skull equipment to tier 70.",
     "requirements": "70 Necromancy",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 886,
@@ -7980,7 +8866,8 @@
     "task": "Complete a Powerful Communion ritual.",
     "information": "Complete a powerful communion ritual.",
     "requirements": "90 Necromancy",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 887,
@@ -7989,7 +8876,8 @@
     "task": "Conjure an undead army at the City of Um ritual site.",
     "information": "Conjure an undead army at the City of Um ritual site.",
     "requirements": "99 Necromancy",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 888,
@@ -7998,7 +8886,8 @@
     "task": "Obtain a new set of Family Crest gauntlets from Dimintheis.",
     "information": "Obtain a new set of family gauntlets from Dimintheis.",
     "requirements": "Completion of Family Crest",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 889,
@@ -8007,7 +8896,8 @@
     "task": "Talk to Romily Weaklax and give him a wild pie.",
     "information": "Talk to Romily Weaklax and give him a wild pie.",
     "requirements": "85 Cooking",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 890,
@@ -8016,7 +8906,8 @@
     "task": "Harness the power of three relics at once.",
     "information": "Activate 3 Archaeology relics at once",
     "requirements": "25 Archaeology",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 891,
@@ -8025,7 +8916,8 @@
     "task": "Mine 50 Dark Animica from the Empty Throne Room.",
     "information": "Mine 50 dark animica from the Empty Throne Room.",
     "requirements": "90 Mining",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 892,
@@ -8034,7 +8926,8 @@
     "task": "Defeat Kerapac, the bound.",
     "information": "Defeat Kerapac, the bound once.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 893,
@@ -8043,7 +8936,8 @@
     "task": "Defeat the Arch-Glacor.",
     "information": "Defeat the Arch-Glacor.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 894,
@@ -8052,7 +8946,8 @@
     "task": "Defeat Nakatra, Devourer Eternal.",
     "information": "Defeat Nakatra, Devourer Eternal.",
     "requirements": "Completion of Soul Searching",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 895,
@@ -8061,7 +8956,8 @@
     "task": "Cleanse the Gate of Elidinis.",
     "information": "Cleanse the Gate of Elidinis.",
     "requirements": "Completion of Ode of the Devourer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 896,
@@ -8070,7 +8966,8 @@
     "task": "Complete the task set: Hard Underworld.",
     "information": "Complete the Hard Underworld achievements.",
     "requirements": "Achievement: Hard City of Um",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 897,
@@ -8079,7 +8976,8 @@
     "task": "Navigate the RuneSpan using a Greater Conjuration Platorm.",
     "information": "Navigate the RuneSpan using a greater conjuration platform.",
     "requirements": "95 Runecrafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 898,
@@ -8088,7 +8986,8 @@
     "task": "Obtain the Greater Runic Staff from the RuneSpan.",
     "information": "Obtain the greater runic staff from the RuneSpan.",
     "requirements": "75 Runecrafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 899,
@@ -8097,7 +8996,8 @@
     "task": "Complete the task set: Elite Varrock.",
     "information": "Given by Vannaka in Edgeville for completing all of the Elite Varrock achievements.",
     "requirements": "Achievement: Elite Varrock",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 900,
@@ -8106,7 +9006,8 @@
     "task": "Upgrade the guardhouse in Fort Forinthry to Tier 3.",
     "information": "Upgrade the guardhouse in Fort Forinthry to tier 3.",
     "requirements": "77 Construction",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 901,
@@ -8115,7 +9016,8 @@
     "task": "Defeat 150 tormented demons.",
     "information": "Defeat 150 tormented demons.",
     "requirements": "Completion of While Guthix Sleeps",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 902,
@@ -8124,7 +9026,8 @@
     "task": "Equip a dragon crossbow.",
     "information": "Equip a dragon crossbow.",
     "requirements": "64 Ranged",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 903,
@@ -8133,7 +9036,8 @@
     "task": "Defeat Rasial, the First Necromancer.",
     "information": "Defeat Rasial, the First Necromancer once.",
     "requirements": "Completion of all Necromancy quests",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 904,
@@ -8142,7 +9046,8 @@
     "task": "Defeat Rasial, the First Necromancer. (100 times)",
     "information": "Defeat Rasial, the First Necromancer 100 times.",
     "requirements": "Completion of all Necromancy quests",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 905,
@@ -8151,7 +9056,8 @@
     "task": "Equip an Omni guard.",
     "information": "Equip an omni guard.",
     "requirements": "95 Necromancy",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 906,
@@ -8160,7 +9066,8 @@
     "task": "Equip a Soulbound lantern.",
     "information": "Equip a soulbound lantern",
     "requirements": "95 Necromancy",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 907,
@@ -8169,7 +9076,8 @@
     "task": "Equip a full set of Robes of the First Necromancer.",
     "information": "Equip a full set of First Necromancer's equipment.",
     "requirements": "95 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 908,
@@ -8178,7 +9086,8 @@
     "task": "Give a blueberry pie to Thalmund in the City of Um.",
     "information": "Give a blueberry pie to Thalmund in the City of Um.",
     "requirements": "30 Cooking",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 909,
@@ -8187,7 +9096,8 @@
     "task": "Track 8 of the owls in the City of Um.",
     "information": "Track 8 of the owls in the City of Um. See Birds of Prey for details.",
     "requirements": "Completion of all Necromancy quests",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 910,
@@ -8196,7 +9106,8 @@
     "task": "Defeat Croesus.",
     "information": "Defeat Croesus 1 time.",
     "requirements": "88 Woodcutting, 88 Mining, 88 Fishing, 88 Hunter",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 911,
@@ -8205,7 +9116,8 @@
     "task": "Defeat Croesus. (100 times)",
     "information": "Defeat Croesus 100 times.",
     "requirements": "88 Woodcutting, 88 Mining, 88 Fishing, 88 Hunter",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 912,
@@ -8214,7 +9126,8 @@
     "task": "Defeat Kerapac, the bound. (100 times)",
     "information": "Defeat Kerapac, the bound 100 times.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 913,
@@ -8223,7 +9136,8 @@
     "task": "Defeat the Arch-Glacor in hard mode. (100 times)",
     "information": "Defeat the Arch-Glacor in hard mode 100 times.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 914,
@@ -8232,7 +9146,8 @@
     "task": "Equip either a Dark Shard of Leng or a Dark Sliver of Leng.",
     "information": "Equip either a Dark Shard of Leng or a Dark Sliver of Leng.",
     "requirements": "92 Attack",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 915,
@@ -8241,7 +9156,8 @@
     "task": "Craft 100 earth runes simultaneously without aid from an explorer's ring, pouches or familiars.",
     "information": "Craft 100 earth runes simultaneously without aid from an explorer's ring, Runecrafting pouches or familiars.",
     "requirements": "99 Runecrafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 916,
@@ -8250,7 +9166,8 @@
     "task": "Bake a summer pie in the Cooking Guild from scratch.",
     "information": "Bake a summer pie in the Cooking Guild from scratch.",
     "requirements": "95 Cooking",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 917,
@@ -8259,7 +9176,8 @@
     "task": "Defeat TzKal-Zuk.",
     "information": "Defeat TzKal-Zuk once.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 918,
@@ -8268,7 +9186,8 @@
     "task": "Defeat TzKal-Zuk. (10 times)",
     "information": "Defeat TzKal-Zuk 10 times.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 919,
@@ -8277,7 +9196,8 @@
     "task": "Craft a soul rune at the soul altar with a soul cape equipped.",
     "information": "Craft a soul rune at the soul altar with a soul cape equipped.",
     "requirements": "90 Runecrafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 920,
@@ -8286,7 +9206,8 @@
     "task": "Upgrade a set of Death Skull equipment to tier 90.",
     "information": "Upgrade a set of Death Skull equipment to tier 90.",
     "requirements": "90 Necromancy",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 921,
@@ -8295,7 +9216,8 @@
     "task": "Defeat Nakatra, Devourer Eternal. (100 times)",
     "information": "Defeat Nakatra, Devourer Eternal 100 times.",
     "requirements": "Completion of Soul Searching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 922,
@@ -8304,7 +9226,8 @@
     "task": "Cleanse the Gate of Elidinis. (100 times)",
     "information": "Cleanse The Gate of Elidinis 100 times.",
     "requirements": "Completion of Ode of the Devourer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 923,
@@ -8313,7 +9236,8 @@
     "task": "Complete the task set: Elite Underworld.",
     "information": "Complete the Elite Underworld achievements.",
     "requirements": "Achievement: Elite City of Um",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 924,
@@ -8322,7 +9246,8 @@
     "task": "Defeat Zemouregal & Vorkath.",
     "information": "Defeat Zemouregal & Vorkath.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 925,
@@ -8331,7 +9256,8 @@
     "task": "Defeat Zemouregal & Vorkath. (100 times)",
     "information": "Defeat Zemouregal & Vorkath 100 times.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 926,
@@ -8340,7 +9266,8 @@
     "task": "Equip an Ek-ZekKil.",
     "information": "Equip an Ek-ZekKil.",
     "requirements": "95 Melee",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 927,
@@ -8349,7 +9276,8 @@
     "task": "Equip a Fractured Staff of Armadyl.",
     "information": "Equip a Fractured Staff of Armadyl.",
     "requirements": "95 Magic",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 928,
@@ -8358,7 +9286,8 @@
     "task": "Complete all Sanctum of Rebirth combat achievements.",
     "information": "Complete all Sanctum of Rebirth combat achievements.",
     "requirements": "Achievement: Sanctum of Rebirth",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 929,
@@ -8367,7 +9296,8 @@
     "task": "Complete all of Rasial, the First Necromancer's combat achievements.",
     "information": "Complete all of Rasial, the First Necromancer's combat achievements.",
     "requirements": "Achievement: Rasial, the First Necromancer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 930,
@@ -8376,7 +9306,8 @@
     "task": "Equip an igneous Kal-Zuk cape.",
     "information": "Equip an igneous Kal-Zuk cape.",
     "requirements": "99 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 931,
@@ -8385,7 +9316,8 @@
     "task": "Take an easy companion through an easy route of Temple Trekking.",
     "information": "Complete an Easy Temple Trek.",
     "requirements": "Completion of In Aid of the Myreque",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 932,
@@ -8394,7 +9326,8 @@
     "task": "Craft your own snelm in Morytania.",
     "information": "Craft a snelm.",
     "requirements": "15 Crafting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 933,
@@ -8403,7 +9336,8 @@
     "task": "Defeat a Werewolf in Morytania.",
     "information": "Defeat a Werewolf in Morytania.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 934,
@@ -8412,7 +9346,8 @@
     "task": "Pass through the Holy barrier.",
     "information": "Pass through the Holy barrier.",
     "requirements": "Defeat a Ghoul (Paterdomus)",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 935,
@@ -8421,7 +9356,8 @@
     "task": "Enter through the western gate of Port Phasmatys.",
     "information": "Pass through the western gate of Port Phasmatys.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 936,
@@ -8430,7 +9366,8 @@
     "task": "Activate the lodestone in Canifis.",
     "information": "Activate the Canifis lodestone.",
     "requirements": "Access to Morytania",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 937,
@@ -8439,7 +9376,8 @@
     "task": "Kill anything on the ground floor of the Slayer Tower.",
     "information": "Kill anything on the ground floor of the Slayer Tower.",
     "requirements": "1 Slayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 938,
@@ -8448,7 +9386,8 @@
     "task": "Using either a Silver Sickle or the Ivandis Flail, grow some fungus in the swamp using Bloom.",
     "information": "Cast Bloom using a blessed sickle or the Ivandis flail in Mort Myre Swamp.",
     "requirements": "18 Crafting",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 939,
@@ -8457,7 +9396,8 @@
     "task": "Defeat 5 Feral Vampyres in the Haunted Woods.",
     "information": "Defeat 5 feral vampyres in the Haunted Woods.",
     "requirements": "Access to Morytania",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 940,
@@ -8466,7 +9406,8 @@
     "task": "Use an ectophial to return to Port Phasmatys.",
     "information": "Use an ectophial to return to Port Phasmatys.",
     "requirements": "Completion of Ghosts Ahoy",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 941,
@@ -8475,7 +9416,8 @@
     "task": "Visit Dragontooth Island by boat.",
     "information": "Visit Dragontooth Island by boat.",
     "requirements": "Ghostspeak amulet",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 942,
@@ -8484,7 +9426,8 @@
     "task": "Complete the task set: Easy Morytania.",
     "information": "Complete the Easy Morytania achievements.",
     "requirements": "Achievement: Easy Morytania",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 943,
@@ -8493,7 +9436,8 @@
     "task": "Take a medium companion through a medium route of Temple Trekking.",
     "information": "Take a medium companion through a medium route of Temple Trekking.",
     "requirements": "Completion of In Aid of the Myreque",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 944,
@@ -8502,7 +9446,8 @@
     "task": "Visit Mos Le'Harmless.",
     "information": "Visit Mos Le'Harmless.",
     "requirements": "Partial completion of Cabin Fever",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 945,
@@ -8511,7 +9456,8 @@
     "task": "Visit Harmony Island.",
     "information": "Visit Harmony Island.",
     "requirements": "Partial completion of The Great Brain Robbery",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 946,
@@ -8520,7 +9466,8 @@
     "task": "Visit the Everlight dig site.",
     "information": "Visit the Everlight dig site.",
     "requirements": "42 Archaeology",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 947,
@@ -8529,7 +9476,8 @@
     "task": "Finish a game of Werewolf Skullball.",
     "information": "Finish a game of Werewolf Skullball.",
     "requirements": "25 Agility",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 948,
@@ -8538,7 +9486,8 @@
     "task": "Defeat the six Barrows Brothers and loot their chest.",
     "information": "Defeat the six Barrows Brothers and loot their chest once.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 949,
@@ -8547,7 +9496,8 @@
     "task": "Defeat the six Barrows Brothers and loot their chest. (100 times)",
     "information": "Defeat the six Barrows Brothers and loot their chest 100 times.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 950,
@@ -8556,7 +9506,8 @@
     "task": "Equip a Barrows weapon.",
     "information": "Equip a barrows weapon.",
     "requirements": "70 Magic, 70 Attack, or 70 Ranged",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 951,
@@ -8565,7 +9516,8 @@
     "task": "Equip a piece of Barrows armour.",
     "information": "Equip a piece of barrows armour.",
     "requirements": "70 Defence",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 952,
@@ -8574,7 +9526,8 @@
     "task": "Equip a Salve Amulet (e).",
     "information": "Equip a salve amulet (e).",
     "requirements": "Completion of Lair of Tarn Razorlor (miniquest)",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 953,
@@ -8583,7 +9536,8 @@
     "task": "Make a batch of cannonballs in Port Phasmatys.",
     "information": "Make a batch of cannonballs in Port Phasmatys.",
     "requirements": "35 Smithing",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 954,
@@ -8592,7 +9546,8 @@
     "task": "Catch 10 Green salamanders.",
     "information": "Catch 10 Green salamanders.",
     "requirements": "29 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 955,
@@ -8601,7 +9556,8 @@
     "task": "Complete the quest: Haunted Mine.",
     "information": "Complete Haunted Mine.",
     "requirements": "Quest: Haunted Mine",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 956,
@@ -8610,7 +9566,8 @@
     "task": "Harvest bittercap mushrooms in the farming patch near Canifis.",
     "information": "Harvest bittercap mushrooms in the farming patch near Canifis.",
     "requirements": "53 Farming",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 957,
@@ -8619,7 +9576,8 @@
     "task": "Complete the task set: Medium Morytania.",
     "information": "Complete the Medium Morytania achievements.",
     "requirements": "Achievement: Medium Morytania",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 958,
@@ -8628,7 +9586,8 @@
     "task": "Take a hard companion through a hard route of Temple Trekking.",
     "information": "Take a hard companion through a hard route of Temple Trekking.",
     "requirements": "Completion of In Aid of the Myreque",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 959,
@@ -8637,7 +9596,8 @@
     "task": "Mine 30 Phasmatite.",
     "information": "Mine 30 phasmatite at Port Phasmatys south mine.",
     "requirements": "70 Mining",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 960,
@@ -8646,7 +9606,8 @@
     "task": "Defeat 25 Gargoyles.",
     "information": "Defeat 25 gargoyles.",
     "requirements": "75 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 961,
@@ -8655,7 +9616,8 @@
     "task": "Defeat 35 Aberrant Spectres.",
     "information": "Defeat 35 aberrant spectres.",
     "requirements": "60 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 962,
@@ -8664,7 +9626,8 @@
     "task": "Equip a full set of Ahrim's equipment, including the staff.",
     "information": "Equip a full set of Ahrim's equipment, including the staff.",
     "requirements": "70 Defence, 70 Magic",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 963,
@@ -8673,7 +9636,8 @@
     "task": "Equip a full set of Dharok's equipment, including the greataxe.",
     "information": "Equip a full set of Dharok's equipment, including the greataxe.",
     "requirements": "70 Defence, 70 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 964,
@@ -8682,7 +9646,8 @@
     "task": "Equip a full set of Guthan's equipment, including the warspear.",
     "information": "Equip a full set of Guthan's equipment, including the Guthan's warspear.",
     "requirements": "70 Defence, 70 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 965,
@@ -8691,7 +9656,8 @@
     "task": "Equip a full set of Torag's equipment, including the hammer.",
     "information": "Equip a full set of Torag's equipment, including the hammer.",
     "requirements": "70 Defence, 70 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 966,
@@ -8700,7 +9666,8 @@
     "task": "Equip a full set of Verac's equipment, including the flail.",
     "information": "Equip a full set of Verac's equipment, including the flail.",
     "requirements": "70 Defence, 70 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 967,
@@ -8709,7 +9676,8 @@
     "task": "Equip a full set of Karil's equipment, including the 2h crossbow.",
     "information": "Equip a full set of Karil's equipment, including the 2h crossbow.",
     "requirements": "70 Defence, 70 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 968,
@@ -8718,7 +9686,8 @@
     "task": "Complete the quest: The Branches of Darkmeyer.",
     "information": "Complete The Branches of Darkmeyer.",
     "requirements": "Quest: The Branches of Darkmeyer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 969,
@@ -8727,7 +9696,8 @@
     "task": "Burn 20 Blisterwood logs.",
     "information": "Burn 20 blisterwood logs.",
     "requirements": "76 Woodcutting, 76 Firemaking",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 970,
@@ -8736,7 +9706,8 @@
     "task": "Fully level up all Temple Trekking companions.",
     "information": "Fully level up all Temple Trekking companions.",
     "requirements": "Completion of In Aid of the Myreque",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 971,
@@ -8745,7 +9716,8 @@
     "task": "Catch 5 sharks in Burgh de Rott.",
     "information": "Catch 5 sharks in Burgh de Rott.",
     "requirements": "76 Fishing",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 972,
@@ -8754,7 +9726,8 @@
     "task": "Complete the task set: Hard Morytania.",
     "information": "Complete the Hard Morytania achievements.",
     "requirements": "Achievement: Hard Morytania",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 973,
@@ -8763,7 +9736,8 @@
     "task": "Defeat 30 Abyssal Demons.",
     "information": "Defeat 30 abyssal demons.",
     "requirements": "85 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 974,
@@ -8772,7 +9746,8 @@
     "task": "Harvest 200 radiant energy from Radiant Wisps.",
     "information": "Harvest 200 radiant energy from radiant wisps.",
     "requirements": "85 Divination",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 975,
@@ -8781,7 +9756,8 @@
     "task": "Defeat 20 Celestial Dragons.",
     "information": "Defeat 20 celestial dragons.",
     "requirements": "Completion of One of a Kind",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 976,
@@ -8790,7 +9766,8 @@
     "task": "Defeat Araxxi.",
     "information": "Defeat Araxxi once.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 977,
@@ -8799,7 +9776,8 @@
     "task": "Defeat Araxxi. (100 times)",
     "information": "Defeat Araxxi 100 times.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 978,
@@ -8808,7 +9786,8 @@
     "task": "Defeat the empowered Barrows Brothers.",
     "information": "Complete one Rise of the Six encounter.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 979,
@@ -8817,7 +9796,8 @@
     "task": "Defeat the empowered Barrows Brothers.",
     "information": "Complete 100 Rise of the Six encounters.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 980,
@@ -8826,7 +9806,8 @@
     "task": "Equip a Noxious Scythe.",
     "information": "Equip a noxious scythe.",
     "requirements": "90 Attack",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 981,
@@ -8835,7 +9816,8 @@
     "task": "Equip a Noxious Staff.",
     "information": "Equip a noxious staff.",
     "requirements": "90 Magic",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 982,
@@ -8844,7 +9826,8 @@
     "task": "Equip a Noxious Bow.",
     "information": "Equip a noxious bow.",
     "requirements": "90 Ranged",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 983,
@@ -8853,7 +9836,8 @@
     "task": "Equip a full set of Linza's equipment, including the hammer and shield.",
     "information": "Equip a full set of Linza the Disgraced's equipment, including the hammer and shield.",
     "requirements": "80 Defence, 80 Attack",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 984,
@@ -8862,7 +9846,8 @@
     "task": "Equip a full set of Akrisae's equipment, including the war mace.",
     "information": "Equip a full set of Akrisae the Doomed's equipment, including the war mace.",
     "requirements": "80 Defence, 80 Attack",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 985,
@@ -8871,7 +9856,8 @@
     "task": "Equip a Malevolent Kiteshield.",
     "information": "Equip a malevolent kiteshield.",
     "requirements": "90 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 986,
@@ -8880,7 +9866,8 @@
     "task": "Equip a Merciless Kiteshield.",
     "information": "Equip a merciless kiteshield.",
     "requirements": "90 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 987,
@@ -8889,7 +9876,8 @@
     "task": "Equip a Vengeful Kiteshield.",
     "information": "Equip a vengeful kiteshield.",
     "requirements": "90 Defence",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 988,
@@ -8898,7 +9886,8 @@
     "task": "Complete all the Everlight mysteries.",
     "information": "Complete all of the Everlight Dig Site mysteries.",
     "requirements": "98 Archaeology",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 989,
@@ -8907,7 +9896,8 @@
     "task": "Obtain an Araxyte Pheremone drop.",
     "information": "Obtain an araxyte pheremone drop.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 990,
@@ -8916,7 +9906,8 @@
     "task": "Complete the task set: Elite Morytania.",
     "information": "Complete the Elite Morytania achievements.",
     "requirements": "Achievement: Elite Morytania",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 991,
@@ -8925,7 +9916,8 @@
     "task": "Enter the Morytania Slayer Tower resource dungeon.",
     "information": "Enter the Morytania Slayer Tower resource dungeon.",
     "requirements": "95 Dungeoneering",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 992,
@@ -8934,7 +9926,8 @@
     "task": "Read the book acquired from Roberta outside the Everlight porcelain clay mine.",
     "information": "Read On the Origin of Centaurs.",
     "requirements": "42 Archaeology",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 993,
@@ -8943,7 +9936,8 @@
     "task": "Fully explore the history of the Everlight Dig Site.",
     "information": "Complete the Mastery - Everlight achievements.",
     "requirements": "98 Archaeology",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 994,
@@ -8952,7 +9946,8 @@
     "task": "Complete all Araxxor and Araxxi combat achievements.",
     "information": "Complete all Araxxor and Araxxi combat achievements.",
     "requirements": "Achievement: Araxxor",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 995,
@@ -8961,7 +9956,8 @@
     "task": "Complete the quest: River of Blood.",
     "information": "Complete River of Blood.",
     "requirements": "Quest: River of Blood",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 996,
@@ -8970,7 +9966,8 @@
     "task": "Cook a Rabbit in Tirannwn.",
     "information": "Cook a raw rabbit in Tirannwn.",
     "requirements": "1 Cooking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 997,
@@ -8979,7 +9976,8 @@
     "task": "Attempt to pass a leaf trap.",
     "information": "Attempt to pass a leaf trap.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 998,
@@ -8988,7 +9986,8 @@
     "task": "Use the Bank in Lletya.",
     "information": "Use the bank in Lletya.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 999,
@@ -8997,7 +9996,8 @@
     "task": "Charter a ship from Port Tyras.",
     "information": "Charter a ship from Port Tyras.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1000,
@@ -9006,7 +10006,8 @@
     "task": "Climb the Tower of Voices.",
     "information": "Climb the Tower of Voices.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1001,
@@ -9015,7 +10016,8 @@
     "task": "Burn some logs using the everlasting bonfire in the Tower of Voices.",
     "information": "Burn some logs using the everlasting bonfire in the Tower of Voices.",
     "requirements": "1 Firemaking",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1002,
@@ -9024,7 +10026,8 @@
     "task": "Activate the lodestone in Prifddinas.",
     "information": "Activate the Prifddinas lodestone.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1003,
@@ -9033,7 +10036,8 @@
     "task": "Activate the lodestone in Tirannwn.",
     "information": "Activate the Tirannwn lodestone.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1004,
@@ -9042,7 +10046,8 @@
     "task": "Restore your prayer using the altar in Lletya.",
     "information": "Restore your prayer using the altar in Lletya.",
     "requirements": "1 Prayer",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1005,
@@ -9051,7 +10056,8 @@
     "task": "Complete the task set: Easy Tirannwn.",
     "information": "Complete the Easy Tirannwn achievements.",
     "requirements": "Achievement: Easy Tirannwn",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1006,
@@ -9060,7 +10066,8 @@
     "task": "Check a grown Papaya Tree in Lletya.",
     "information": "Check a grown papaya tree in Lletya.",
     "requirements": "57 Farming",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1007,
@@ -9069,7 +10076,8 @@
     "task": "Craft 50 Death Runes.",
     "information": "Craft 50 death runes.",
     "requirements": "65 Runecrafting",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1008,
@@ -9078,7 +10086,8 @@
     "task": "Move your house to Prifddinas.",
     "information": "Move your player-owned house's location to Prifddinas by speaking to an estate agent.",
     "requirements": "75 Construction",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1009,
@@ -9087,7 +10096,8 @@
     "task": "Use an Elven Teleport Crystal.",
     "information": "Use a crystal teleport seed.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1010,
@@ -9096,7 +10106,8 @@
     "task": "Equip Iban's staff.",
     "information": "Equip Iban's staff.",
     "requirements": "50 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1011,
@@ -9105,7 +10116,8 @@
     "task": "Catch 10 Pawyas in Isafdar.",
     "information": "Catch 10 pawyas in Isafdar.",
     "requirements": "66 Hunter",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1012,
@@ -9114,7 +10126,8 @@
     "task": "Mine 200 soft clay in Prifddinas.",
     "information": "Mine 200 soft clay in Prifddinas.",
     "requirements": "75 Mining",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1013,
@@ -9123,7 +10136,8 @@
     "task": "Use the fairy ring in the Amlodd district.",
     "information": "Use the fairy ring in the Amlodd district.",
     "requirements": "Partial completion of A Fairy Tale II - Cure a Queen",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1014,
@@ -9132,7 +10146,8 @@
     "task": "Complete the task set: Medium Tirannwn.",
     "information": "Complete the Medium Tirannwn achievements.",
     "requirements": "Achievement: Medium Tirannwn",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1015,
@@ -9141,7 +10156,8 @@
     "task": "Plant a mushroom seed in the mushroom patch in Isafdar.",
     "information": "Plant a mushroom seed in the mushroom patch in Isafdar.",
     "requirements": "53 Farming",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1016,
@@ -9150,7 +10166,8 @@
     "task": "Defeat 30 Cadarn warriors in Prifddinas.",
     "information": "Defeat 30 Cadarn warriors in Prifddinas.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1017,
@@ -9159,7 +10176,8 @@
     "task": "Harvest some harmony moss from a harmony pillar.",
     "information": "Harvest some harmony moss from a harmony pillar.",
     "requirements": "75 Farming",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1018,
@@ -9168,7 +10186,8 @@
     "task": "Complete the Hefin Agility course with a light creature familiar summoned.",
     "information": "Complete the Hefin Agility course with a light creature familiar summoned.",
     "requirements": "77 Agility, 88 Summoning, 71 Divination",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1019,
@@ -9177,7 +10196,8 @@
     "task": "Cleanse the Corrupted Seren stone with 5 cleansing crystals.",
     "information": "Cleanse the corrupted Seren stone with 5 cleansing crystals.",
     "requirements": "75 Prayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1020,
@@ -9186,7 +10206,8 @@
     "task": "Complete 10 laps of the Hefin agility course.",
     "information": "Complete 10 laps of the Hefin agility course.",
     "requirements": "77 Agility",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1021,
@@ -9195,7 +10216,8 @@
     "task": "Harvest 100 Incandescent energy from Incandescent Wisps.",
     "information": "Harvest 100 incandescent energy from incandescent wisps.",
     "requirements": "95 Divination",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1022,
@@ -9204,7 +10226,8 @@
     "task": "Equip a Dark bow.",
     "information": "Equip a dark bow.",
     "requirements": "90 Slayer, 70 Ranged, 70 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1023,
@@ -9213,7 +10236,8 @@
     "task": "Defeat 30 Dark beasts in Tirannwn.",
     "information": "Defeat 30 dark beasts in Tirannwn.",
     "requirements": "90 Slayer",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1024,
@@ -9222,7 +10246,8 @@
     "task": "Equip a Crystal halberd.",
     "information": "Equip a crystal halberd.",
     "requirements": "50 Agility, 70 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1025,
@@ -9231,7 +10256,8 @@
     "task": "Equip a Crystal shield.",
     "information": "Equip a crystal shield.",
     "requirements": "50 Agility, 70 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1026,
@@ -9240,7 +10266,8 @@
     "task": "Equip a Crystal bow.",
     "information": "Equip a crystal bow.",
     "requirements": "50 Agility, 70 Ranged",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1027,
@@ -9249,7 +10276,8 @@
     "task": "Catch 25 Grenwalls in Isafdar.",
     "information": "Catch 25 grenwalls in Isafdar.",
     "requirements": "77 Hunter",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1028,
@@ -9258,7 +10286,8 @@
     "task": "Defeat 10 Elf warriors in Lletya.",
     "information": "Defeat 10 elf warriors in Lletya.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1029,
@@ -9267,7 +10296,8 @@
     "task": "Chop 50 Magic logs in Tirannwn.",
     "information": "Chop 50 magic logs in Tirannwn.",
     "requirements": "80 Woodcutting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1030,
@@ -9276,7 +10306,8 @@
     "task": "Open the crystal chest in Prifddinas 10 times.",
     "information": "Open the crystal chest in Prifddinas 10 times.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1031,
@@ -9285,7 +10316,8 @@
     "task": "Charge a piece of Dragonstone jewellery using the Tears of Seren.",
     "information": "Charge a piece of dragonstone jewellery using the Tears of Seren.",
     "requirements": "Completion of Legends' Quest",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1032,
@@ -9294,7 +10326,8 @@
     "task": "Complete the task set: Hard Tirannwn.",
     "information": "Complete the Hard Tirannwn achievements.",
     "requirements": "Achievement: Hard Tirannwn",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1033,
@@ -9303,7 +10336,8 @@
     "task": "Enter the Gorajo Hoardstalker resource dungeon.",
     "information": "Enter the Gorajo Hoardstalker resource dungeon.",
     "requirements": "95 Dungeoneering",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1034,
@@ -9312,7 +10346,8 @@
     "task": "Have Lady Ithell create a crystal pickaxe, hatchet, or mattock.",
     "information": "Have Lady Ithell create a crystal pickaxe, hatchet, or mattock.",
     "requirements": "70 Smithing, 70 Invention",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1035,
@@ -9321,7 +10356,8 @@
     "task": "Find all of the memoriam crystals in Prifddinas.",
     "information": "Find all of the memoriam crystals in Prifddinas.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1036,
@@ -9330,7 +10366,8 @@
     "task": "Aid Lord Amlodd in cleansing shadow cores.",
     "information": "Complete the I'm Forever Washing Shadows achievement.",
     "requirements": "71 Divination",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1037,
@@ -9339,7 +10376,8 @@
     "task": "Help Lady Ithell with crystal singing research.",
     "information": "Complete the Sing for the Lady achievement.",
     "requirements": "75 Smithing, 75 Crafting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1038,
@@ -9348,7 +10386,8 @@
     "task": "Aid Lady Trahaearn in removing some corruption by smelting 100 corrupted ore.",
     "information": "Complete the Uncorrupted Ore achievement.",
     "requirements": "75 Mining, 75 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1039,
@@ -9357,7 +10396,8 @@
     "task": "Check a grown Crystal Tree in the Tower of Voices.",
     "information": "Check a grown crystal tree in the Tower of Voices.",
     "requirements": "94 Farming",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1040,
@@ -9366,7 +10406,8 @@
     "task": "Have 4 elven clans suspect you of thieving at the same time.",
     "information": "Have 4 elven clans suspect you of thieving at the same time. If you have the Five Finger Discount relic this task is completed when pickpocketing an elf.",
     "requirements": "75 Thieving",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1041,
@@ -9375,7 +10416,8 @@
     "task": "Chop a log from an elder tree you have grown in the Prifddinas farming patch, then fletch it into a shortbow.",
     "information": "Chop a log from an elder tree you have grown in the Prifddinas farming patch, then fletch it into an elder shortbow.",
     "requirements": "90 Farming, 90 Woodcutting, 90 Fletching",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1042,
@@ -9384,7 +10426,8 @@
     "task": "Catch a Crystal impling.",
     "information": "Catch a crystal impling.",
     "requirements": "80 Hunter",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1043,
@@ -9393,7 +10436,8 @@
     "task": "Craft an Attuned crystal teleport seed.",
     "information": "Craft an attuned crystal teleport seed.",
     "requirements": "85 Crafting, 85 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1044,
@@ -9402,7 +10446,8 @@
     "task": "Mine 50 Light animica in Isafdar.",
     "information": "Mine 50 light animica in Isafdar.",
     "requirements": "90 Mining",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1045,
@@ -9411,7 +10456,8 @@
     "task": "Chop 25 Elder logs in Tirannwn.",
     "information": "Chop 25 elder logs in Tirannwn.",
     "requirements": "90 Woodcutting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1046,
@@ -9420,7 +10466,8 @@
     "task": "Catch 75 Crystal skillchompas in Isafdar.",
     "information": "Catch 75 crystal skillchompas in Isafdar.",
     "requirements": "97 Hunter",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1047,
@@ -9429,7 +10476,8 @@
     "task": "Complete the task set: Elite Tirannwn.",
     "information": "Complete the Elite Tirannwn achievements.",
     "requirements": "Achievement: Elite Tirannwn",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1048,
@@ -9438,7 +10486,8 @@
     "task": "Complete a Seren symbol.",
     "information": "Create a Seren's symbol.",
     "requirements": "75 Farming, 75 Prayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1049,
@@ -9447,7 +10496,8 @@
     "task": "Obtain the titles of the elven clans.",
     "information": "Obtain the titles of the elven clans.",
     "requirements": "Various",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1050,
@@ -9456,7 +10506,8 @@
     "task": "Perform well enough in Rush of Blood to impress Morvran.",
     "information": "Complete the Make Them Bleed achievement.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1051,
@@ -9465,7 +10516,8 @@
     "task": "Reach inside the Motherlode Maw 5 times.",
     "information": "Reach inside the Motherlode Maw 5 times.",
     "requirements": "115 Dungeoneering",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1052,
@@ -9474,7 +10526,8 @@
     "task": "Obtain 'the Elven' title by purchasing each of the elven clan capes.",
     "information": "Obtain the Elven title by purchasing each of the elven clan capes.",
     "requirements": "Various",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1053,
@@ -9483,7 +10536,8 @@
     "task": "Obtain the 'Dark Lord' title by unlocking a selection of titles from Prifddinas.",
     "information": "Obtain the Dark Lord title by completing the Sort of Crystally achievement.",
     "requirements": "Various",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1054,
@@ -9492,7 +10546,8 @@
     "task": "Use the bank at the Mage Arena.",
     "information": "Use the Mage Arena bank.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1055,
@@ -9501,7 +10556,8 @@
     "task": "Defeat the Chaos Elemental.",
     "information": "Defeat the Chaos Elemental once.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1056,
@@ -9510,7 +10566,8 @@
     "task": "Defeat the Chaos Elemental. (100 times)",
     "information": "Defeat the Chaos Elemental 100 times.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1057,
@@ -9519,7 +10576,8 @@
     "task": "Reach a score of 10 using the strange switches in the Wilderness.",
     "information": "Reach a score of 10 using the strange switches in the Wilderness.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1058,
@@ -9528,7 +10586,8 @@
     "task": "Jump over the Wilderness wall.",
     "information": "Jump over the Wilderness wall.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1059,
@@ -9537,7 +10596,8 @@
     "task": "Activate the lodestone near the Wilderness Crater.",
     "information": "Activate the Wilderness Crater lodestone.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1060,
@@ -9546,7 +10606,8 @@
     "task": "Complete a Frozen floor in Daemonheim.",
     "information": "Complete a Frozen floor in Daemonheim.",
     "requirements": "1 Dungeoneering",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1061,
@@ -9555,7 +10616,8 @@
     "task": "Make use of either an autoheater, gem bag, herbicide, bonecrusher or charming imp.",
     "information": "Make use of either an autoheater, gem bag, herbicide, bonecrusher or charming imp.",
     "requirements": "2000 dungeoneering token",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1062,
@@ -9564,7 +10626,8 @@
     "task": "Enter the chaos tunnels from an entrance in the Wilderness.",
     "information": "Enter the Chaos Tunnels from an entrance in the Wilderness.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1063,
@@ -9573,7 +10636,8 @@
     "task": "Defeat a Black Unicorn in the Wilderness.",
     "information": "Defeat a black unicorn in the Wilderness.",
     "requirements": "N/A",
-    "points": 10
+    "points": 10,
+    "tier": "Easy"
   },
   {
     "id": 1064,
@@ -9582,7 +10646,8 @@
     "task": "Complete the task set: Easy Wilderness.",
     "information": "Complete the Easy Wilderness achievements.",
     "requirements": "Achievement: Easy Wilderness",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1065,
@@ -9591,7 +10656,8 @@
     "task": "Defeat the King Black Dragon.",
     "information": "Defeat the King Black Dragon once.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1066,
@@ -9600,7 +10666,8 @@
     "task": "Defeat the King Black Dragon. (100 times)",
     "information": "Defeat the King Black Dragon 100 times.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1067,
@@ -9609,7 +10676,8 @@
     "task": "Sacrifice Dragon bones on the Chaos Altar.",
     "information": "Sacrifice dragon bones on the chaos altar in the Wilderness.",
     "requirements": "1 Prayer",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1068,
@@ -9618,7 +10686,8 @@
     "task": "Cast the Claws of Guthix special attack.",
     "information": "Cast the Claws of Guthix special attack.",
     "requirements": "60 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1069,
@@ -9627,7 +10696,8 @@
     "task": "Defeat 5 Green dragons.",
     "information": "Defeat 5 green dragons.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1070,
@@ -9636,7 +10706,8 @@
     "task": "Complete 10 laps of the Wilderness agility course.",
     "information": "Complete 10 laps of the Wilderness agility course.",
     "requirements": "52 Agility",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1071,
@@ -9645,7 +10716,8 @@
     "task": "Equip a Saradomin, Zamorak, or Guthix cape.",
     "information": "Equip a Saradomin, Zamorak, or Guthix cape.",
     "requirements": "60 Magic",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1072,
@@ -9654,7 +10726,8 @@
     "task": "Visit any Runecrafting altar through the Abyss.",
     "information": "Visit any Runecrafting altar through the Abyss.",
     "requirements": "Completion of Enter the Abyss (miniquest)",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1073,
@@ -9663,7 +10736,8 @@
     "task": "Defeat 10 Fetid Zombies.",
     "information": "Defeat 10 fetid zombies.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1074,
@@ -9672,7 +10746,8 @@
     "task": "Defeat 20 Bound Skeletons.",
     "information": "Defeat 20 bound skeletons.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1075,
@@ -9681,7 +10756,8 @@
     "task": "Defeat the Rammernaut.",
     "information": "Defeat the Rammernaut.",
     "requirements": "35 Dungeoneering",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1076,
@@ -9690,7 +10766,8 @@
     "task": "Defeat Bossy McBoss Face.",
     "information": "Defeat Bossy McBoss Face.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1077,
@@ -9699,7 +10776,8 @@
     "task": "Activate and teleport from each of the Wilderness teleport obelisks.",
     "information": "Activate and teleport from each of the Wilderness teleport obelisks.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1078,
@@ -9708,7 +10786,8 @@
     "task": "Defeat Bossy McBossface's first mate.",
     "information": "Defeat Bossy McBossface's first mate.",
     "requirements": "N/A",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1079,
@@ -9717,7 +10796,8 @@
     "task": "Complete the task set: Medium Wilderness.",
     "information": "Complete the Medium Wilderness achievements.",
     "requirements": "Achievement: Medium Wilderness",
-    "points": 30
+    "points": 30,
+    "tier": "Medium"
   },
   {
     "id": 1080,
@@ -9726,7 +10806,8 @@
     "task": "Defeat the King Black Dragon while wearing black dragonhide in six equipment slots. Can only be completed in a solo instance.",
     "information": "Defeat the King Black Dragon while wearing black dragonhide in six equipment slots.",
     "requirements": "60 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1081,
@@ -9735,7 +10816,8 @@
     "task": "Defeat one of each revenant creature in the Forinthry dungeon.",
     "information": "Defeat one of each revenant creature in the Forinthry dungeon.",
     "requirements": "N/A",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1082,
@@ -9744,7 +10826,8 @@
     "task": "Equip a Statius's warhammer.",
     "information": "Equip a Statius's warhammer.",
     "requirements": "78 Attack",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1083,
@@ -9753,7 +10836,8 @@
     "task": "Catch 25 Black Salamanders.",
     "information": "Catch 25 black salamanders.",
     "requirements": "67 Hunter",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1084,
@@ -9762,7 +10846,8 @@
     "task": "Restore an artefact from the Daemonheim digsite.",
     "information": "Restore an artefact from the Daemonheim digsite.",
     "requirements": "73 Archaeology",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1085,
@@ -9771,7 +10856,8 @@
     "task": "Defeat the Corporeal Beast.",
     "information": "Defeat the Corporeal Beast once.",
     "requirements": "Completion of Summer's End",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1086,
@@ -9780,7 +10866,8 @@
     "task": "Defeat the Corporeal Beast. (100 times)",
     "information": "Defeat the Corporeal Beast 100 times.",
     "requirements": "Completion of Summer's End",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1087,
@@ -9789,7 +10876,8 @@
     "task": "Defeat the Skeletal Trio.",
     "information": "Defeat the Skeletal Trio.",
     "requirements": "71 Dungeoneering",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1088,
@@ -9798,7 +10886,8 @@
     "task": "Upgrade your Gem bag.",
     "information": "Upgrade your gem bag.",
     "requirements": "40 Dungeoneering, 45 Crafting",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1089,
@@ -9807,7 +10896,8 @@
     "task": "Equip a pair of Steadfast boots.",
     "information": "Equip a pair of steadfast boots.",
     "requirements": "85 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1090,
@@ -9816,7 +10906,8 @@
     "task": "Equip a pair of Glaiven boots.",
     "information": "Equip a pair of glaiven boots.",
     "requirements": "85 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1091,
@@ -9825,7 +10916,8 @@
     "task": "Equip a pair of Ragefire boots.",
     "information": "Equip a pair of ragefire boots.",
     "requirements": "85 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1092,
@@ -9834,7 +10926,8 @@
     "task": "Complete the task set: Hard Wilderness.",
     "information": "Complete the Hard Wilderness achievements.",
     "requirements": "Achievement: Hard Wilderness",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1093,
@@ -9843,7 +10936,8 @@
     "task": "Equip a Chaotic weapon or kiteshield.",
     "information": "Equip a chaotic weapon or kiteshield.",
     "requirements": "80 Dungeoneering, 80 Attack OR 80 Ranged OR 80 Magic OR 80 Defence",
-    "points": 80
+    "points": 80,
+    "tier": "Hard"
   },
   {
     "id": 1094,
@@ -9852,7 +10946,8 @@
     "task": "Equip the Hellfire bow.",
     "information": "Equip the hellfire bow.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1095,
@@ -9861,7 +10956,8 @@
     "task": "Complete a slayer task from Mandrith.",
     "information": "Complete a slayer task from Mandrith.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1096,
@@ -9870,7 +10966,8 @@
     "task": "Chop 20 Bloodwood logs in the Wilderness.",
     "information": "Chop 20 bloodwood logs in the Wilderness.",
     "requirements": "85 Woodcutting",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1097,
@@ -9879,7 +10976,8 @@
     "task": "Unlock the Greater Flurry, Barge, and Fury abilities.",
     "information": "Unlock the Greater Flurry, Barge, and Fury abilities.",
     "requirements": "Various",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1098,
@@ -9888,7 +10986,8 @@
     "task": "Crack 6 safes inside the Rogues' Castle.",
     "information": "Crack 6 safes inside the Rogues' Castle.",
     "requirements": "62 Thieving",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1099,
@@ -9897,7 +10996,8 @@
     "task": "Defeat 5 Ripper Demons.",
     "information": "Defeat 5 ripper demons.",
     "requirements": "96 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1100,
@@ -9906,7 +11006,8 @@
     "task": "Defeat 10 Lava Strykewyrms in the Wilderness, south of the Lava Maze.",
     "information": "Defeat 10 lava strykewyrms in the Wilderness, south of the Lava Maze.",
     "requirements": "94 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1101,
@@ -9915,7 +11016,8 @@
     "task": "Equip Annihilation, Decimation, or Obliteration.",
     "information": "Equip Annihilation, Decimation, or Obliteration.",
     "requirements": "87 Attack, 87 Ranged, 87 Magic",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1102,
@@ -9924,7 +11026,8 @@
     "task": "Kill Blink in a solo Dungeoneering instance, without dying.",
     "information": "Kill Blink in a solo Dungeoneering instance without dying.",
     "requirements": "117 Dungeoneering",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1103,
@@ -9933,7 +11036,8 @@
     "task": "Defeat every miniboss inside the Dragonkin Laboratory.",
     "information": "Defeat every miniboss inside the Dragonkin Laboratory.",
     "requirements": "95 Dungeoneering",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1104,
@@ -9942,7 +11046,8 @@
     "task": "Defeat the Black Stone Dragon.",
     "information": "Defeat the black stone dragon once.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1105,
@@ -9951,7 +11056,8 @@
     "task": "Defeat the Black Stone Dragon. (25 times)",
     "information": "Defeat the black stone dragon 25 times.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1106,
@@ -9960,7 +11066,8 @@
     "task": "Complete the task set: Elite Wilderness.",
     "information": "Complete the Elite Wilderness achievements.",
     "requirements": "Achievement: Elite Wilderness",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1107,
@@ -9969,7 +11076,8 @@
     "task": "Defeat 25 Hydrix dragons in the Wilderness.",
     "information": "Defeat 25 hydrix dragons in the Wilderness.",
     "requirements": "101 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1108,
@@ -9978,7 +11086,8 @@
     "task": "Defeat 10 Abyssal lords in the Wilderness.",
     "information": "Defeat 10 abyssal lords in the Wilderness.",
     "requirements": "115 Slayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1109,
@@ -9987,7 +11096,8 @@
     "task": "Mine 30 Primal ores.",
     "information": "Mine 30 primal ores.",
     "requirements": "99 Mining",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1110,
@@ -9996,7 +11106,8 @@
     "task": "Smelt 150 Primal bars.",
     "information": "Smelt 150 primal bars.",
     "requirements": "99 Smithing",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1111,
@@ -10005,7 +11116,8 @@
     "task": "Defeat Kal'Ger the Warmonger.",
     "information": "Defeat Kal'Ger the Warmonger.",
     "requirements": "90 Dungeoneering",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1112,
@@ -10014,7 +11126,8 @@
     "task": "Defeat the Ambassador.",
     "information": "Defeat the Ambassador once.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1113,
@@ -10023,7 +11136,8 @@
     "task": "Defeat the Ambassador. (25 times)",
     "information": "Defeat the Ambassador 25 times.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1114,
@@ -10032,7 +11146,8 @@
     "task": "Equip a Spectral, Arcane, Elysian, or Divine spirit shield.",
     "information": "Equip a spectral, arcane, Elysian, or divine spirit shield.",
     "requirements": "75 Defence, 75 Prayer",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1115,
@@ -10041,7 +11156,8 @@
     "task": "Defeat the Ambassador after allowing 4 unstable black holes to explode.",
     "information": "Defeat the Ambassador after allowing 4 unstable black holes to explode.",
     "requirements": "N/A",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   },
   {
     "id": 1116,
@@ -10050,6 +11166,7 @@
     "task": "Equip an Eldritch Crossbow.",
     "information": "Equip an eldritch crossbow.",
     "requirements": "92 Ranged",
-    "points": 200
+    "points": 200,
+    "tier": "Elite"
   }
 ]


### PR DESCRIPTION
This commit resolves a bug where the progress visualizer was displaying incorrect task counts for different difficulty tiers.

The root cause was that the tier was being inferred from the task's point value, which was incorrect for "Master" tasks and some "Elite" tasks.

To fix this, an explicit `tier` property has been added to each task object during the data processing step. The application logic has been updated to use this new `tier` property, ensuring that the progress visualizer now displays accurate and reliable data.